### PR TITLE
chore: name venv dir by OS/arch to allow shared filesystem usage

### DIFF
--- a/.claude/instructions/python.md
+++ b/.claude/instructions/python.md
@@ -20,7 +20,9 @@ general coding standards in `coding-standards.md`.
 
 - **`ruff`** — linting and formatting.
 - **`mypy` and `pyright`** — type checking. Run both in CI.
-- **`uv`** — virtual environment and dependency resolution. Creates `.venv/`
-  in the project directory per the global convention.
+- **`uv`** — virtual environment and dependency resolution. Point it at
+  `.venv-$(uname -s)-$(uname -m)/` in the project directory (e.g. by
+  exporting `UV_PROJECT_ENVIRONMENT`) so macOS and Linux venvs can coexist
+  on a shared filesystem.
 - **`pytest-cov`** — line and branch coverage with a ratcheting threshold.
 - **`pip-audit`** (or `safety`) — dependency vulnerability scanning in CI.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.venv/
+.venv*/
 __pycache__/
 *.pyc
 *.egg-info/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,12 @@ simplifying for "personal project" scope.
 
 ## Commands
 
-- `source .venv/bin/activate` — activate the virtualenv
+- `source ".venv-$(uname -s)-$(uname -m)/bin/activate"` — activate the virtualenv (per-OS/arch so Darwin and Linux venvs can coexist on a shared filesystem)
 - `pip install -e .` — install in development mode
 - `agent-auth --help` — show CLI usage
-- `scripts/agent-auth.sh <args...>` — run the agent-auth CLI (bootstraps `.venv` if missing); e.g. `scripts/agent-auth.sh serve`
-- `scripts/things-bridge.sh <args...>` — run the things-bridge CLI (bootstraps `.venv` if missing); e.g. `scripts/things-bridge.sh serve`
-- `scripts/things-cli.sh <args...>` — run the things-cli client (bootstraps `.venv` if missing); e.g. `scripts/things-cli.sh todos list`
+- `scripts/agent-auth.sh <args...>` — run the agent-auth CLI (bootstraps `.venv-$(uname -s)-$(uname -m)` if missing); e.g. `scripts/agent-auth.sh serve`
+- `scripts/things-bridge.sh <args...>` — run the things-bridge CLI (bootstraps `.venv-$(uname -s)-$(uname -m)` if missing); e.g. `scripts/things-bridge.sh serve`
+- `scripts/things-cli.sh <args...>` — run the things-cli client (bootstraps `.venv-$(uname -s)-$(uname -m)` if missing); e.g. `scripts/things-cli.sh todos list`
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Requires Python 3.11+.
 
 ```bash
 cd ~/Projects/agent-auth
-python3 -m venv .venv
-source .venv/bin/activate
+python3 -m venv ".venv-$(uname -s)-$(uname -m)"
+source ".venv-$(uname -s)-$(uname -m)/bin/activate"
 pip install -e .
 ```
 

--- a/scripts/agent-auth.sh
+++ b/scripts/agent-auth.sh
@@ -9,9 +9,11 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 cd "${REPO_ROOT}"
 
-if [[ ! -d .venv ]]; then
-  python3 -m venv .venv
-  .venv/bin/pip install -e ".[dev]"
+VENV_DIR=".venv-$(uname -s)-$(uname -m)"
+
+if [[ ! -d "${VENV_DIR}" ]]; then
+  python3 -m venv "${VENV_DIR}"
+  "${VENV_DIR}/bin/pip" install -e ".[dev]"
 fi
 
-exec .venv/bin/agent-auth "$@"
+exec "${VENV_DIR}/bin/agent-auth" "$@"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,9 +9,11 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 cd "${REPO_ROOT}"
 
-if [[ ! -d .venv ]]; then
-  python3 -m venv .venv
-  .venv/bin/pip install -e ".[dev]"
+VENV_DIR=".venv-$(uname -s)-$(uname -m)"
+
+if [[ ! -d "${VENV_DIR}" ]]; then
+  python3 -m venv "${VENV_DIR}"
+  "${VENV_DIR}/bin/pip" install -e ".[dev]"
 fi
 
-.venv/bin/python -m pytest tests/ "$@"
+"${VENV_DIR}/bin/python" -m pytest tests/ "$@"

--- a/scripts/things-bridge.sh
+++ b/scripts/things-bridge.sh
@@ -9,9 +9,11 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 cd "${REPO_ROOT}"
 
-if [[ ! -d .venv ]]; then
-  python3 -m venv .venv
-  .venv/bin/pip install -e ".[dev]"
+VENV_DIR=".venv-$(uname -s)-$(uname -m)"
+
+if [[ ! -d "${VENV_DIR}" ]]; then
+  python3 -m venv "${VENV_DIR}"
+  "${VENV_DIR}/bin/pip" install -e ".[dev]"
 fi
 
-exec .venv/bin/things-bridge "$@"
+exec "${VENV_DIR}/bin/things-bridge" "$@"

--- a/scripts/things-cli.sh
+++ b/scripts/things-cli.sh
@@ -9,9 +9,11 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 cd "${REPO_ROOT}"
 
-if [[ ! -d .venv ]]; then
-  python3 -m venv .venv
-  .venv/bin/pip install -e ".[dev]"
+VENV_DIR=".venv-$(uname -s)-$(uname -m)"
+
+if [[ ! -d "${VENV_DIR}" ]]; then
+  python3 -m venv "${VENV_DIR}"
+  "${VENV_DIR}/bin/pip" install -e ".[dev]"
 fi
 
-exec .venv/bin/things-cli "$@"
+exec "${VENV_DIR}/bin/things-cli" "$@"


### PR DESCRIPTION
## Summary

- Rename the project virtualenv from `.venv/` to `.venv-$(uname -s)-$(uname -m)/` (e.g. `.venv-Linux-aarch64/`, `.venv-Darwin-arm64/`) so the same repo checkout on a shared filesystem (e.g. macOS host bind-mounted into a Linux devcontainer) can maintain per-OS/arch venvs without clobbering each other.
- Update `.gitignore`, `README.md`, `CLAUDE.md`, `.claude/instructions/python.md`, and the four bootstrap scripts (`scripts/test.sh`, `scripts/agent-auth.sh`, `scripts/things-bridge.sh`, `scripts/things-cli.sh`) to use the new pattern.
- Mirrors the convention already used by `~/Projects/systems-engineering`.

## Test plan

- [x] `scripts/test.sh` bootstraps a fresh `.venv-$(uname -s)-$(uname -m)/` and runs the full pytest suite green on Linux (163 passed)
- [x] `grep -rn '\.venv[^-*]' .` returns no stale `.venv` references in tracked files
- [x] `.gitignore` still matches both the legacy `.venv/` and the new per-OS/arch dirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)