### PR TITLE
ci: gate PRs on shellcheck and shfmt for bash scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.sh]
+shell_variant = bash
+indent_style = space
+indent_size = 2
+binary_next_line = true
+switch_case_indent = true

--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -1,0 +1,35 @@
+name: Bash
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  SHFMT_VERSION: 3.8.0
+
+jobs:
+  bash:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+          shellcheck --version
+
+      - name: Install shfmt
+        run: |
+          curl -fsSL -o /tmp/shfmt \
+            "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
+          sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
+          shfmt --version
+
+      - name: Run shellcheck
+        run: scripts/lint.sh
+
+      - name: Run shfmt --check
+        run: scripts/format.sh --check

--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -16,6 +16,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install d2
+        run: curl -fsSL https://d2lang.com/install.sh | sh -s --
+
+      - name: Install systems-engineering
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/aidanns/systems-engineering/main/install.sh -o install.sh
+          bash install.sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install go-task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.50.0
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install shellcheck
         run: |
           curl -fsSL -o /tmp/shellcheck.tar.xz \
@@ -31,8 +50,11 @@ jobs:
           sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
           shfmt --version
 
+      - name: Verify Required Tooling
+        run: task verify-dependencies
+
       - name: Run shellcheck
-        run: scripts/lint.sh
+        run: task lint
 
       - name: Run shfmt --check
-        run: scripts/format.sh --check
+        run: task format -- --check

--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
 
 env:
+  SHELLCHECK_VERSION: 0.10.0
   SHFMT_VERSION: 3.8.0
 
 jobs:
@@ -17,8 +18,10 @@ jobs:
 
       - name: Install shellcheck
         run: |
-          sudo apt-get update
-          sudo apt-get install -y shellcheck
+          curl -fsSL -o /tmp/shellcheck.tar.xz \
+            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+          sudo install -m0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
           shellcheck --version
 
       - name: Install shfmt

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: Bash
+name: Check
 
 on:
   push:
@@ -11,7 +11,7 @@ env:
   SHFMT_VERSION: 3.8.0
 
 jobs:
-  bash:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,8 +53,5 @@ jobs:
       - name: Verify Required Tooling
         run: task verify-dependencies
 
-      - name: Run shellcheck
-        run: task lint
-
-      - name: Run shfmt --check
-        run: task format -- --check
+      - name: Run lint + format --check
+        run: task check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  SHELLCHECK_VERSION: 0.10.0
+  SHFMT_VERSION: 3.8.0
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -30,6 +34,19 @@ jobs:
         with:
           version: 3.50.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install shellcheck
+        run: |
+          curl -fsSL -o /tmp/shellcheck.tar.xz \
+            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+          sudo install -m0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+
+      - name: Install shfmt
+        run: |
+          curl -fsSL -o /tmp/shfmt \
+            "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
+          sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
 
       - name: Verify Required Tooling
         run: task verify-dependencies

--- a/.github/workflows/verify-design.yml
+++ b/.github/workflows/verify-design.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  SHELLCHECK_VERSION: 0.10.0
+  SHFMT_VERSION: 3.8.0
+
 jobs:
   verify-design:
     runs-on: ubuntu-latest
@@ -30,6 +34,19 @@ jobs:
         with:
           version: 3.50.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install shellcheck
+        run: |
+          curl -fsSL -o /tmp/shellcheck.tar.xz \
+            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+          sudo install -m0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+
+      - name: Install shfmt
+        run: |
+          curl -fsSL -o /tmp/shfmt \
+            "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
+          sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
 
       - name: Verify Required Tooling
         run: task verify-dependencies

--- a/.github/workflows/verify-function-tests.yml
+++ b/.github/workflows/verify-function-tests.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  SHELLCHECK_VERSION: 0.10.0
+  SHFMT_VERSION: 3.8.0
+
 jobs:
   verify-function-tests:
     runs-on: ubuntu-latest
@@ -30,6 +34,19 @@ jobs:
         with:
           version: 3.50.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install shellcheck
+        run: |
+          curl -fsSL -o /tmp/shellcheck.tar.xz \
+            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+          sudo install -m0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+
+      - name: Install shfmt
+        run: |
+          curl -fsSL -o /tmp/shfmt \
+            "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
+          sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
 
       - name: Verify Required Tooling
         run: task verify-dependencies

--- a/.github/workflows/verify-standards.yml
+++ b/.github/workflows/verify-standards.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  SHELLCHECK_VERSION: 0.10.0
+  SHFMT_VERSION: 3.8.0
+
 jobs:
   verify-standards:
     runs-on: ubuntu-latest
@@ -30,6 +34,19 @@ jobs:
         with:
           version: 3.50.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install shellcheck
+        run: |
+          curl -fsSL -o /tmp/shellcheck.tar.xz \
+            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+          sudo install -m0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+
+      - name: Install shfmt
+        run: |
+          curl -fsSL -o /tmp/shfmt \
+            "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
+          sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
 
       - name: Verify Required Tooling
         run: task verify-dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,13 @@
    canonical task runner (`brew install go-task` on macOS,
    `sh -c "$(curl -fsSL https://taskfile.dev/install.sh)" -- -d -b "$HOME/.local/bin"`
    elsewhere).
-2. Clone the repo and `cd` into it.
-3. Run `task --list` to see every repeatable operation.
+2. Install [shellcheck](https://www.shellcheck.net/) and
+   [shfmt](https://github.com/mvdan/sh) — required by `task lint` and
+   `task format` (and gated in CI). On macOS: `brew install shellcheck
+   shfmt`. On Debian/Ubuntu: `apt-get install shellcheck` and download
+   `shfmt` from its [GitHub releases](https://github.com/mvdan/sh/releases).
+3. Clone the repo and `cd` into it.
+4. Run `task --list` to see every repeatable operation.
 
 The first time you run `task test` or `task build`, the script
 bootstraps a per-OS/arch virtualenv at `.venv-$(uname -s)-$(uname -m)/`
@@ -24,7 +29,7 @@ Every repeatable operation is exposed through the task runner. Run
 | --- | --- |
 | `task test` | Run the pytest suite. |
 | `task lint` | Run all configured linters. |
-| `task format` | Run all configured formatters. |
+| `task format` | Run all configured formatters. Pass `-- --check` for diff-only mode (CI uses this). |
 | `task build` | Build sdist and wheel distributions into `dist/`. |
 | `task install-hooks` | Install project git hooks (lefthook). |
 | `task verify-design` | Verify every leaf function in the functional decomposition is allocated in the product breakdown. |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,6 +18,12 @@ tasks:
     cmds:
       - scripts/format.sh {{.CLI_ARGS}}
 
+  check:
+    desc: Run all linters and assert every tracked file is formatted.
+    cmds:
+      - scripts/lint.sh
+      - scripts/format.sh --check
+
   verify-design:
     desc: Verify every leaf function in the functional decomposition is allocated in the product breakdown.
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,14 +9,14 @@ tasks:
       - scripts/test.sh {{.CLI_ARGS}}
 
   lint:
-    desc: Run all configured linters (placeholder — no linters wired yet).
+    desc: Run all configured linters.
     cmds:
       - scripts/lint.sh
 
   format:
-    desc: Run all configured formatters (placeholder — no formatters wired yet).
+    desc: Run all configured formatters. Pass `-- --check` for diff-only mode.
     cmds:
-      - scripts/format.sh
+      - scripts/format.sh {{.CLI_ARGS}}
 
   verify-design:
     desc: Verify every leaf function in the functional decomposition is allocated in the product breakdown.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# lefthook git hook manager configuration.
+# Install with `task install-hooks` (wraps `lefthook install`).
+# shfmt formatting options live in .editorconfig.
+
+pre-commit:
+  parallel: true
+  commands:
+    shellcheck:
+      glob: "*.sh"
+      run: shellcheck {staged_files}
+    shfmt:
+      glob: "*.sh"
+      run: shfmt -d {staged_files}

--- a/plans/shellcheck-shfmt-ci.md
+++ b/plans/shellcheck-shfmt-ci.md
@@ -1,0 +1,153 @@
+# Plan: Gate PRs with shellcheck and shfmt for bash scripts
+
+Issue: [#51](https://github.com/aidanns/agent-auth/issues/51).
+
+Source standard: `.claude/instructions/bash.md` — *shellcheck* and *shfmt*
+gate PRs for every `*.sh` file.
+
+## Goal
+
+Gate PRs on bash linting (`shellcheck`) and formatting (`shfmt`) for every
+tracked `*.sh` file. Wire both tools through the project's canonical
+entrypoints: `Taskfile.yml` → `scripts/lint.sh` / `scripts/format.sh`, a new
+`treefmt.toml`, a new `lefthook.yml` pre-commit stage, and a dedicated GitHub
+Actions workflow. The existing scripts under `scripts/` must be brought into
+compliance so CI is green on merge.
+
+## Non-goals
+
+- Wiring other formatters (`ruff`, `mdformat`, `taplo`) into `treefmt.toml` —
+  tracked separately under issues [#47](https://github.com/aidanns/agent-auth/issues/47)
+  and [#45](https://github.com/aidanns/agent-auth/issues/45).
+- Adding `ripsecrets` or a fast unit-test subset to `lefthook.yml` — tracked
+  under [#42](https://github.com/aidanns/agent-auth/issues/42). This plan
+  introduces `lefthook.yml` and wires in shellcheck/shfmt only; #42 extends it.
+- Building a container image with pinned tool versions — out of scope.
+
+## Deliverables
+
+1. **`treefmt.toml`** at repo root with a `shellcheck` formatter (lint mode)
+   and a `shfmt` formatter covering every tracked `*.sh` file.
+2. **`lefthook.yml`** at repo root with a `pre-commit` stage that runs
+   `shellcheck` and `shfmt` on staged `*.sh` files. Wired so future issues
+   (#42) can append additional hooks without restructuring.
+3. **`scripts/lint.sh`** — replaces the placeholder with a real implementation
+   that runs `shellcheck` against every tracked `*.sh` file in the repo.
+   Exits non-zero on any finding.
+4. **`scripts/format.sh`** — replaces the placeholder with a real implementation
+   that runs `shfmt -w` to write canonical formatting. A `--check` mode runs
+   `shfmt -d` (diff) and exits non-zero on any drift; CI uses this mode.
+5. **`.github/workflows/bash.yml`** — new workflow that installs `shellcheck`
+   and `shfmt`, then runs `scripts/lint.sh` and `scripts/format.sh --check`.
+   Gates PRs for every `*.sh`.
+6. **`scripts/verify-standards.sh`** — extend with a new deterministic check
+   that asserts:
+   - At least one `.github/workflows/*.yml` invokes `shellcheck` AND `shfmt`.
+   - `treefmt.toml` exists and references both `shellcheck` and `shfmt`.
+   - `lefthook.yml` exists and references both `shellcheck` and `shfmt` in
+     its `pre-commit` stage.
+7. **Existing scripts brought into compliance** — run `shfmt -w` and
+   `shellcheck` over every `scripts/*.sh`, fix any findings by hand where
+   auto-format is not applicable.
+8. **`CONTRIBUTING.md`** — document how to install `shellcheck` and `shfmt`,
+   and how to run `task lint` / `task format` locally.
+9. **`README.md`** — no substantive change expected; verify links are still
+   correct after CONTRIBUTING updates.
+
+## Design and verification
+
+The following plan-template steps are **not applicable** and are
+intentionally skipped:
+
+- *Verify implementation against design doc* — bash linting and formatting
+  is developer tooling, not a behavioural component of `agent-auth` or
+  `things-bridge`. It does not appear in `design/DESIGN.md`,
+  `functional_decomposition.yaml`, or `product_breakdown.yaml`, and does
+  not need to.
+- *Threat model / cybersecurity standard compliance* — no change to the
+  running service's attack surface, keys, or data flow. These tools run at
+  developer-time and CI-time only.
+- *QM / SIL compliance* — no change to the production code path or its
+  evidence requirements.
+- *ADRs* — `shellcheck` and `shfmt` are already mandated by
+  `.claude/instructions/bash.md` as the standard tools for this category.
+  Adopting a pre-chosen standard tool is not a novel design decision.
+
+## Implementation steps
+
+1. **Configure shfmt flags via `.editorconfig`** — settle on two-space
+   indent, case indent, and binary ops on next line (matches the existing
+   script style). Commit an `.editorconfig` at repo root that `shfmt`
+   reads automatically, so every invocation path (local, pre-commit, CI,
+   task runner) gets the same flags without duplicating a literal
+   `-i 2 -ci -bn` in three config files.
+2. **`scripts/lint.sh`** — discover every tracked `*.sh` file via
+   `git ls-files '*.sh'`, then exec `shellcheck` on the batch. Fail fast on
+   any finding. Guard against `shellcheck` not being on `PATH` with a clear
+   install hint (same pattern as `scripts/install-hooks.sh`).
+3. **`scripts/format.sh`** — same discovery logic as `lint.sh`. Accept a
+   `--check` flag: default runs `shfmt -w` (write in place); `--check` runs
+   `shfmt -d` (diff) and exits non-zero if any diff is produced. Guard
+   `shfmt` presence with an install hint.
+4. **`treefmt.toml`** — two formatters: one for `shellcheck` (treefmt
+   supports lint-mode formatters via `options`), one for `shfmt`. Both
+   match `*.sh`.
+5. **`lefthook.yml`** — `pre-commit` stage with two commands: `shellcheck`
+   and `shfmt -d`, each run only on staged `*.sh` files (using lefthook's
+   `{staged_files}` substitution). Glob restricted to `*.sh`. shfmt flags
+   come from `.editorconfig`, not inline.
+6. **`.github/workflows/bash.yml`** — mirror the `verify-standards.yml`
+   skeleton. Install `shellcheck` via `apt-get install shellcheck` (Ubuntu
+   runner ships a recent version) and `shfmt` via a pinned GitHub release
+   download. Run `scripts/lint.sh` then `scripts/format.sh --check`.
+7. **`scripts/verify-standards.sh`** — extend the existing script with a
+   section that uses `grep` against `treefmt.toml`, `lefthook.yml`, and
+   `.github/workflows/*.yml` to assert the three regression checks above.
+   Fail fast with a clear message per missing invocation. Keep the existing
+   Taskfile check intact.
+8. **Bring existing scripts into compliance** — run `scripts/format.sh`
+   and `scripts/lint.sh` over every tracked `*.sh` and address any
+   findings. Expected changes are minor (one heredoc reformat in
+   `verify-standards.sh` per a pre-check).
+9. **Docs** — update `CONTRIBUTING.md` *Dev setup* with `shellcheck` / `shfmt`
+   install steps (apt on Linux, Homebrew on macOS). Link from the *Running
+   tasks* table row for `task lint` / `task format`.
+
+## Deterministic regression check
+
+Per the issue: `scripts/verify-standards.sh` asserts that `shellcheck` and
+`shfmt` are invoked by at least one `.github/workflows/*.yml` file AND are
+wired into `treefmt.toml` / `lefthook.yml`. Concrete checks:
+
+- `grep -qE '\bshellcheck\b'` over `.github/workflows/*.yml` → at least one match.
+- `grep -qE '\bshfmt\b'` over `.github/workflows/*.yml` → at least one match.
+- `treefmt.toml` contains `shellcheck` and `shfmt`.
+- `lefthook.yml` contains `shellcheck` and `shfmt` under `pre-commit`.
+
+A future regression that removes any of these wirings fails `task
+verify-standards` immediately.
+
+## Post-implementation standards review
+
+Run each of the following against the diff (per CLAUDE.md → *Post-Change
+Review*):
+
+- [ ] `/simplify` on the changes.
+- [ ] Independent code-review subagent; address findings.
+- [ ] One parallel subagent per file in `.claude/instructions/` — each
+      reviews the diff against its instruction file and reports
+      violations. Address findings.
+
+Specifically verify:
+
+- **`coding-standards.md`** — script names are verbs (`lint.sh`,
+  `format.sh`), flags have explicit names.
+- **`bash.md`** — every `*.sh` passes `shellcheck` and `shfmt` (by
+  construction, since CI gates on it).
+- **`service-design.md`** — not applicable (no service changes).
+- **`testing-standards.md`** — no behavioural code changes, so no new unit
+  tests. The deterministic regression check *is* the test.
+- **`tooling-and-ci.md`** — `scripts/lint.sh` and `scripts/format.sh` have a
+  CI workflow; the Taskfile surfaces are unchanged.
+- **`release-and-hygiene.md`** — no changes to required project files.
+- **`python.md`** — no Python-code changes.

--- a/plans/shellcheck-shfmt-ci.md
+++ b/plans/shellcheck-shfmt-ci.md
@@ -37,9 +37,12 @@ compliance so CI is green on merge.
 4. **`scripts/format.sh`** — replaces the placeholder with a real implementation
    that runs `shfmt -w` to write canonical formatting. A `--check` mode runs
    `shfmt -d` (diff) and exits non-zero on any drift; CI uses this mode.
-5. **`.github/workflows/bash.yml`** — new workflow that installs `shellcheck`
-   and `shfmt`, then runs `scripts/lint.sh` and `scripts/format.sh --check`.
-   Gates PRs for every `*.sh`.
+5. **`.github/workflows/check.yml`** — new unified "Check" workflow that
+   installs `shellcheck` and `shfmt` (and future cross-language lint/format
+   tooling), runs `task verify-dependencies` as a preflight, then invokes
+   `task check` (which wraps `task lint` + `task format -- --check`). Gates
+   PRs for every `*.sh`; extension points for other languages land in the
+   same workflow rather than fanning out per-language workflows.
 6. **`scripts/verify-standards.sh`** — extend with a new deterministic check
    that asserts:
    - At least one `.github/workflows/*.yml` invokes `shellcheck` AND `shfmt`.
@@ -96,10 +99,12 @@ intentionally skipped:
    and `shfmt -d`, each run only on staged `*.sh` files (using lefthook's
    `{staged_files}` substitution). Glob restricted to `*.sh`. shfmt flags
    come from `.editorconfig`, not inline.
-6. **`.github/workflows/bash.yml`** — mirror the `verify-standards.yml`
-   skeleton. Install `shellcheck` via `apt-get install shellcheck` (Ubuntu
-   runner ships a recent version) and `shfmt` via a pinned GitHub release
-   download. Run `scripts/lint.sh` then `scripts/format.sh --check`.
+6. **`.github/workflows/check.yml`** — mirror the `verify-standards.yml`
+   skeleton. Install `shellcheck` and `shfmt` from pinned GitHub releases
+   (both tools are also declared in `scripts/verify-dependencies.sh` so the
+   preflight catches drift). Run `task verify-dependencies` then
+   `task check`. Job name is `check` and the workflow is a single
+   cross-language "check" entrypoint rather than one-per-language.
 7. **`scripts/verify-standards.sh`** — extend the existing script with a
    section that uses `grep` against `treefmt.toml`, `lefthook.yml`, and
    `.github/workflows/*.yml` to assert the three regression checks above.

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,9 +1,50 @@
 #!/usr/bin/env bash
 
-# Run all configured formatters. Currently a no-op placeholder: individual
-# formatters (ruff format, shfmt, taplo, mdformat, treefmt) are tracked as
-# separate tooling-and-ci items and will be wired in here as each lands.
+# Run shfmt over every tracked *.sh file. Pass --check to diff-only mode
+# (CI uses this); default rewrites files in place. shfmt reads formatting
+# options from .editorconfig at the repo root.
 
 set -euo pipefail
 
-echo "task format: no formatters configured yet; see .claude/instructions/tooling-and-ci.md"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+mode="write"
+for arg in "$@"; do
+  case "${arg}" in
+    --check) mode="check" ;;
+    *)
+      echo "task format: unknown argument '${arg}'" >&2
+      echo "usage: scripts/format.sh [--check]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v shfmt >/dev/null 2>&1; then
+  echo "task format: 'shfmt' is not on PATH." >&2
+  echo "Install from https://github.com/mvdan/sh/releases or" >&2
+  echo "'brew install shfmt' (macOS), then re-run." >&2
+  exit 1
+fi
+
+# Capture into a variable (not process substitution) so `set -e` catches a
+# git failure — mapfile always succeeds regardless of the inner command's
+# exit status, which would otherwise silently pass the gate with zero
+# files outside a valid checkout.
+shell_files_raw="$(git ls-files '*.sh')"
+
+if [[ -z "${shell_files_raw}" ]]; then
+  echo "task format: no *.sh files tracked; nothing to format."
+  exit 0
+fi
+
+mapfile -t shell_files <<<"${shell_files_raw}"
+
+if [[ "${mode}" == "check" ]]; then
+  shfmt -d "${shell_files[@]}"
+else
+  shfmt -w "${shell_files[@]}"
+fi

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,9 +1,32 @@
 #!/usr/bin/env bash
 
-# Run all configured linters. Currently a no-op placeholder: individual linters
-# (ruff, shellcheck, taplo, mdformat) are tracked as separate tooling-and-ci
-# items and will be wired in here as each lands.
+# Run shellcheck over every tracked *.sh file.
 
 set -euo pipefail
 
-echo "task lint: no linters configured yet; see .claude/instructions/tooling-and-ci.md"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "task lint: 'shellcheck' is not on PATH." >&2
+  echo "Install via 'apt-get install shellcheck' (Linux) or" >&2
+  echo "'brew install shellcheck' (macOS), then re-run." >&2
+  exit 1
+fi
+
+# Capture into a variable (not process substitution) so `set -e` catches a
+# git failure — mapfile always succeeds regardless of the inner command's
+# exit status, which would otherwise silently pass the gate with zero
+# files outside a valid checkout.
+shell_files_raw="$(git ls-files '*.sh')"
+
+if [[ -z "${shell_files_raw}" ]]; then
+  echo "task lint: no *.sh files tracked; nothing to lint."
+  exit 0
+fi
+
+mapfile -t shell_files <<<"${shell_files_raw}"
+
+shellcheck "${shell_files[@]}"

--- a/scripts/verify-dependencies.sh
+++ b/scripts/verify-dependencies.sh
@@ -10,6 +10,8 @@ set -euo pipefail
 # keep-sorted start
 REQUIRED_TOOLS=(
   python3
+  shellcheck
+  shfmt
   systems-engineering
   task
   yq

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -118,7 +118,9 @@ else
 fi
 
 # Bash tooling: shellcheck + shfmt must be wired into CI, treefmt, and
-# lefthook per .claude/instructions/bash.md.
+# lefthook per .claude/instructions/bash.md. Strip comments before
+# grepping so a stale `# shellcheck` mention doesn't satisfy the check
+# after the actual invocation has been removed.
 
 bash_tool_missing=0
 
@@ -128,18 +130,25 @@ fail_bash_check() {
   bash_tool_missing=1
 }
 
+strip_comments() {
+  sed -E 's/(^|[[:space:]])#.*$//' "$@"
+}
+
 for tool in shellcheck shfmt; do
-  if ! grep -rqE "\\b${tool}\\b" .github/workflows 2>/dev/null; then
+  if ! find .github/workflows -name '*.yml' -print0 2>/dev/null \
+    | xargs -0 -r cat 2>/dev/null \
+    | strip_comments \
+    | grep -qE "\\b${tool}\\b"; then
     fail_bash_check "${tool}" ".github/workflows/*.yml" \
       "Add a workflow step that invokes '${tool}' (see .github/workflows/bash.yml)."
   fi
 
-  if ! grep -qE "\\b${tool}\\b" treefmt.toml 2>/dev/null; then
+  if ! { [[ -f treefmt.toml ]] && strip_comments treefmt.toml | grep -qE "^\\[formatter\\.${tool}\\]"; }; then
     fail_bash_check "${tool}" "treefmt.toml" \
       "Add a [formatter.${tool}] entry to treefmt.toml."
   fi
 
-  if ! grep -qE "\\b${tool}\\b" lefthook.yml 2>/dev/null; then
+  if ! { [[ -f lefthook.yml ]] && strip_comments lefthook.yml | grep -qE "\\b${tool}\\b"; }; then
     fail_bash_check "${tool}" "lefthook.yml" \
       "Add a pre-commit command that invokes '${tool}' to lefthook.yml."
   fi

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -10,6 +10,8 @@
 #      tooling-and-ci.md Security). An ecosystem is "in use" when its
 #      manifest files are present; ecosystems without manifests are
 #      skipped rather than required.
+#   3. Bash gating (shellcheck, shfmt) is wired into CI, treefmt, and
+#      lefthook per .claude/instructions/bash.md.
 
 set -euo pipefail
 
@@ -54,7 +56,8 @@ catalogue="$(task --list-all --json)"
 # Capture into a variable (not process substitution) so `set -e` catches a
 # crash in the python helper — otherwise a parser failure silently yields an
 # empty `missing` array and the check falsely reports success.
-missing_output="$(python3 - "${catalogue}" "${REQUIRED_TASKS[@]}" <<'PY'
+missing_output="$(
+  python3 - "${catalogue}" "${REQUIRED_TASKS[@]}" <<'PY'
 import json
 import sys
 
@@ -113,3 +116,37 @@ else
 
   echo "verify-standards: dependabot.yml covers detected ecosystems (${required_ecosystems[*]}) with minor/patch grouping."
 fi
+
+# Bash tooling: shellcheck + shfmt must be wired into CI, treefmt, and
+# lefthook per .claude/instructions/bash.md.
+
+bash_tool_missing=0
+
+fail_bash_check() {
+  echo "verify-standards: '$1' is not wired into $2." >&2
+  echo "  $3" >&2
+  bash_tool_missing=1
+}
+
+for tool in shellcheck shfmt; do
+  if ! grep -rqE "\\b${tool}\\b" .github/workflows 2>/dev/null; then
+    fail_bash_check "${tool}" ".github/workflows/*.yml" \
+      "Add a workflow step that invokes '${tool}' (see .github/workflows/bash.yml)."
+  fi
+
+  if ! grep -qE "\\b${tool}\\b" treefmt.toml 2>/dev/null; then
+    fail_bash_check "${tool}" "treefmt.toml" \
+      "Add a [formatter.${tool}] entry to treefmt.toml."
+  fi
+
+  if ! grep -qE "\\b${tool}\\b" lefthook.yml 2>/dev/null; then
+    fail_bash_check "${tool}" "lefthook.yml" \
+      "Add a pre-commit command that invokes '${tool}' to lefthook.yml."
+  fi
+done
+
+if [[ ${bash_tool_missing} -ne 0 ]]; then
+  exit 1
+fi
+
+echo "verify-standards: shellcheck and shfmt are wired into CI, treefmt, and lefthook."

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -39,6 +39,7 @@ fi
 # keep-sorted start
 REQUIRED_TASKS=(
   build
+  check
   format
   install-hooks
   lint
@@ -149,7 +150,7 @@ lefthook_stripped=""
 for tool in shellcheck shfmt; do
   if ! grep -qE "\\b${tool}\\b" <<<"${workflows_stripped}"; then
     fail_bash_check "${tool}" ".github/workflows/*.yml" \
-      "Add a workflow step that invokes '${tool}' (see .github/workflows/bash.yml)."
+      "Add a workflow step that invokes '${tool}' (see .github/workflows/check.yml)."
   fi
 
   if ! grep -qE "^\\[formatter\\.${tool}\\]" <<<"${treefmt_stripped}"; then

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -134,21 +134,30 @@ strip_comments() {
   sed -E 's/(^|[[:space:]])#.*$//' "$@"
 }
 
+# Collect comment-stripped content into variables so the match step
+# doesn't early-exit its upstream pipeline — `grep -q` exiting on first
+# match would otherwise SIGPIPE `sed`/`cat`, and `pipefail` turns that
+# into a whole-pipeline failure when the input is large enough to race.
+workflows_stripped="$(find .github/workflows -name '*.yml' -print0 2>/dev/null \
+  | xargs -0 -r cat 2>/dev/null \
+  | strip_comments)"
+treefmt_stripped=""
+[[ -f treefmt.toml ]] && treefmt_stripped="$(strip_comments treefmt.toml)"
+lefthook_stripped=""
+[[ -f lefthook.yml ]] && lefthook_stripped="$(strip_comments lefthook.yml)"
+
 for tool in shellcheck shfmt; do
-  if ! find .github/workflows -name '*.yml' -print0 2>/dev/null \
-    | xargs -0 -r cat 2>/dev/null \
-    | strip_comments \
-    | grep -qE "\\b${tool}\\b"; then
+  if ! grep -qE "\\b${tool}\\b" <<<"${workflows_stripped}"; then
     fail_bash_check "${tool}" ".github/workflows/*.yml" \
       "Add a workflow step that invokes '${tool}' (see .github/workflows/bash.yml)."
   fi
 
-  if ! { [[ -f treefmt.toml ]] && strip_comments treefmt.toml | grep -qE "^\\[formatter\\.${tool}\\]"; }; then
+  if ! grep -qE "^\\[formatter\\.${tool}\\]" <<<"${treefmt_stripped}"; then
     fail_bash_check "${tool}" "treefmt.toml" \
       "Add a [formatter.${tool}] entry to treefmt.toml."
   fi
 
-  if ! { [[ -f lefthook.yml ]] && strip_comments lefthook.yml | grep -qE "\\b${tool}\\b"; }; then
+  if ! grep -qE "\\b${tool}\\b" <<<"${lefthook_stripped}"; then
     fail_bash_check "${tool}" "lefthook.yml" \
       "Add a pre-commit command that invokes '${tool}' to lefthook.yml."
   fi

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,0 +1,13 @@
+# treefmt formatter/linter multiplexer.
+# shfmt formatting options live in .editorconfig.
+# The authoritative bash gate is scripts/lint.sh + scripts/format.sh,
+# invoked directly by .github/workflows/bash.yml and lefthook.yml.
+
+[formatter.shellcheck]
+command = "shellcheck"
+includes = ["*.sh"]
+
+[formatter.shfmt]
+command = "shfmt"
+options = ["-w"]
+includes = ["*.sh"]


### PR DESCRIPTION
Closes #51.

## Summary

- New `.github/workflows/check.yml` runs `task check` on push + pull_request — a single cross-language lint/format gate that composes `task lint` + `task format -- --check`. Future linters/formatters extend those task surfaces rather than adding per-language workflows.
- New `check` task in `Taskfile.yml` wrapping lint + format-check; registered in `REQUIRED_TASKS` so its removal trips `task verify-standards`.
- `shellcheck` and `shfmt` added to `scripts/verify-dependencies.sh` — the preflight now fails fast with an actionable list if either is missing locally or in CI. Both versions are pinned in the workflow (shellcheck 0.10.0, shfmt 3.8.0) via release tarballs.
- `scripts/lint.sh` and `scripts/format.sh` replace the placeholder stubs — they run `shellcheck` / `shfmt` over every tracked `*.sh`.
- `treefmt.toml` and `lefthook.yml` wire both tools through the formatter multiplexer and the pre-commit hook manager respectively.
- `.editorconfig` is the single source for `shfmt` formatting options (2-space indent, `-ci`, `-bn`), read automatically by shfmt — no duplicated flag lists across Taskfile, CI, treefmt, and lefthook.
- `scripts/verify-standards.sh` gains a bash-tooling regression check that asserts both tools are invoked by at least one workflow file and wired into `treefmt.toml` and `lefthook.yml`. Comments are stripped before matching and `treefmt.toml` requires a structural `[formatter.<tool>]` header, so stale `# shellcheck` mentions can't satisfy the gate after the real invocation is removed.
- One minor `shfmt` reformat in `scripts/verify-standards.sh` (heredoc line break) brings the existing tree into compliance.

Plan: `plans/shellcheck-shfmt-ci.md`.

## Test plan

- [x] `task check` succeeds locally.
- [x] `task verify-dependencies` succeeds locally.
- [x] `task verify-standards` succeeds locally.
- [x] `task test` succeeds locally (no behavioural changes; sanity check only).
- [x] Check workflow passes on the PR.
- [x] Verify Standards workflow passes on the PR.
- [x] All other existing CI workflows pass on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)