### PR TITLE
docs: add commit-signing section to CONTRIBUTING.md; gate in verify-standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,9 @@ Use conventional commit messages (`feat:`, `fix:`, `docs:`, `chore:`,
 is `main`; feature branches follow `aidanns/<feature-name>`. See the
 project [CLAUDE.md](CLAUDE.md) for the full working agreement.
 
+See also: [Commit signing](#commit-signing) — commit message format and GPG/SSH
+signing are sibling requirements, not the same thing.
+
 ## Release process
 
 `task release` is the release entrypoint. The underlying automation
@@ -80,7 +83,10 @@ releases that would skip the standard checks.
 
 ## Commit signing
 
-Commits to `main` must be signed. Configure GPG or SSH signing in git:
+Commits to `main` must be signed. Enforcement via GitHub branch protection is
+not yet wired up (tracked in
+[#93](https://github.com/aidanns/agent-auth/issues/93)); until then this is an
+honour-system requirement. Configure GPG or SSH signing in git:
 
 ```bash
 # GPG (recommended)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,3 +77,23 @@ project [CLAUDE.md](CLAUDE.md) for the full working agreement.
 [#18](https://github.com/aidanns/agent-auth/issues/18) and is not yet
 implemented — running the task today exits non-zero to prevent manual
 releases that would skip the standard checks.
+
+## Commit signing
+
+Commits to `main` must be signed. Configure GPG or SSH signing in git:
+
+```bash
+# GPG (recommended)
+git config --global commit.gpgsign true
+git config --global user.signingkey <YOUR_KEY_ID>
+
+# SSH (alternative — set these instead of the GPG options above)
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+```
+
+Verify signing is working:
+
+```bash
+git log --show-signature -1
+```

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -29,6 +29,9 @@
 #      `pip install` to bootstrap a venv.
 #   6. ruff is configured in pyproject.toml, wired into treefmt and
 #      lefthook, and gated in CI per .claude/instructions/python.md.
+#   7. CONTRIBUTING.md exists at repo root and contains dev-setup, testing,
+#      release, and commit-signing sections per
+#      .claude/instructions/release-and-hygiene.md.
 
 set -euo pipefail
 
@@ -323,3 +326,50 @@ if [[ ${ruff_missing} -ne 0 ]]; then
 fi
 
 echo "verify-standards: ruff is configured in pyproject.toml, wired into treefmt and lefthook, and gated in CI."
+
+# CONTRIBUTING.md must exist and contain the four required sections per
+# .claude/instructions/release-and-hygiene.md.
+
+contributing_missing=0
+
+fail_contributing_check() {
+  echo "verify-standards: $1" >&2
+  echo "  $2" >&2
+  contributing_missing=1
+}
+
+if [[ ! -f CONTRIBUTING.md ]]; then
+  fail_contributing_check \
+    "CONTRIBUTING.md is missing from the repo root." \
+    "Add CONTRIBUTING.md covering dev setup, testing, release, and commit signing."
+else
+  contributing_content="$(cat CONTRIBUTING.md)"
+
+  # Parallel arrays (bash 3.2-compatible): section_names[i] pairs with section_patterns[i].
+  section_names=(
+    dev-setup
+    testing
+    release
+    commit-signing
+  )
+  section_patterns=(
+    "## Dev setup|## Development environment setup|## Getting started|## Setup"
+    "## Running tasks|## Testing|## Running tests"
+    "## Release"
+    "## Commit signing"
+  )
+
+  for i in "${!section_names[@]}"; do
+    if ! grep -qE "${section_patterns[${i}]}" <<<"${contributing_content}"; then
+      fail_contributing_check \
+        "CONTRIBUTING.md is missing a '${section_names[${i}]}' section." \
+        "Add a section matching: ${section_patterns[${i}]}"
+    fi
+  done
+fi
+
+if [[ ${contributing_missing} -ne 0 ]]; then
+  exit 1
+fi
+
+echo "verify-standards: CONTRIBUTING.md exists with dev-setup, testing, release, and commit-signing sections."

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -343,8 +343,6 @@ if [[ ! -f CONTRIBUTING.md ]]; then
     "CONTRIBUTING.md is missing from the repo root." \
     "Add CONTRIBUTING.md covering dev setup, testing, release, and commit signing."
 else
-  contributing_content="$(cat CONTRIBUTING.md)"
-
   # Parallel arrays (bash 3.2-compatible): section_names[i] pairs with section_patterns[i].
   section_names=(
     dev-setup
@@ -354,13 +352,16 @@ else
   )
   section_patterns=(
     "## Dev setup|## Development environment setup|## Getting started|## Setup"
+    # This project collapses testing and the task catalogue into one section
+    # ("## Running tasks"). Accept that heading as well as a dedicated testing
+    # section heading so the check stays valid if the two are split later.
     "## Running tasks|## Testing|## Running tests"
     "## Release"
     "## Commit signing"
   )
 
   for i in "${!section_names[@]}"; do
-    if ! grep -qE "${section_patterns[${i}]}" <<<"${contributing_content}"; then
+    if ! grep -qiE "${section_patterns[${i}]}" CONTRIBUTING.md; then
       fail_contributing_check \
         "CONTRIBUTING.md is missing a '${section_names[${i}]}' section." \
         "Add a section matching: ${section_patterns[${i}]}"


### PR DESCRIPTION
## Summary

- Adds `## Commit signing` section to `CONTRIBUTING.md` covering GPG and SSH signing configuration, fulfilling the requirement in `.claude/instructions/release-and-hygiene.md`
- Extends `scripts/verify-standards.sh` to assert `CONTRIBUTING.md` exists and contains dev-setup, testing, release, and commit-signing sections
- Uses bash 3.2-compatible parallel arrays (not `declare -A`) so the script works on macOS system bash

Closes #13

## Test plan

- [x] `bash scripts/verify-standards.sh` passes
- [x] Temporarily rename `CONTRIBUTING.md` and verify the check fails with a clear error
- [x] Temporarily remove `## Commit signing` and verify the check fails identifying that section

🤖 Generated with [Claude Code](https://claude.com/claude-code)