### PR TITLE
fix(things-bridge): repair AppleScript payload + log osascript failures

### DIFF
--- a/src/things_bridge/things.py
+++ b/src/things_bridge/things.py
@@ -34,14 +34,14 @@ on _esc(v)
     if v is missing value then return "missing value"
     set s to v as text
     set out to ""
-    set tabPh to (character id 9246)
-    set lfPh to (character id 9247)
+    set tabPlaceholder to (character id 9246)
+    set linefeedPlaceholder to (character id 9247)
     repeat with i from 1 to count of characters of s
         set c to character i of s
         if c is tab then
-            set out to out & tabPh
+            set out to out & tabPlaceholder
         else if c is return or c is linefeed then
-            set out to out & lfPh
+            set out to out & linefeedPlaceholder
         else
             set out to out & c
         end if

--- a/src/things_bridge/things.py
+++ b/src/things_bridge/things.py
@@ -10,6 +10,7 @@ un-escaped by the parser so free-form text survives the framing.
 """
 
 import subprocess
+import sys
 from dataclasses import dataclass
 
 from things_bridge.errors import ThingsError, ThingsNotFoundError, ThingsPermissionError
@@ -23,17 +24,24 @@ MISSING = "missing value"
 # Escapes tabs/newlines/carriage returns into unicode placeholders and
 # coerces missing value to the literal "missing value" so the parser
 # can treat it uniformly.
+#
+# ``character id N`` is the AppleScript way to produce a Unicode codepoint
+# inside a string. AppleScript string literals do NOT support ``\uXXXX``
+# escapes — attempting to use them produces a ``-2741`` syntax error at
+# compile time.
 _HELPERS = r"""
 on _esc(v)
     if v is missing value then return "missing value"
     set s to v as text
     set out to ""
+    set tabPh to (character id 9246)
+    set lfPh to (character id 9247)
     repeat with i from 1 to count of characters of s
         set c to character i of s
         if c is tab then
-            set out to out & "\u241e"
+            set out to out & tabPh
         else if c is return or c is linefeed then
-            set out to out & "\u241f"
+            set out to out & lfPh
         else
             set out to out & c
         end if
@@ -91,11 +99,16 @@ on _areaName(t)
 end _areaName
 
 on _statusText(s)
-    if s is open then
+    -- Handlers run outside the enclosing ``tell application "Things3"``
+    -- block, so bare Things3 keywords like ``open``/``completed``/``canceled``
+    -- are not in scope here. Coerce the status enum to its text name at
+    -- the handler boundary and compare as strings instead.
+    set stxt to (s as text)
+    if stxt is "open" then
         return "open"
-    else if s is completed then
+    else if stxt is "completed" then
         return "completed"
-    else if s is canceled then
+    else if stxt is "canceled" then
         return "canceled"
     else
         return "open"
@@ -210,6 +223,16 @@ class AppleScriptRunner:
 
         if result.returncode != 0:
             stderr = (result.stderr or "").strip()
+            # Surface the raw osascript message to the bridge's own stderr
+            # so operators can diagnose failures. The HTTP response body is
+            # intentionally sparse to avoid leaking host paths or script
+            # fragments to clients, which makes stderr the only channel.
+            print(
+                f"things-bridge: osascript failed (rc={result.returncode}): "
+                f"{stderr or '<empty stderr>'}",
+                file=sys.stderr,
+                flush=True,
+            )
             if "-1743" in stderr:
                 raise ThingsPermissionError(
                     "macOS Automation permission has not been granted for Things3. "

--- a/tests/test_things_bridge_things.py
+++ b/tests/test_things_bridge_things.py
@@ -6,9 +6,11 @@ number of tests exercise the real AppleScriptRunner on macOS to guard against
 regressions where the emitted script is rejected by osascript itself.
 """
 
+import os
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -27,6 +29,24 @@ from things_bridge.things import (
 _darwin_only = pytest.mark.skipif(
     sys.platform != "darwin" or shutil.which("osascript") is None,
     reason="osascript is only available on macOS",
+)
+
+
+def _things3_installed() -> bool:
+    for candidate in (
+        "/Applications/Things3.app",
+        os.path.expanduser("~/Applications/Things3.app"),
+    ):
+        if Path(candidate).is_dir():
+            return True
+    return False
+
+
+_requires_things3 = pytest.mark.skipif(
+    sys.platform != "darwin"
+    or shutil.which("osascript") is None
+    or not _things3_installed(),
+    reason="requires macOS with Things 3 installed",
 )
 
 
@@ -266,7 +286,7 @@ def test_helper_applescript_is_valid_syntax(tmp_path):
 
 
 @pytest.mark.covers_function("Execute External System Interaction")
-@_darwin_only
+@_requires_things3
 def test_list_projects_executes_against_things():
     """End-to-end smoke test against real Things 3.
 
@@ -284,7 +304,6 @@ def test_list_projects_executes_against_things():
     client.list_projects()
 
 
-@pytest.mark.covers_function("Execute External System Interaction")
 @_darwin_only
 def test_osascript_failure_writes_diagnostic_to_stderr(capfd):
     """Clients receive a deliberately-sparse ``502 things_unavailable`` on

--- a/tests/test_things_bridge_things.py
+++ b/tests/test_things_bridge_things.py
@@ -1,8 +1,14 @@
 """Tests for AppleScript runner and ThingsApplescriptClient.
 
-These tests avoid shelling out to osascript — they substitute a deterministic
-fake runner and assert the script content and TSV parsing behaviour.
+Most tests avoid shelling out to osascript — they substitute a deterministic
+fake runner and assert the script content and TSV parsing behaviour. A small
+number of tests exercise the real AppleScriptRunner on macOS to guard against
+regressions where the emitted script is rejected by osascript itself.
 """
+
+import shutil
+import subprocess
+import sys
 
 import pytest
 
@@ -10,10 +16,17 @@ from things_bridge.errors import ThingsError, ThingsNotFoundError
 from things_bridge.things import (
     NEWLINE_PLACEHOLDER,
     TAB_PLACEHOLDER,
+    AppleScriptRunner,
     ThingsApplescriptClient,
+    _HELPERS,
     _TODO_FIELDS,
     _PROJECT_FIELDS,
     _AREA_FIELDS,
+)
+
+_darwin_only = pytest.mark.skipif(
+    sys.platform != "darwin" or shutil.which("osascript") is None,
+    reason="osascript is only available on macOS",
 )
 
 
@@ -222,3 +235,70 @@ def test_get_todo_rejects_injection_in_id():
     with pytest.raises(ThingsError):
         client.get_todo("foo\nbar")
     assert runner.last_script is None
+
+
+@_darwin_only
+def test_helper_applescript_is_valid_syntax(tmp_path):
+    """The AppleScript prelude shared by every bridge request must compile.
+
+    If this script is invalid, every ``list`` and ``show`` endpoint fails
+    with an opaque ``502 things_unavailable`` — clients can't tell the
+    bridge is broken from the error taxonomy alone. FakeRunner-based tests
+    don't catch this because they never hand the script to osascript.
+    """
+    # osacompile parses the script without executing any ``tell application``
+    # block, so we can validate syntax without requiring Things 3 or
+    # Automation permissions.
+    out_path = tmp_path / "helpers.scpt"
+    source_path = tmp_path / "helpers.applescript"
+    # Append a no-op reference so the compiler accepts a helpers-only file.
+    source_path.write_text(_HELPERS + "\nreturn\n")
+
+    result = subprocess.run(
+        ["osacompile", "-o", str(out_path), str(source_path)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, (
+        f"osacompile rejected _HELPERS: {result.stderr.strip()}"
+    )
+
+
+@pytest.mark.covers_function("Execute External System Interaction")
+@_darwin_only
+def test_list_projects_executes_against_things():
+    """End-to-end smoke test against real Things 3.
+
+    Guards the full osascript compile-and-execute path: if the emitted
+    script is invalid or its handlers raise at runtime, clients see an
+    opaque ``502 things_unavailable`` rather than useful data. FakeRunner
+    short-circuits that path, so every other test in this file would pass
+    while production breaks.
+
+    Uses ``list_projects`` rather than ``list_todos`` because project counts
+    are typically small enough to complete well under the 30s default
+    timeout on any Mac. Requires Things 3 and Automation permissions.
+    """
+    client = ThingsApplescriptClient(AppleScriptRunner())
+    client.list_projects()
+
+
+@pytest.mark.covers_function("Execute External System Interaction")
+@_darwin_only
+def test_osascript_failure_writes_diagnostic_to_stderr(capfd):
+    """Clients receive a deliberately-sparse ``502 things_unavailable`` on
+    AppleScript failures so response bodies never leak host filesystem paths
+    or script fragments. Operators need the same detail on the server's own
+    stderr to diagnose why requests are failing.
+    """
+    runner = AppleScriptRunner()
+    with pytest.raises(ThingsError):
+        # Deliberately invalid AppleScript so osascript exits non-zero.
+        runner.run('this is not valid applescript "')
+
+    captured = capfd.readouterr()
+    # Should name the subsystem so mixed stderr streams stay greppable,
+    # and include enough of osascript's message to be useful.
+    assert "things-bridge" in captured.err
+    assert "osascript" in captured.err.lower()


### PR DESCRIPTION
## Summary

- Fix two AppleScript bugs that caused every `list` / `show` bridge endpoint to return an opaque `502 things_unavailable`: `_HELPERS` used unsupported `\uXXXX` escapes (replaced with `character id N`), and `_statusText` referenced bare Things3 keywords (`open`/`completed`/`canceled`) outside their enclosing `tell application` block (replaced with text coercion and string comparison).
- Surface raw osascript stderr to the bridge process's own stderr on non-zero exit so operators have a diagnostic channel. Response bodies stay sparse to preserve the host-info leak guarantee that `design/DESIGN.md` already documents.
- Add three darwin-only regression tests: an `osacompile`-based syntax check of `_HELPERS`, an end-to-end `list_projects` exercise against real Things 3, and a `capfd` assertion that osascript failures reach the bridge's stderr. Existing `FakeRunner`-based tests never touched the compile-and-execute path, which is why these bugs reached production.

## Test plan

- [x] `.venv-Darwin-arm64/bin/pytest -q` — full suite green on macOS (including the three new darwin-only tests). 166 passed.
- [x] `bash scripts/verify-function-tests.sh` — "Execute External System Interaction" now allocated. Coverage rose 37/47 → 38/47.
- [x] Manually restart `things-bridge` and confirm `scripts/things-cli.sh todos list` returns todos instead of `502 things_unavailable`. Verified in the debugging session that produced this PR.
- [ ] Manually trigger an osascript failure (e.g. revoke Automation permission) and confirm the bridge's stderr carries the `things-bridge: osascript failed` line while the HTTP response body stays sparse. The automated `test_osascript_failure_writes_diagnostic_to_stderr` exercises the same failure path deterministically with invalid AppleScript; the permission-revoke variant is left as a manual follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)