### PR TITLE
ci: extract shared workflow setup into a composite action

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -26,6 +26,9 @@ inputs:
   taplo-version:
     description: taplo version to install
     default: "0.10.0"
+  systems-engineering-ref:
+    description: Commit SHA or ref of aidanns/systems-engineering to install
+    default: "d8e664a5ad20c071d4ec1cd62377597f9404b6e9"
   github-token:
     description: GitHub token to avoid rate limits when installing go-task
     required: false
@@ -44,8 +47,10 @@ runs:
 
     - name: Install systems-engineering
       shell: bash
+      env:
+        SYSTEMS_ENGINEERING_REF: ${{ inputs.systems-engineering-ref }}
       run: |
-        curl -fsSL https://raw.githubusercontent.com/aidanns/systems-engineering/main/install.sh | bash
+        curl -fsSL "https://raw.githubusercontent.com/aidanns/systems-engineering/${SYSTEMS_ENGINEERING_REF}/install.sh" | bash
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
     - name: Install go-task

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -1,0 +1,114 @@
+name: Setup Toolchain
+description: Install all CI tooling and verify dependencies
+
+inputs:
+  go-task-version:
+    description: go-task version to install
+    default: "3.50.0"
+  keep-sorted-version:
+    description: keep-sorted version to install
+    default: "0.8.0"
+  mdformat-version:
+    description: mdformat version to install
+    default: "0.7.22"
+  mdformat-gfm-version:
+    description: mdformat-gfm version to install
+    default: "1.0.0"
+  mdformat-tables-version:
+    description: mdformat-tables version to install
+    default: "1.0.0"
+  shellcheck-version:
+    description: shellcheck version to install
+    default: "0.10.0"
+  shfmt-version:
+    description: shfmt version to install
+    default: "3.8.0"
+  taplo-version:
+    description: taplo version to install
+    default: "0.10.0"
+  github-token:
+    description: GitHub token to avoid rate limits when installing go-task
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+
+    - name: Install d2
+      shell: bash
+      run: curl -fsSL https://d2lang.com/install.sh | sh -s --
+
+    - name: Install systems-engineering
+      shell: bash
+      run: |
+        curl -fsSL https://raw.githubusercontent.com/aidanns/systems-engineering/main/install.sh | bash
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+    - name: Install go-task
+      uses: arduino/setup-task@v2
+      with:
+        version: ${{ inputs.go-task-version }}
+        repo-token: ${{ inputs.github-token }}
+
+    - name: Install shellcheck
+      shell: bash
+      env:
+        SHELLCHECK_VERSION: ${{ inputs.shellcheck-version }}
+      run: |
+        curl -fsSL -o /tmp/shellcheck.tar.xz \
+          "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+        tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+        sudo install -m0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+        shellcheck --version
+
+    - name: Install shfmt
+      shell: bash
+      env:
+        SHFMT_VERSION: ${{ inputs.shfmt-version }}
+      run: |
+        curl -fsSL -o /tmp/shfmt \
+          "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
+        sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
+        shfmt --version
+
+    - name: Install mdformat
+      shell: bash
+      env:
+        MDFORMAT_VERSION: ${{ inputs.mdformat-version }}
+        MDFORMAT_GFM_VERSION: ${{ inputs.mdformat-gfm-version }}
+        MDFORMAT_TABLES_VERSION: ${{ inputs.mdformat-tables-version }}
+      run: |
+        uv tool install \
+          "mdformat==${MDFORMAT_VERSION}" \
+          --with "mdformat-gfm==${MDFORMAT_GFM_VERSION}" \
+          --with "mdformat-tables==${MDFORMAT_TABLES_VERSION}"
+        mdformat --version
+
+    - name: Install taplo
+      shell: bash
+      env:
+        TAPLO_VERSION: ${{ inputs.taplo-version }}
+      run: |
+        curl -fsSL -o /tmp/taplo.gz \
+          "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz"
+        gunzip -f /tmp/taplo.gz
+        sudo install -m0755 /tmp/taplo /usr/local/bin/taplo
+        taplo --version
+
+    - name: Install keep-sorted
+      shell: bash
+      env:
+        KEEP_SORTED_VERSION: ${{ inputs.keep-sorted-version }}
+      run: |
+        curl -fsSL -o /tmp/keep-sorted \
+          "https://github.com/google/keep-sorted/releases/download/v${KEEP_SORTED_VERSION}/keep-sorted_linux"
+        sudo install -m0755 /tmp/keep-sorted /usr/local/bin/keep-sorted
+        keep-sorted --version
+
+    - name: Verify Required Tooling
+      shell: bash
+      run: task verify-dependencies

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,82 +6,15 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  KEEP_SORTED_VERSION: 0.8.0
-  MDFORMAT_GFM_VERSION: 1.0.0
-  MDFORMAT_TABLES_VERSION: 1.0.0
-  MDFORMAT_VERSION: 0.7.22
-  SHELLCHECK_VERSION: 0.10.0
-  SHFMT_VERSION: 3.8.0
-  TAPLO_VERSION: 0.10.0
-
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - uses: ./.github/actions/setup-toolchain
         with:
-          enable-cache: true
-
-      - name: Install d2
-        run: curl -fsSL https://d2lang.com/install.sh | sh -s --
-
-      - name: Install systems-engineering
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/aidanns/systems-engineering/main/install.sh -o install.sh
-          bash install.sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Install go-task
-        uses: arduino/setup-task@v2
-        with:
-          version: 3.50.0
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install shellcheck
-        run: |
-          curl -fsSL -o /tmp/shellcheck.tar.xz \
-            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
-          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
-          sudo install -m0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
-          shellcheck --version
-
-      - name: Install shfmt
-        run: |
-          curl -fsSL -o /tmp/shfmt \
-            "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
-          sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
-          shfmt --version
-
-      - name: Install mdformat
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install \
-            "mdformat==${MDFORMAT_VERSION}" \
-            "mdformat-gfm==${MDFORMAT_GFM_VERSION}" \
-            "mdformat-tables==${MDFORMAT_TABLES_VERSION}"
-          mdformat --version
-
-      - name: Install taplo
-        run: |
-          curl -fsSL -o /tmp/taplo.gz \
-            "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz"
-          gunzip -f /tmp/taplo.gz
-          sudo install -m0755 /tmp/taplo /usr/local/bin/taplo
-          taplo --version
-
-      - name: Install keep-sorted
-        run: |
-          curl -fsSL -o /tmp/keep-sorted \
-            "https://github.com/google/keep-sorted/releases/download/v${KEEP_SORTED_VERSION}/keep-sorted_linux"
-          sudo install -m0755 /tmp/keep-sorted /usr/local/bin/keep-sorted
-          keep-sorted --version
-
-      - name: Verify Required Tooling
-        run: task verify-dependencies
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run lint + format --check
         run: task check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,77 +6,15 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  KEEP_SORTED_VERSION: 0.8.0
-  MDFORMAT_GFM_VERSION: 1.0.0
-  MDFORMAT_TABLES_VERSION: 1.0.0
-  MDFORMAT_VERSION: 0.7.22
-  SHELLCHECK_VERSION: 0.10.0
-  SHFMT_VERSION: 3.8.0
-  TAPLO_VERSION: 0.10.0
-
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - uses: ./.github/actions/setup-toolchain
         with:
-          enable-cache: true
-
-      - name: Install d2
-        run: curl -fsSL https://d2lang.com/install.sh | sh -s --
-
-      - name: Install systems-engineering
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/aidanns/systems-engineering/main/install.sh -o install.sh
-          bash install.sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Install go-task
-        uses: arduino/setup-task@v2
-        with:
-          version: 3.50.0
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install shellcheck
-        run: |
-          curl -fsSL -o /tmp/shellcheck.tar.xz \
-            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
-          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
-          sudo install -m0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
-
-      - name: Install shfmt
-        run: |
-          curl -fsSL -o /tmp/shfmt \
-            "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
-          sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
-
-      - name: Install mdformat
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install \
-            "mdformat==${MDFORMAT_VERSION}" \
-            "mdformat-gfm==${MDFORMAT_GFM_VERSION}" \
-            "mdformat-tables==${MDFORMAT_TABLES_VERSION}"
-
-      - name: Install taplo
-        run: |
-          curl -fsSL -o /tmp/taplo.gz \
-            "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz"
-          gunzip -f /tmp/taplo.gz
-          sudo install -m0755 /tmp/taplo /usr/local/bin/taplo
-
-      - name: Install keep-sorted
-        run: |
-          curl -fsSL -o /tmp/keep-sorted \
-            "https://github.com/google/keep-sorted/releases/download/v${KEEP_SORTED_VERSION}/keep-sorted_linux"
-          sudo install -m0755 /tmp/keep-sorted /usr/local/bin/keep-sorted
-
-      - name: Verify Required Tooling
-        run: task verify-dependencies
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
         run: task test -- --all

--- a/.github/workflows/verify-design.yml
+++ b/.github/workflows/verify-design.yml
@@ -6,77 +6,15 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  KEEP_SORTED_VERSION: 0.8.0
-  MDFORMAT_GFM_VERSION: 1.0.0
-  MDFORMAT_TABLES_VERSION: 1.0.0
-  MDFORMAT_VERSION: 0.7.22
-  SHELLCHECK_VERSION: 0.10.0
-  SHFMT_VERSION: 3.8.0
-  TAPLO_VERSION: 0.10.0
-
 jobs:
   verify-design:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - uses: ./.github/actions/setup-toolchain
         with:
-          enable-cache: true
-
-      - name: Install d2
-        run: curl -fsSL https://d2lang.com/install.sh | sh -s --
-
-      - name: Install systems-engineering
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/aidanns/systems-engineering/main/install.sh -o install.sh
-          bash install.sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Install go-task
-        uses: arduino/setup-task@v2
-        with:
-          version: 3.50.0
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install shellcheck
-        run: |
-          curl -fsSL -o /tmp/shellcheck.tar.xz \
-            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
-          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
-          sudo install -m0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
-
-      - name: Install shfmt
-        run: |
-          curl -fsSL -o /tmp/shfmt \
-            "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
-          sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
-
-      - name: Install mdformat
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install \
-            "mdformat==${MDFORMAT_VERSION}" \
-            "mdformat-gfm==${MDFORMAT_GFM_VERSION}" \
-            "mdformat-tables==${MDFORMAT_TABLES_VERSION}"
-
-      - name: Install taplo
-        run: |
-          curl -fsSL -o /tmp/taplo.gz \
-            "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz"
-          gunzip -f /tmp/taplo.gz
-          sudo install -m0755 /tmp/taplo /usr/local/bin/taplo
-
-      - name: Install keep-sorted
-        run: |
-          curl -fsSL -o /tmp/keep-sorted \
-            "https://github.com/google/keep-sorted/releases/download/v${KEEP_SORTED_VERSION}/keep-sorted_linux"
-          sudo install -m0755 /tmp/keep-sorted /usr/local/bin/keep-sorted
-
-      - name: Verify Required Tooling
-        run: task verify-dependencies
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify all functions are allocated
         run: task verify-design

--- a/.github/workflows/verify-function-tests.yml
+++ b/.github/workflows/verify-function-tests.yml
@@ -6,77 +6,15 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  KEEP_SORTED_VERSION: 0.8.0
-  MDFORMAT_GFM_VERSION: 1.0.0
-  MDFORMAT_TABLES_VERSION: 1.0.0
-  MDFORMAT_VERSION: 0.7.22
-  SHELLCHECK_VERSION: 0.10.0
-  SHFMT_VERSION: 3.8.0
-  TAPLO_VERSION: 0.10.0
-
 jobs:
   verify-function-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - uses: ./.github/actions/setup-toolchain
         with:
-          enable-cache: true
-
-      - name: Install d2
-        run: curl -fsSL https://d2lang.com/install.sh | sh -s --
-
-      - name: Install systems-engineering
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/aidanns/systems-engineering/main/install.sh -o install.sh
-          bash install.sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Install go-task
-        uses: arduino/setup-task@v2
-        with:
-          version: 3.50.0
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install shellcheck
-        run: |
-          curl -fsSL -o /tmp/shellcheck.tar.xz \
-            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
-          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
-          sudo install -m0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
-
-      - name: Install shfmt
-        run: |
-          curl -fsSL -o /tmp/shfmt \
-            "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
-          sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
-
-      - name: Install mdformat
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install \
-            "mdformat==${MDFORMAT_VERSION}" \
-            "mdformat-gfm==${MDFORMAT_GFM_VERSION}" \
-            "mdformat-tables==${MDFORMAT_TABLES_VERSION}"
-
-      - name: Install taplo
-        run: |
-          curl -fsSL -o /tmp/taplo.gz \
-            "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz"
-          gunzip -f /tmp/taplo.gz
-          sudo install -m0755 /tmp/taplo /usr/local/bin/taplo
-
-      - name: Install keep-sorted
-        run: |
-          curl -fsSL -o /tmp/keep-sorted \
-            "https://github.com/google/keep-sorted/releases/download/v${KEEP_SORTED_VERSION}/keep-sorted_linux"
-          sudo install -m0755 /tmp/keep-sorted /usr/local/bin/keep-sorted
-
-      - name: Verify Required Tooling
-        run: task verify-dependencies
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # continue-on-error until aidanns/agent-auth#5 is resolved: the
       # check currently reports 37/47 leaf functions covered, so it

--- a/.github/workflows/verify-standards.yml
+++ b/.github/workflows/verify-standards.yml
@@ -6,77 +6,15 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  KEEP_SORTED_VERSION: 0.8.0
-  MDFORMAT_GFM_VERSION: 1.0.0
-  MDFORMAT_TABLES_VERSION: 1.0.0
-  MDFORMAT_VERSION: 0.7.22
-  SHELLCHECK_VERSION: 0.10.0
-  SHFMT_VERSION: 3.8.0
-  TAPLO_VERSION: 0.10.0
-
 jobs:
   verify-standards:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - uses: ./.github/actions/setup-toolchain
         with:
-          enable-cache: true
-
-      - name: Install d2
-        run: curl -fsSL https://d2lang.com/install.sh | sh -s --
-
-      - name: Install systems-engineering
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/aidanns/systems-engineering/main/install.sh -o install.sh
-          bash install.sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Install go-task
-        uses: arduino/setup-task@v2
-        with:
-          version: 3.50.0
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install shellcheck
-        run: |
-          curl -fsSL -o /tmp/shellcheck.tar.xz \
-            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
-          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
-          sudo install -m0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
-
-      - name: Install shfmt
-        run: |
-          curl -fsSL -o /tmp/shfmt \
-            "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
-          sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
-
-      - name: Install mdformat
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install \
-            "mdformat==${MDFORMAT_VERSION}" \
-            "mdformat-gfm==${MDFORMAT_GFM_VERSION}" \
-            "mdformat-tables==${MDFORMAT_TABLES_VERSION}"
-
-      - name: Install taplo
-        run: |
-          curl -fsSL -o /tmp/taplo.gz \
-            "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz"
-          gunzip -f /tmp/taplo.gz
-          sudo install -m0755 /tmp/taplo /usr/local/bin/taplo
-
-      - name: Install keep-sorted
-        run: |
-          curl -fsSL -o /tmp/keep-sorted \
-            "https://github.com/google/keep-sorted/releases/download/v${KEEP_SORTED_VERSION}/keep-sorted_linux"
-          sudo install -m0755 /tmp/keep-sorted /usr/local/bin/keep-sorted
-
-      - name: Verify Required Tooling
-        run: task verify-dependencies
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify Project Standards
         run: task verify-standards

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -157,7 +157,7 @@ strip_comments() {
 # doesn't early-exit its upstream pipeline — `grep -q` exiting on first
 # match would otherwise SIGPIPE `sed`/`cat`, and `pipefail` turns that
 # into a whole-pipeline failure when the input is large enough to race.
-workflows_stripped="$(find .github/workflows -name '*.yml' -print0 2>/dev/null \
+workflows_stripped="$(find .github/workflows .github/actions -name '*.yml' -print0 2>/dev/null \
   | xargs -0 -r cat 2>/dev/null \
   | strip_comments)"
 treefmt_stripped=""


### PR DESCRIPTION
## Summary

- Adds `.github/actions/setup-toolchain/action.yml` — a composite action owning all tool installs (uv, d2, systems-engineering, go-task, shellcheck, shfmt, mdformat, taplo, keep-sorted) and `task verify-dependencies`
- Reduces all five workflows to: checkout → setup-toolchain → workflow-specific task
- Version pins are now inputs with defaults, so a single edit updates all workflows; mdformat uses `uv tool install` for consistency with the project's uv adoption

Closes #79

## Test plan

- [x] All five CI workflows pass on this PR
- [x] Verify each workflow runs its correct task (`task check`, `task test -- --all`, `task verify-design`, `task verify-function-tests`, `task verify-standards`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)