### PR TITLE
fix(scripts): rebuild venv when pyproject.toml changes; add service tasks

### DIFF
--- a/.claude/instructions/tooling-and-ci.md
+++ b/.claude/instructions/tooling-and-ci.md
@@ -30,7 +30,12 @@ language: `python.md`, `bash.md`.
 - **`go-task`** — task runner with `Taskfile.yml` at the repo root. Every
   operation (build, lint, test, release) should be discoverable via
   `task --list`. Keep `scripts/*.sh` implementations; have the Taskfile
-  dispatch to them.
+  dispatch to them. Project-specific tasks (running a local service
+  CLI, a one-off domain command) are fine to add to `Taskfile.yml`, but
+  must **not** be added to the `REQUIRED_TASKS` list in
+  `scripts/verify-standards.sh`: that list is reserved for task names
+  mandated by this cross-project tooling standard so the check stays
+  portable to other repositories adopting it.
 - **`treefmt`** — formatter/linter multiplexer. Run all formatters under one
   command with consistent behaviour.
 - **`lefthook`** — git hook manager. Commit a `lefthook.yml` that runs

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,10 @@
+# Allow shellcheck to follow `source` directives (e.g.
+# `# shellcheck source=./_bootstrap_venv.sh`) across files so SC1091 does
+# not fire on intentional shared helpers sourced via a variable path.
+external-sources=true
+
+# Resolve `source=` paths relative to each script's own directory, not
+# the current working directory, so shared helpers (e.g.
+# scripts/_bootstrap_venv.sh) resolve consistently whether shellcheck is
+# invoked from the repo root or another directory.
+source-path=SCRIPTDIR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,10 +14,10 @@ simplifying for "personal project" scope.
 - `source ".venv-$(uname -s)-$(uname -m)/bin/activate"` — activate the virtualenv (per-OS/arch so Darwin and Linux venvs can coexist on a shared filesystem)
 - `pip install -e .` — install in development mode
 - `agent-auth --help` — show CLI usage
-- `scripts/agent-auth.sh <args...>` — run the agent-auth CLI (bootstraps `.venv-$(uname -s)-$(uname -m)` if missing); e.g. `scripts/agent-auth.sh serve`
-- `scripts/things-bridge.sh <args...>` — run the things-bridge CLI (bootstraps `.venv-$(uname -s)-$(uname -m)` if missing); e.g. `scripts/things-bridge.sh serve`
-- `scripts/things-client-applescript.sh <args...>` — run the things-client-cli-applescript CLI directly (macOS-only); e.g. `scripts/things-client-applescript.sh todos list --status open`
-- `scripts/things-cli.sh <args...>` — run the things-cli client (bootstraps `.venv-$(uname -s)-$(uname -m)` if missing); e.g. `scripts/things-cli.sh todos list`
+- `task agent-auth -- <args...>` (or `scripts/agent-auth.sh <args...>`) — run the agent-auth CLI; bootstraps `.venv-$(uname -s)-$(uname -m)` and reinstalls when `pyproject.toml` changes. E.g. `task agent-auth -- serve`.
+- `task things-bridge -- <args...>` (or `scripts/things-bridge.sh <args...>`) — run the things-bridge CLI. E.g. `task things-bridge -- serve`.
+- `task things-client-applescript -- <args...>` (or `scripts/things-client-applescript.sh <args...>`) — run the things-client-cli-applescript CLI directly (macOS-only). E.g. `task things-client-applescript -- todos list --status open`.
+- `task things-cli -- <args...>` (or `scripts/things-cli.sh <args...>`) — run the things-cli client. E.g. `task things-cli -- todos list`.
 
 ## Architecture
 
@@ -42,7 +42,7 @@ simplifying for "personal project" scope.
   refresh/rotate pair -> JIT approval for prompt-tier scope -> revoke ->
   verify invalidation
 - Function-to-test allocation tracked via `scripts/verify-function-tests.sh`
-- Project standards (Taskfile task coverage, Dependabot ecosystem coverage, ...) verified via `scripts/verify-standards.sh`
+- Generic, portable project standards (Taskfile task coverage, Dependabot ecosystem coverage, bash CI gating, ...) verified via `scripts/verify-standards.sh`. Project-specific task names (e.g. `task agent-auth`) are **not** enforced by this script — its `REQUIRED_TASKS` list only covers cross-project standards so the check stays portable.
 - Required local CLI tooling (python3, task, yq, ...) verified via `scripts/verify-dependencies.sh`
 - Plugin trust boundary: the notification plugin currently uses
   `importlib.import_module` inside the server process which holds signing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,16 @@
 3. Clone the repo and `cd` into it.
 4. Run `task --list` to see every repeatable operation.
 
-The first time you run `task test` or `task build`, the script
-bootstraps a per-OS/arch virtualenv at `.venv-$(uname -s)-$(uname -m)/`
-and installs the project in editable mode with dev extras. Other tasks
-(e.g. `task verify-standards`) do not require the venv and skip that
-setup.
+The first time you run any venv-backed task (e.g. `task test`,
+`task build`, or a service task like `task agent-auth -- serve`), the
+shared `scripts/_bootstrap_venv.sh` helper creates the per-OS/arch
+virtualenv at `.venv-$(uname -s)-$(uname -m)/` and installs the project
+in editable mode with dev extras. The helper hashes `pyproject.toml`
+into a marker inside the venv and reinstalls on the next invocation
+whenever the hash changes, so a new dependency or entry-point edit is
+picked up automatically without you having to blow away the venv.
+Other tasks (e.g. `task verify-standards`) do not require the venv and
+skip that setup.
 
 ## Running tasks
 
@@ -34,8 +39,13 @@ Every repeatable operation is exposed through the task runner. Run
 | `task install-hooks` | Install project git hooks (lefthook). |
 | `task verify-design` | Verify every leaf function in the functional decomposition is allocated in the product breakdown. |
 | `task verify-function-tests` | Verify every leaf function in the functional decomposition has test coverage. |
-| `task verify-standards` | Verify the Taskfile exposes every task mandated by the tooling-and-ci standard. |
+| `task verify-dependencies` | Verify required CLI tools (python3, task, yq, ...) are installed on PATH. |
+| `task verify-standards` | Verify generic, portable standards (Taskfile task coverage, Dependabot ecosystem coverage, bash CI gating). Does not enforce project-specific task names. |
 | `task release` | Cut a release (version bump, tag, GitHub release, publish). |
+| `task agent-auth -- <args>` | Run the `agent-auth` CLI (any subcommand). |
+| `task things-bridge -- <args>` | Run the `things-bridge` CLI. |
+| `task things-cli -- <args>` | Run the `things-cli` client. |
+| `task things-client-applescript -- <args>` | Run the `things-client-cli-applescript` CLI (macOS-only). |
 
 Each task dispatches to a script under `scripts/*.sh`; the scripts are
 the single source of truth and can also be invoked directly if

--- a/README.md
+++ b/README.md
@@ -26,14 +26,20 @@ task test        # bootstraps .venv-$(uname -s)-$(uname -m) and runs the suite
 Every repeatable operation is exposed through the task runner — run `task --list` to see the catalogue. Common commands:
 
 ```bash
-task test                   # run the pytest suite
-task build                  # build sdist and wheel into dist/
-task verify-design          # verify functional decomposition allocation
-task verify-function-tests  # verify functional decomposition test coverage
-task verify-standards       # verify the Taskfile matches the tooling standard
+task test                           # run the pytest suite
+task build                          # build sdist and wheel into dist/
+task verify-design                  # verify functional decomposition allocation
+task verify-function-tests          # verify functional decomposition test coverage
+task verify-standards               # verify the Taskfile matches the tooling standard
+task agent-auth -- serve            # run the agent-auth CLI (any subcommand)
+task things-bridge -- serve         # run the things-bridge CLI
+task things-cli -- todos list       # run the things-cli client
+task things-client-applescript -- todos list  # run the macOS-only things client CLI
 ```
 
-If you don't have `go-task` installed, every task dispatches to a script under `scripts/*.sh` that you can invoke directly (e.g. `scripts/test.sh`).
+Every tool invocation routes through `scripts/_bootstrap_venv.sh`, which creates the per-OS/arch virtualenv on first use and reinstalls in editable mode whenever `pyproject.toml` changes (hash-compared against a marker file inside the venv), so rerunning a task after a dependency or entry-point edit picks the change up automatically.
+
+If you don't have `go-task` installed, every task dispatches to a script under `scripts/*.sh` that you can invoke directly (e.g. `scripts/test.sh`, `scripts/agent-auth.sh serve`).
 
 For a bare Python install without the task runner:
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,3 +58,23 @@ tasks:
     desc: Cut a release (version bump, tag, GitHub release, publish).
     cmds:
       - scripts/release.sh
+
+  agent-auth:
+    desc: Run the agent-auth CLI (e.g. `task agent-auth -- serve`).
+    cmds:
+      - scripts/agent-auth.sh {{.CLI_ARGS}}
+
+  things-bridge:
+    desc: Run the things-bridge CLI (e.g. `task things-bridge -- serve`).
+    cmds:
+      - scripts/things-bridge.sh {{.CLI_ARGS}}
+
+  things-cli:
+    desc: Run the things-cli client (e.g. `task things-cli -- todos list`).
+    cmds:
+      - scripts/things-cli.sh {{.CLI_ARGS}}
+
+  things-client-applescript:
+    desc: Run the things-client-cli-applescript CLI (macOS-only; e.g. `task things-client-applescript -- todos list`).
+    cmds:
+      - scripts/things-client-applescript.sh {{.CLI_ARGS}}

--- a/plans/venv-rebuild-and-task-services.md
+++ b/plans/venv-rebuild-and-task-services.md
@@ -1,0 +1,201 @@
+# Plan: Fix Stale Venv in `scripts/*.sh` Wrappers + Run Services via Taskfile
+
+Issue: [#60](https://github.com/aidanns/agent-auth/issues/60).
+
+Bundles a secondary change: expose each service/CLI (`agent-auth`,
+`things-bridge`, `things-cli`, `things-client-applescript`) through
+`task`, so the new wrapper behaviour is reached through the project's
+canonical entrypoint as well as via direct script invocation.
+
+## Goal
+
+Re-running any `scripts/*.sh` wrapper must reflect the current state of
+`pyproject.toml` (entry points, dependencies, extras) without users
+having to remember to reinstall or blow away the venv. In parallel,
+surface each of the three tool CLIs as `task` commands so the standard
+task-runner entrypoint (see `tooling-and-ci.md` → *Orchestration*) can
+start a service or run the client.
+
+## Non-goals
+
+- Replacing `pip` with `uv` or another installer. Out of scope.
+- Adding `uv.lock` / `requirements*.txt`. Out of scope.
+- Changing how `scripts/test.sh` / `scripts/build.sh` bootstrap the
+  venv. Those scripts already reinstall unconditionally (different
+  correctness strategy). They will be migrated to the shared helper
+  only if the helper's semantics match — see *Implementation steps*.
+- Wrapping the CLIs in a long-running supervisor (`systemd`,
+  `launchd`, `honcho`). Task dispatch is synchronous and foreground;
+  stopping a service is `Ctrl+C`.
+
+## Deliverables
+
+1. `scripts/_bootstrap_venv.sh` — shared helper sourced by every
+   wrapper. Ensures the per-OS/arch venv exists and is up-to-date
+   against `pyproject.toml` using a hash marker (`pyproject.sha256`)
+   stored inside the venv. Fast path (hash match) is a no-op; slow
+   path runs `pip install -e ".[dev]"` and refreshes the marker.
+2. `scripts/agent-auth.sh`, `scripts/things-bridge.sh`,
+   `scripts/things-cli.sh`, `scripts/things-client-applescript.sh` —
+   refactored to source the helper. No behavioural change except that
+   a changed `pyproject.toml` now triggers a reinstall on the next
+   invocation.
+3. `scripts/test.sh` and `scripts/build.sh` — refactored to source the
+   same helper, so all wrappers share one bootstrap implementation.
+   The helper's rebuild-on-hash-change semantics are strictly safer
+   than the existing "reinstall every time" behaviour (it still
+   reinstalls when the hash changes; it just skips the redundant
+   reinstalls), so the migration does not regress correctness and
+   removes the duplication these two scripts call out in their own
+   comments.
+4. `Taskfile.yml` — four new tasks that dispatch to the existing
+   wrapper scripts:
+   - `agent-auth` → `scripts/agent-auth.sh {{.CLI_ARGS}}`
+   - `things-bridge` → `scripts/things-bridge.sh {{.CLI_ARGS}}`
+   - `things-cli` → `scripts/things-cli.sh {{.CLI_ARGS}}`
+   - `things-client-applescript` →
+     `scripts/things-client-applescript.sh {{.CLI_ARGS}}`
+
+   Naming matches the underlying CLI name (not `serve-…`) so the task
+   is a general-purpose entrypoint, not a server-only shortcut. The
+   same task serves all subcommands — e.g.
+   `task agent-auth -- token create --scope things:read=allow`.
+5. `scripts/verify-standards.sh` — **does not** list these
+   project-specific task names in `REQUIRED_TASKS`. That list is
+   reserved for generic, portable tasks mandated by
+   `.claude/instructions/tooling-and-ci.md` so the script stays
+   applicable across projects. The header comment, `CLAUDE.md`, and
+   `tooling-and-ci.md` are updated to make this boundary explicit.
+6. `scripts/verify-dependencies.sh` — add `shasum` to the list of
+   required CLI tools so a missing `shasum` surfaces as a dependency
+   error rather than a cryptic failure inside the bootstrap helper.
+7. `README.md` and `CONTRIBUTING.md` — document the new task entries
+   and note that the wrapper scripts now self-heal when
+   `pyproject.toml` changes.
+
+## Rationale for the chosen rebuild strategy
+
+The issue proposes three options:
+
+1. Reinstall on every invocation — simple but adds ~1s to every
+   wrapper call, which compounds for the CLI (`things-cli` is run
+   interactively and repeatedly).
+2. Compare `pyproject.toml` mtime — fragile under rebases, `touch`,
+   and filesystem copy. Mtime loses correctness when users move their
+   checkout or revert a file.
+3. Hash `pyproject.toml` into a marker — fast path is a single
+   `shasum -a 256` compare; slow path is the same `pip install` as
+   today. Correct under rebases, reverts, and `touch`. We use
+   `shasum -a 256` rather than `sha256sum` because macOS does not
+   ship GNU coreutils by default, so `sha256sum` is not on PATH
+   there; `shasum` is present on both macOS (perl-backed) and Linux.
+
+(3) is the option the issue calls out as the best trade-off, and this
+plan adopts it. The marker file (`pyproject.sha256`) lives inside
+the venv, so a `rm -rf .venv-*` force-reinstall workflow still works.
+
+## Design and verification
+
+The following plan-template steps are **not applicable** and are
+intentionally skipped:
+
+- *Verify implementation against design doc* — the wrapper scripts
+  and task runner are developer tooling, not behavioural components
+  of `agent-auth`. They do not appear in `design/DESIGN.md`,
+  `functional_decomposition.yaml`, or `product_breakdown.yaml`.
+- *Threat model / cybersecurity standard compliance* — no change to
+  the running service's attack surface, keys, or data flow. The
+  marker file is a local developer-tooling artefact that is never
+  loaded by the server. Hashing `pyproject.toml` with `sha256sum` is
+  not a security control; it is an integrity check for a local
+  cache.
+- *QM / SIL compliance* — no change to production code, functional
+  behaviour, or evidence requirements.
+- *ADRs* — the per-OS/arch venv layout and the go-task dispatch
+  pattern are both already standard for this project (documented in
+  `CLAUDE.md` and `.claude/instructions/tooling-and-ci.md`). Adding
+  a new task that follows the established dispatch pattern and a
+  helper that factors duplication out of existing scripts is not a
+  novel design decision; no new ADR required.
+
+## Implementation steps
+
+1. **`scripts/_bootstrap_venv.sh`** — new file. Exports `VENV_DIR`
+   and `REPO_ROOT`, then chdirs to the repo root so callers can use
+   relative paths. Designed to be *sourced*, not executed, so callers
+   can then `exec "${VENV_DIR}/bin/<cli>"` in the same process.
+   Contract:
+   - Resolves repo root via `BASH_SOURCE`, independent of caller CWD.
+   - Detects a missing or half-built venv (`[[ -x "${VENV_DIR}/bin/pip" ]]`)
+     and (re)creates it with `python3 -m venv --clear` so an interrupted
+     prior bootstrap is self-healing.
+   - Reinstalls `".[dev]"` when the stored hash differs from the
+     current `pyproject.toml` hash, then rewrites the marker.
+   - Uses `pip install --quiet` to keep the fast path quiet.
+   - Emits a one-line stderr notice ("Bootstrapping venv…" /
+     "Refreshing venv (pyproject.toml changed)…") on the slow path
+     so users know why the first call after an edit is slower.
+   - Fast path reads the current and stored hashes with `read -r`
+     (no `awk` / `cat` subprocesses beyond the single `shasum`).
+2. **Refactor wrappers** — each of `agent-auth.sh`,
+   `things-bridge.sh`, `things-cli.sh` reduces to:
+   ```bash
+   #!/usr/bin/env bash
+   set -euo pipefail
+   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+   # shellcheck source=./_bootstrap_venv.sh
+   source "${SCRIPT_DIR}/_bootstrap_venv.sh"
+   exec "${VENV_DIR}/bin/<cli>" "$@"
+   ```
+3. **Refactor `scripts/test.sh` and `scripts/build.sh`** — same
+   source-and-exec pattern. Drop the local "reinstall every time"
+   comment (now obsolete).
+4. **`Taskfile.yml`** — append three new tasks (`agent-auth`,
+   `things-bridge`, `things-cli`) following the existing
+   `{{.CLI_ARGS}}` pattern used by `task test`.
+5. **`scripts/verify-standards.sh`** — extend `REQUIRED_TASKS` with
+   the three new task names (keep-sorted block preserved).
+6. **`README.md` / `CONTRIBUTING.md`** — document `task agent-auth`,
+   `task things-bridge`, `task things-cli` as the preferred
+   entrypoints; note that wrappers reinstall automatically when
+   `pyproject.toml` changes.
+
+## Deterministic regression check
+
+- `scripts/verify-standards.sh` now fails if any of `agent-auth`,
+  `things-bridge`, `things-cli` is removed from `Taskfile.yml`.
+- The bootstrap helper is exercised by the full test suite on every
+  `task test` run (same bootstrap runs there), so a regression that
+  breaks the fast path or the rebuild trigger is caught by CI.
+
+## Post-implementation standards review
+
+Run each of the following against the diff (per CLAUDE.md → *Post-Change
+Review*):
+
+- [ ] `/simplify` on the changes.
+- [ ] Independent code-review subagent; address findings.
+- [ ] One parallel subagent per file in `.claude/instructions/` — each
+      reviews the diff against its instruction file and reports
+      violations. Address findings.
+
+Specifically verify:
+
+- **`coding-standards.md`** — no implicit-unit names
+  (marker file is a hash, not a duration). The helper exports
+  `VENV_DIR`, a path, not a numeric config value.
+- **`bash.md`** — every new and refactored `*.sh` follows the
+  standard header block (`#!/usr/bin/env bash`, blank-line-padded
+  description comment, `set -euo pipefail`).
+- **`service-design.md`** — not applicable (no service changes).
+- **`testing-standards.md`** — no behavioural code changes, so no
+  new unit tests. The deterministic regression check (updated
+  `verify-standards.sh`) is the test for the task-surface change;
+  the rebuild logic is exercised by every developer's next
+  `task test` run and by CI.
+- **`tooling-and-ci.md`** — the new tasks are the canonical
+  entrypoint for running each service; the Taskfile remains the
+  single `task --list` source of truth.
+- **`release-and-hygiene.md`** — no impact on release artefacts or
+  required files.
+- **`python.md`** — no Python-code changes.

--- a/scripts/_bootstrap_venv.sh
+++ b/scripts/_bootstrap_venv.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Ensure the per-OS/arch project virtualenv exists and reflects the
+# current pyproject.toml. Designed to be sourced (not executed) so the
+# caller can then exec the installed entry point in the same process.
+# The helper chdirs to the repo root; subsequent relative paths in the
+# caller (e.g. `tests/` for pytest, implicit pyproject.toml lookup for
+# `python -m build`) resolve there.
+#
+# Exports:
+#   REPO_ROOT — absolute path to the repo root.
+#   VENV_DIR — path to the virtualenv, relative to the repo root.
+
+set -euo pipefail
+
+BOOTSTRAP_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${BOOTSTRAP_SCRIPT_DIR}/.." && pwd)"
+export REPO_ROOT
+
+cd "${REPO_ROOT}"
+
+VENV_DIR=".venv-$(uname -s)-$(uname -m)"
+export VENV_DIR
+
+PYPROJECT_HASH_MARKER="${VENV_DIR}/pyproject.sha256"
+
+# `shasum -a 256` is present on both macOS (perl-backed, part of the base
+# system) and Linux (usually via coreutils or perl), unlike GNU `sha256sum`
+# which is not installed on macOS by default.
+read -r current_hash _ < <(shasum -a 256 pyproject.toml)
+
+needs_install=0
+if [[ ! -x "${VENV_DIR}/bin/pip" ]]; then
+  # `--clear` covers a half-built venv from an interrupted prior run
+  # (dir exists but bin/pip missing); on a clean miss it's a no-op.
+  echo "Bootstrapping venv at ${VENV_DIR}..." >&2
+  python3 -m venv --clear "${VENV_DIR}"
+  needs_install=1
+elif [[ ! -f "${PYPROJECT_HASH_MARKER}" ]] || {
+  read -r stored_hash <"${PYPROJECT_HASH_MARKER}"
+  [[ "${stored_hash}" != "${current_hash}" ]]
+}; then
+  echo "Refreshing venv (pyproject.toml changed)..." >&2
+  needs_install=1
+fi
+
+if [[ "${needs_install}" -eq 1 ]]; then
+  "${VENV_DIR}/bin/pip" install --quiet -e ".[dev]"
+  printf '%s\n' "${current_hash}" >"${PYPROJECT_HASH_MARKER}"
+fi

--- a/scripts/agent-auth.sh
+++ b/scripts/agent-auth.sh
@@ -5,15 +5,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-
-cd "${REPO_ROOT}"
-
-VENV_DIR=".venv-$(uname -s)-$(uname -m)"
-
-if [[ ! -d "${VENV_DIR}" ]]; then
-  python3 -m venv "${VENV_DIR}"
-  "${VENV_DIR}/bin/pip" install -e ".[dev]"
-fi
+# shellcheck source=./_bootstrap_venv.sh
+source "${SCRIPT_DIR}/_bootstrap_venv.sh"
 
 exec "${VENV_DIR}/bin/agent-auth" "$@"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,18 +5,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-
-cd "${REPO_ROOT}"
-
-VENV_DIR=".venv-$(uname -s)-$(uname -m)"
-
-if [[ ! -d "${VENV_DIR}" ]]; then
-  python3 -m venv "${VENV_DIR}"
-fi
-
-# Re-run the editable install unconditionally so that a venv created before
-# `build` was added to [dev] extras picks it up on the next `task build`.
-"${VENV_DIR}/bin/pip" install --quiet -e ".[dev]"
+# shellcheck source=./_bootstrap_venv.sh
+source "${SCRIPT_DIR}/_bootstrap_venv.sh"
 
 "${VENV_DIR}/bin/python" -m build --outdir "${REPO_ROOT}/dist"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,18 +5,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-
-cd "${REPO_ROOT}"
-
-VENV_DIR=".venv-$(uname -s)-$(uname -m)"
-
-if [[ ! -d "${VENV_DIR}" ]]; then
-  python3 -m venv "${VENV_DIR}"
-fi
-
-# Re-run the editable install unconditionally so that a venv created before
-# a new `[dev]` dependency was added picks it up on the next `task test`.
-"${VENV_DIR}/bin/pip" install --quiet -e ".[dev]"
+# shellcheck source=./_bootstrap_venv.sh
+source "${SCRIPT_DIR}/_bootstrap_venv.sh"
 
 "${VENV_DIR}/bin/python" -m pytest tests/ "$@"

--- a/scripts/things-bridge.sh
+++ b/scripts/things-bridge.sh
@@ -5,15 +5,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-
-cd "${REPO_ROOT}"
-
-VENV_DIR=".venv-$(uname -s)-$(uname -m)"
-
-if [[ ! -d "${VENV_DIR}" ]]; then
-  python3 -m venv "${VENV_DIR}"
-  "${VENV_DIR}/bin/pip" install -e ".[dev]"
-fi
+# shellcheck source=./_bootstrap_venv.sh
+source "${SCRIPT_DIR}/_bootstrap_venv.sh"
 
 exec "${VENV_DIR}/bin/things-bridge" "$@"

--- a/scripts/things-cli.sh
+++ b/scripts/things-cli.sh
@@ -5,15 +5,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-
-cd "${REPO_ROOT}"
-
-VENV_DIR=".venv-$(uname -s)-$(uname -m)"
-
-if [[ ! -d "${VENV_DIR}" ]]; then
-  python3 -m venv "${VENV_DIR}"
-  "${VENV_DIR}/bin/pip" install -e ".[dev]"
-fi
+# shellcheck source=./_bootstrap_venv.sh
+source "${SCRIPT_DIR}/_bootstrap_venv.sh"
 
 exec "${VENV_DIR}/bin/things-cli" "$@"

--- a/scripts/things-client-applescript.sh
+++ b/scripts/things-client-applescript.sh
@@ -5,16 +5,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-
-cd "${REPO_ROOT}"
-
-VENV_DIR=".venv-$(uname -s)-$(uname -m)"
-
-if [[ ! -d "${VENV_DIR}" ]]; then
-  python3 -m venv "${VENV_DIR}"
-fi
-
-"${VENV_DIR}/bin/pip" install --quiet -e ".[dev]"
+# shellcheck source=./_bootstrap_venv.sh
+source "${SCRIPT_DIR}/_bootstrap_venv.sh"
 
 exec "${VENV_DIR}/bin/things-client-cli-applescript" "$@"

--- a/scripts/verify-dependencies.sh
+++ b/scripts/verify-dependencies.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # keep-sorted start
 REQUIRED_TOOLS=(
   python3
+  shasum
   shellcheck
   shfmt
   systems-engineering

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 
-# Verify generic project standards mandated by .claude/instructions/.
+# Verify generic, portable project standards mandated by
+# .claude/instructions/. This script intentionally does NOT assert on
+# anything project-specific (service names, repo-specific CLI entry
+# points, domain tasks) — those belong in project documentation, not in
+# the standards gate. REQUIRED_TASKS only lists the task names the
+# cross-project tooling standard mandates (build, lint, format, test,
+# ...); project-specific tasks like running a local service CLI are
+# added to Taskfile.yml without being required here.
+#
 # Checks grow over time as new cross-cutting standards are added. Today:
 #
-#   1. Taskfile.yml exposes every task named in REQUIRED_TASKS (see
-#      tooling-and-ci.md Orchestration).
+#   1. Taskfile.yml exposes every generic task named in REQUIRED_TASKS
+#      (see tooling-and-ci.md Orchestration).
 #   2. .github/dependabot.yml covers every dependency ecosystem actually
 #      in use by this repository with minor/patch grouping (see
 #      tooling-and-ci.md Security). An ecosystem is "in use" when its
@@ -36,6 +44,9 @@ if ! command -v yq >/dev/null 2>&1; then
   exit 1
 fi
 
+# Only list task names that are required by the cross-project tooling
+# standard, not project-specific service/CLI entry points. See the
+# header comment for the rationale.
 # keep-sorted start
 REQUIRED_TASKS=(
   build


### PR DESCRIPTION
## Summary

- Extract `scripts/_bootstrap_venv.sh` — a shared helper that hashes `pyproject.toml` into a marker inside the venv and reinstalls `".[dev]"` whenever the hash changes, so re-running any `scripts/*.sh` (or `task <name>`) picks up new entry points / dependencies without a manual reinstall or `rm -rf .venv-*`. Fixes [#60](https://github.com/aidanns/agent-auth/issues/60).
- Collapse `scripts/{agent-auth,things-bridge,things-cli,things-client-applescript,test,build}.sh` onto the helper so there is one bootstrap implementation.
- Add `task agent-auth`, `task things-bridge`, `task things-cli`, and `task things-client-applescript` to `Taskfile.yml` (passing `{{.CLI_ARGS}}`) so each CLI can be run through the project task runner — e.g. `task agent-auth -- serve`, `task things-cli -- todos list`.
- Deliberately do **not** add these project-specific task names to `scripts/verify-standards.sh`'s `REQUIRED_TASKS`. That list is reserved for generic, portable task names mandated by the cross-project tooling standard (`build`, `lint`, `format`, `test`, …) so the check stays portable. Header comment, `CLAUDE.md`, and `.claude/instructions/tooling-and-ci.md` updated to make the boundary explicit.
- Add `shasum` to `scripts/verify-dependencies.sh` so a missing `shasum` surfaces as a dependency error rather than a cryptic failure inside the bootstrap helper.

Helper details:
- Uses `shasum -a 256` rather than `sha256sum` (portable across macOS and Linux).
- Gates on `${VENV_DIR}/bin/pip` and uses `python3 -m venv --clear`, so a half-built venv from an interrupted prior run self-heals.
- Fast path is one `shasum` + two `read -r` calls — no `pip` or `awk` on a hit.

## Test plan

- [x] `task test` — full pytest suite passes (bootstrap runs as part of it).
- [x] `task verify-standards` — passes; does not enforce project-specific task names.
- [x] `task verify-dependencies` — passes with `shasum` added to `REQUIRED_TOOLS`.
- [x] `task agent-auth -- --help`, `task things-bridge -- --help`, `task things-cli -- --help`, `task things-client-applescript -- --help` — each prints the CLI usage.
- [x] Fast path: second invocation of any wrapper prints no bootstrap/refresh message.
- [x] Rebuild trigger: corrupt `.venv-*/pyproject.sha256` (or edit `pyproject.toml`) and confirm the next wrapper run prints `Refreshing venv (pyproject.toml changed)...` and exits cleanly.
- [x] Half-built recovery: `rm -f .venv-*/bin/pip` and confirm the next wrapper run prints `Bootstrapping venv...` and succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)