### PR TITLE
feat: expose token management operations via HTTP API

### DIFF
--- a/.github/workflows/verify-token-cli-http-parity.yml
+++ b/.github/workflows/verify-token-cli-http-parity.yml
@@ -1,0 +1,20 @@
+name: Verify Token CLI / HTTP Parity
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  verify-token-cli-http-parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify every `agent-auth token *` subcommand has an HTTP route
+        run: task verify-token-cli-http-parity

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,9 +11,11 @@ There are two trust zones:
 
 ## Token Management Endpoints
 
-The management endpoints (`POST /agent-auth/token/create`, `GET /agent-auth/token/list`, `POST /agent-auth/token/modify`, `POST /agent-auth/token/revoke`, `POST /agent-auth/token/rotate`) carry no additional authentication. The trust boundary is the server's bind address — any caller that can reach the server already has equivalent access via the CLI.
+The management endpoints (`POST /agent-auth/token/create`, `GET /agent-auth/token/list`, `POST /agent-auth/token/modify`, `POST /agent-auth/token/revoke`, `POST /agent-auth/token/rotate`) require `Authorization: Bearer <token>` where the token's family carries `agent-auth:manage=allow` in its scopes.
 
-If the server is ever reconfigured to bind to a non-loopback address, these endpoints become network-accessible without authentication. Operators who expose agent-auth on a non-local interface must place a reverse proxy with an independent auth layer in front of it. See `design/decisions/0006-management-endpoint-no-auth.md` for the full rationale.
+On first startup the server creates this management token family directly via the store and stores the refresh token in the OS keyring. Operators retrieve it with `agent-auth management-token show` and exchange it for an access token via `POST /agent-auth/token/refresh`. External clients must refresh before each management session (access tokens expire after 900 s by default).
+
+The `agent-auth:manage` scope is reserved. The management token family is excluded from `GET /token/list` responses. If the management family is rotated or revoked, the server recreates it automatically on the next restart. See `design/decisions/0006-management-endpoint-no-auth.md` for the full rationale.
 
 ## Cryptographic Key Handling
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security
+
+## Trust Boundaries
+
+agent-auth runs as a local daemon on the host machine. It binds to `127.0.0.1` by default, restricting all network access to the local host. No credential material is transmitted over the network except within the localhost loopback interface.
+
+There are two trust zones:
+
+- **Host process trust**: any process on the host that can reach `127.0.0.1:9100` can call the agent-auth HTTP API. This is equivalent to having local shell access.
+- **Devcontainer trust**: the host forwards port 9100 to devcontainers via Docker networking (`host.docker.internal`). Code running in the devcontainer has the same API access as host processes.
+
+## Token Management Endpoints
+
+The management endpoints (`POST /agent-auth/token/create`, `GET /agent-auth/token/list`, `POST /agent-auth/token/modify`, `POST /agent-auth/token/revoke`, `POST /agent-auth/token/rotate`) carry no additional authentication. The trust boundary is the server's bind address — any caller that can reach the server already has equivalent access via the CLI.
+
+If the server is ever reconfigured to bind to a non-loopback address, these endpoints become network-accessible without authentication. Operators who expose agent-auth on a non-local interface must place a reverse proxy with an independent auth layer in front of it. See `design/decisions/0006-management-endpoint-no-auth.md` for the full rationale.
+
+## Cryptographic Key Handling
+
+- **Signing key**: HMAC-SHA256 key stored in the system keyring (macOS Keychain or libsecret). Generated on first startup. All token signatures are verified against this key; a compromised key allows token forgery.
+- **Encryption key**: AES-256-GCM key stored in the system keyring. Used for field-level encryption of sensitive database columns (token HMAC signatures, scope definitions). A compromised encryption key exposes scope definitions and allows offline brute-force of token IDs, but does not allow token forgery without also compromising the signing key.
+
+**Key loss**: if the signing key is lost, all issued tokens become unverifiable. Recovery requires revoking all token families (via the database) and issuing new credentials. If the encryption key is lost, the database is unreadable; the SQLite file must be deleted and all token families recreated. No automatic key backup or escrow is provided.
+
+## Token Revocation
+
+Revocation is propagated immediately: any call to `/agent-auth/validate` checks the token family's revocation flag in the database before returning a result. There is no TTL-based propagation delay.
+
+Refresh token reuse triggers automatic family revocation: if a consumed refresh token is presented again, agent-auth revokes the entire token family (all access and refresh tokens) and returns an error. This detects replay attacks by stolen refresh tokens.
+
+## Audit Surface
+
+All token operations and authorization decisions are written to the audit log at `~/.local/state/agent-auth/audit.log`. The log records:
+
+- Token creation, modification, revocation, rotation, and re-issuance
+- Every `/validate` call with outcome (allowed / denied), scope, and tier
+- JIT approval requests, grants, and denials
+
+The audit log is append-only. It is not encrypted. Operators who need tamper-evident audit trails should ship the log to an external SIEM.
+
+## Vulnerability Reporting
+
+Report security vulnerabilities by email to `aidanns@gmail.com`. Include a description of the issue, reproduction steps, and potential impact. Do not file public GitHub issues for security vulnerabilities until a fix is available.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -51,6 +51,11 @@ tasks:
     cmds:
       - scripts/verify-standards.sh
 
+  verify-token-cli-http-parity:
+    desc: Verify every `agent-auth token *` CLI subcommand has a matching HTTP route.
+    cmds:
+      - scripts/verify-token-cli-http-parity.sh
+
   build:
     desc: Build sdist and wheel distributions into dist/.
     cmds:

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -564,6 +564,19 @@ Response (200):
 }
 ```
 
+### Management endpoint authentication
+
+All five management endpoints require `Authorization: Bearer <access_token>`
+where the access token's family has `agent-auth:manage=allow` in its scopes.
+On first startup, the server creates this management token family automatically
+and stores the refresh token in the OS keyring. Retrieve the refresh token via
+`agent-auth management-token show`, then exchange it for an access token via
+`POST /agent-auth/token/refresh` before calling management endpoints. See
+[ADR 0006](decisions/0006-management-endpoint-no-auth.md) for the rationale.
+
+Errors returned when auth is missing or invalid: `401 missing_token`,
+`401 invalid_token`, `401 token_expired`, `403 scope_denied`.
+
 ### POST /agent-auth/token/create
 
 Create a new token family and return an access/refresh token pair.

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -564,6 +564,114 @@ Response (200):
 }
 ```
 
+### POST /agent-auth/token/create
+
+Create a new token family and return an access/refresh token pair.
+
+Request:
+
+```json
+{"scopes": {"things:read": "allow", "things:write": "prompt"}}
+```
+
+Response (200):
+
+```json
+{
+  "family_id": "fff",
+  "access_token": "aa_xxx_yyy",
+  "refresh_token": "rt_xxx_yyy",
+  "scopes": {"things:read": "allow", "things:write": "prompt"},
+  "expires_in": 900
+}
+```
+
+Errors: `400 no_scopes` (empty or missing scopes), `400 invalid_tier` (tier not in `allow`/`prompt`/`deny`), `400 malformed_request`.
+
+No authentication required. Trust boundary is the server's bind address (127.0.0.1 by default — see ADR 0006).
+
+### GET /agent-auth/token/list
+
+Return all token families, including revoked ones.
+
+Response (200): JSON array of family objects.
+
+```json
+[
+  {"id": "fff", "scopes": {"things:read": "allow"}, "created_at": "2026-04-19T10:00:00Z", "revoked": false}
+]
+```
+
+No authentication required.
+
+### POST /agent-auth/token/modify
+
+Modify the scopes on an existing token family. Takes effect on the next `/validate` call — no new tokens are issued.
+
+Request:
+
+```json
+{
+  "family_id": "fff",
+  "add_scopes": {"things:write": "allow"},
+  "remove_scopes": ["things:read"],
+  "set_tiers": {"things:write": "prompt"}
+}
+```
+
+All modification fields are optional; at least one must be non-empty. `set_tiers` silently skips scope names that do not exist on the family.
+
+Response (200):
+
+```json
+{"family_id": "fff", "scopes": {"things:write": "prompt"}}
+```
+
+Errors: `400 no_modifications`, `400 invalid_tier`, `400 malformed_request`, `404 family_not_found`, `409 family_revoked`. No authentication required.
+
+### POST /agent-auth/token/revoke
+
+Revoke a token family, invalidating all its tokens. Idempotent: revoking an already-revoked family returns 200.
+
+Request:
+
+```json
+{"family_id": "fff"}
+```
+
+Response (200):
+
+```json
+{"family_id": "fff", "revoked": true}
+```
+
+Errors: `400 malformed_request`, `404 family_not_found`. No authentication required.
+
+### POST /agent-auth/token/rotate
+
+Revoke an existing token family and create a new one with the same scopes.
+
+Request:
+
+```json
+{"family_id": "fff"}
+```
+
+Response (200):
+
+```json
+{
+  "old_family_id": "fff",
+  "new_family_id": "ggg",
+  "access_token": "aa_xxx_yyy",
+  "refresh_token": "rt_xxx_yyy",
+  "scopes": {"things:read": "allow"},
+  "expires_in": 900
+}
+```
+
+Errors: `400 malformed_request`, `404 family_not_found`, `409 family_revoked`. No authentication required.
+
 ## Network Configuration
 
 ### Local (host only)

--- a/design/decisions/0006-management-endpoint-no-auth.md
+++ b/design/decisions/0006-management-endpoint-no-auth.md
@@ -1,0 +1,44 @@
+# ADR 0006: Management Endpoints Carry No Additional Authentication
+
+## Context
+
+Issue #3 adds HTTP endpoints for token lifecycle management (create, list,
+modify, revoke, rotate). These are privileged operations — they can create new
+tokens or cancel existing ones. The runtime endpoints (`/validate`,
+`/token/refresh`, `/token/reissue`, `/token/status`) require a valid bearer
+token issued by the server itself. The management endpoints need a trust model.
+
+The alternatives considered:
+
+1. **No additional auth** — trust is derived from network access, which is
+   scoped to localhost (127.0.0.1) by default. Anyone who can reach the server
+   is already on the host and could run the CLI directly.
+2. **Bearer token with a management scope** — a pre-existing token carrying
+   `agent-auth:manage` would gate all management calls. This creates a
+   chicken-and-egg problem: the first token must still be created through some
+   other mechanism (the CLI), and there is no bootstrapping story without it.
+3. **Separate management API key** — a static key stored in config or keyring.
+   Adds friction (key distribution, rotation) without meaningfully improving
+   the security posture for a local daemon whose threat model is already
+   bounded by host access.
+
+## Decision
+
+Management endpoints carry no additional authentication. The trust boundary is
+the server's bind address: the default `127.0.0.1` restricts callers to the
+local host, which is the same trust level as running the CLI directly.
+
+## Consequences
+
+- Any process on the host can call the management endpoints without a token.
+  This matches the CLI's trust model (any user who can exec the CLI can manage
+  tokens).
+- If the server is ever reconfigured to bind to a non-loopback address,
+  management endpoints become network-accessible with no auth gate. Operators
+  who expose the server on a non-local interface must be aware of this risk.
+  A firewall or reverse proxy with its own auth layer is required in that case.
+- The bootstrapping story remains simple: `agent-auth token create` (CLI) or
+  `POST /agent-auth/token/create` (HTTP) both work without any pre-existing
+  credential.
+- If a management token model is added in the future, the scope name
+  `agent-auth:manage` is reserved for that purpose.

--- a/design/decisions/0006-management-endpoint-no-auth.md
+++ b/design/decisions/0006-management-endpoint-no-auth.md
@@ -1,4 +1,4 @@
-# ADR 0006: Management Endpoints Carry No Additional Authentication
+# ADR 0006: Management Endpoints Require a Management Bearer Token
 
 ## Context
 
@@ -11,34 +11,49 @@ token issued by the server itself. The management endpoints need a trust model.
 The alternatives considered:
 
 1. **No additional auth** — trust is derived from network access, which is
-   scoped to localhost (127.0.0.1) by default. Anyone who can reach the server
-   is already on the host and could run the CLI directly.
-2. **Bearer token with a management scope** — a pre-existing token carrying
-   `agent-auth:manage` would gate all management calls. This creates a
-   chicken-and-egg problem: the first token must still be created through some
-   other mechanism (the CLI), and there is no bootstrapping story without it.
-3. **Separate management API key** — a static key stored in config or keyring.
-   Adds friction (key distribution, rotation) without meaningfully improving
-   the security posture for a local daemon whose threat model is already
-   bounded by host access.
+   scoped to localhost (127.0.0.1) by default. Simple, but provides no
+   programmatic identity for audit logging, and offers no gate if the bind
+   address is changed to a non-loopback interface.
+2. **Bearer token with a management scope** — a token carrying
+   `agent-auth:manage=allow` gates all management calls. The bootstrapping
+   challenge (you need a token to create the first token) is resolved by
+   creating the initial management token directly via the store on server
+   startup, storing the refresh token in the OS keyring alongside the
+   signing and encryption keys. Operators retrieve the refresh token via
+   `agent-auth management-token show`. External clients exchange it for an
+   access token via the standard `/token/refresh` endpoint.
+3. **Separate management API key** — a static opaque key stored in config or
+   keyring. Adds friction (separate key format, rotation story) without
+   integrating with the existing token model.
 
 ## Decision
 
-Management endpoints carry no additional authentication. The trust boundary is
-the server's bind address: the default `127.0.0.1` restricts callers to the
-local host, which is the same trust level as running the CLI directly.
+Management endpoints require an `Authorization: Bearer <token>` header
+carrying an access token whose family has `agent-auth:manage=allow` in its
+scopes. Only `allow`-tier management tokens are accepted; `prompt`-tier JIT
+approval for management operations is left as a future enhancement.
+
+On first startup, `run_server` calls `_bootstrap_management_token` which
+checks the keyring for an existing management refresh token. If none is found
+(or the stored token's family has been revoked), a new token family is created
+directly via the store and the refresh token is persisted to the keyring.
+
+The management token family is excluded from `GET /token/list` responses so it
+does not appear in external clients' token inventories.
 
 ## Consequences
 
-- Any process on the host can call the management endpoints without a token.
-  This matches the CLI's trust model (any user who can exec the CLI can manage
-  tokens).
-- If the server is ever reconfigured to bind to a non-loopback address,
-  management endpoints become network-accessible with no auth gate. Operators
-  who expose the server on a non-local interface must be aware of this risk.
-  A firewall or reverse proxy with its own auth layer is required in that case.
-- The bootstrapping story remains simple: `agent-auth token create` (CLI) or
-  `POST /agent-auth/token/create` (HTTP) both work without any pre-existing
-  credential.
-- If a management token model is added in the future, the scope name
-  `agent-auth:manage` is reserved for that purpose.
+- Management endpoints return 401 if no `Authorization` header is present and
+  403 if the token exists but lacks `agent-auth:manage=allow` scope.
+- The `agent-auth:manage` scope is reserved; no user-created token should
+  carry it. Future work: enforce this at creation time.
+- `agent-auth management-token show` exposes the management refresh token from
+  the keyring so operators can hand it to external clients.
+- If the server is restarted after the management token family is rotated or
+  revoked externally, `_bootstrap_management_token` detects the revoked state
+  and creates a fresh family automatically.
+- Access tokens expire (default 900 s). External clients must refresh via
+  `/token/refresh` before each management session or when they receive 401.
+- The `prompt`-tier JIT path for management operations is not yet wired; a
+  management token with `agent-auth:manage=prompt` is currently rejected
+  (treated as scope_denied). This will be addressed in a follow-up issue.

--- a/design/functional_decomposition.yaml
+++ b/design/functional_decomposition.yaml
@@ -93,6 +93,8 @@ functions:
         description: Handle POST /agent-auth/token/revoke requests to revoke a token family, invalidating all its tokens.
       - name: Serve Token Rotate Endpoint
         description: Handle POST /agent-auth/token/rotate requests to revoke an existing token family and create a new one with the same scopes.
+      - name: Bootstrap Management Token
+        description: On server startup, check the OS keyring for a management refresh token; if absent or revoked, create a new agent-auth:manage=allow token family directly via the store and persist the refresh token to the keyring.
   - name: Audit Logging
     description: Record all token operations and authorization decisions for security review.
     functions:

--- a/design/functional_decomposition.yaml
+++ b/design/functional_decomposition.yaml
@@ -117,6 +117,8 @@ functions:
         description: Parse arguments and invoke token family rotation.
       - name: Handle Serve Command
         description: Start the agent-auth HTTP server.
+      - name: Handle Management Token Show Command
+        description: Retrieve the management refresh token from the OS keyring and print it (or surface a clean error and non-zero exit if the keyring is unavailable).
   - name: Things Bridge
     description: Expose authenticated Things 3 read operations over HTTP to the CLI client, delegating authorization to agent-auth.
     functions:

--- a/design/functional_decomposition.yaml
+++ b/design/functional_decomposition.yaml
@@ -83,6 +83,16 @@ functions:
         description: Handle GET /agent-auth/token/status requests for token introspection.
       - name: Serve Health Endpoint
         description: Handle GET /agent-auth/health liveness / readiness probes; require an access token carrying the agent-auth:health scope, return 200 when the token store is reachable, 401 / 403 on missing / unscoped tokens, and 503 when the store is unreachable.
+      - name: Serve Token Create Endpoint
+        description: Handle POST /agent-auth/token/create requests to create a new token family and return an access/refresh token pair.
+      - name: Serve Token List Endpoint
+        description: Handle GET /agent-auth/token/list requests to return all token families and their scopes.
+      - name: Serve Token Modify Endpoint
+        description: Handle POST /agent-auth/token/modify requests to add, remove, or change tiers on scopes of an existing token family.
+      - name: Serve Token Revoke Endpoint
+        description: Handle POST /agent-auth/token/revoke requests to revoke a token family, invalidating all its tokens.
+      - name: Serve Token Rotate Endpoint
+        description: Handle POST /agent-auth/token/rotate requests to revoke an existing token family and create a new one with the same scopes.
   - name: Audit Logging
     description: Record all token operations and authorization decisions for security review.
     functions:

--- a/design/product_breakdown.yaml
+++ b/design/product_breakdown.yaml
@@ -44,6 +44,7 @@ components:
           - Handle Token Revoke Command
           - Handle Token Rotate Command
           - Handle Serve Command
+          - Handle Management Token Show Command
       - name: SQLite
         description: Third-party embedded relational database providing persistent storage for token families and tokens.
         functions:

--- a/design/product_breakdown.yaml
+++ b/design/product_breakdown.yaml
@@ -35,6 +35,7 @@ components:
           - Serve Token Modify Endpoint
           - Serve Token Revoke Endpoint
           - Serve Token Rotate Endpoint
+          - Bootstrap Management Token
           - Log Token Operation
           - Log Authorization Decision
           - Handle Token Create Command

--- a/design/product_breakdown.yaml
+++ b/design/product_breakdown.yaml
@@ -30,6 +30,11 @@ components:
           - Serve Reissue Endpoint
           - Serve Status Endpoint
           - Serve Health Endpoint
+          - Serve Token Create Endpoint
+          - Serve Token List Endpoint
+          - Serve Token Modify Endpoint
+          - Serve Token Revoke Endpoint
+          - Serve Token Rotate Endpoint
           - Log Token Operation
           - Log Authorization Decision
           - Handle Token Create Command

--- a/plans/token-management-http-api.md
+++ b/plans/token-management-http-api.md
@@ -7,36 +7,41 @@ programmatic clients can manage token lifecycle without SSH/local CLI access.
 
 ## New endpoints
 
-| Method | Path                        | CLI equivalent          |
-|--------|-----------------------------|-------------------------|
-| POST   | /agent-auth/token/create   | agent-auth token create |
-| GET    | /agent-auth/token/list     | agent-auth token list   |
-| POST   | /agent-auth/token/modify   | agent-auth token modify |
-| POST   | /agent-auth/token/revoke   | agent-auth token revoke |
-| POST   | /agent-auth/token/rotate   | agent-auth token rotate |
+| Method | Path                     | CLI equivalent          |
+| ------ | ------------------------ | ----------------------- |
+| POST   | /agent-auth/token/create | agent-auth token create |
+| GET    | /agent-auth/token/list   | agent-auth token list   |
+| POST   | /agent-auth/token/modify | agent-auth token modify |
+| POST   | /agent-auth/token/revoke | agent-auth token revoke |
+| POST   | /agent-auth/token/rotate | agent-auth token rotate |
 
 ## Request/response schemas
 
 ### POST /agent-auth/token/create
+
 Request: `{"scopes": {"<name>": "<tier>", ...}}`
 Response 200: `{"family_id": "...", "access_token": "...", "refresh_token": "...", "scopes": {...}, "expires_in": N}`
 Errors: 400 `malformed_request`, 400 `no_scopes`
 
 ### GET /agent-auth/token/list
+
 No body. Response 200: array of family objects (same shape as CLI JSON output).
 
 ### POST /agent-auth/token/modify
+
 Request: `{"family_id": "...", "add_scopes": {...}, "remove_scopes": [...], "set_tiers": {...}}`
 (All modification fields optional; at least one must be non-empty.)
 Response 200: `{"family_id": "...", "scopes": {...}}`
 Errors: 400 `malformed_request`, 400 `no_modifications`, 404 `family_not_found`, 409 `family_revoked`
 
 ### POST /agent-auth/token/revoke
+
 Request: `{"family_id": "..."}`
 Response 200: `{"family_id": "...", "revoked": true}` (idempotent for already-revoked families)
 Errors: 400 `malformed_request`, 404 `family_not_found`
 
 ### POST /agent-auth/token/rotate
+
 Request: `{"family_id": "..."}`
 Response 200: `{"old_family_id": "...", "new_family_id": "...", "access_token": "...", "refresh_token": "...", "scopes": {...}, "expires_in": N}`
 Errors: 400 `malformed_request`, 404 `family_not_found`, 409 `family_revoked`
@@ -62,6 +67,7 @@ Document in ADR 0006.
 ## Regression check design (verify-standards.sh)
 
 Inline Python script that:
+
 - Imports `COMMAND_HANDLERS` from `agent_auth.cli` to enumerate token subcommands
 - Inspects `AgentAuthHandler.do_POST` / `do_GET` source to find `/agent-auth/token/<cmd>` routes
 - Fails if any subcommand has no matching route

--- a/plans/token-management-http-api.md
+++ b/plans/token-management-http-api.md
@@ -1,0 +1,77 @@
+# Plan: Token Management HTTP API (Issue #3)
+
+## Goal
+
+Expose the five CLI token-management operations as HTTP endpoints so that
+programmatic clients can manage token lifecycle without SSH/local CLI access.
+
+## New endpoints
+
+| Method | Path                        | CLI equivalent          |
+|--------|-----------------------------|-------------------------|
+| POST   | /agent-auth/token/create   | agent-auth token create |
+| GET    | /agent-auth/token/list     | agent-auth token list   |
+| POST   | /agent-auth/token/modify   | agent-auth token modify |
+| POST   | /agent-auth/token/revoke   | agent-auth token revoke |
+| POST   | /agent-auth/token/rotate   | agent-auth token rotate |
+
+## Request/response schemas
+
+### POST /agent-auth/token/create
+Request: `{"scopes": {"<name>": "<tier>", ...}}`
+Response 200: `{"family_id": "...", "access_token": "...", "refresh_token": "...", "scopes": {...}, "expires_in": N}`
+Errors: 400 `malformed_request`, 400 `no_scopes`
+
+### GET /agent-auth/token/list
+No body. Response 200: array of family objects (same shape as CLI JSON output).
+
+### POST /agent-auth/token/modify
+Request: `{"family_id": "...", "add_scopes": {...}, "remove_scopes": [...], "set_tiers": {...}}`
+(All modification fields optional; at least one must be non-empty.)
+Response 200: `{"family_id": "...", "scopes": {...}}`
+Errors: 400 `malformed_request`, 400 `no_modifications`, 404 `family_not_found`, 409 `family_revoked`
+
+### POST /agent-auth/token/revoke
+Request: `{"family_id": "..."}`
+Response 200: `{"family_id": "...", "revoked": true}` (idempotent for already-revoked families)
+Errors: 400 `malformed_request`, 404 `family_not_found`
+
+### POST /agent-auth/token/rotate
+Request: `{"family_id": "..."}`
+Response 200: `{"old_family_id": "...", "new_family_id": "...", "access_token": "...", "refresh_token": "...", "scopes": {...}, "expires_in": N}`
+Errors: 400 `malformed_request`, 404 `family_not_found`, 409 `family_revoked`
+
+## Security decision
+
+Management endpoints (create, modify, revoke, rotate) carry no additional
+authentication beyond the existing runtime endpoints. The trust boundary is
+the localhost binding (127.0.0.1 by default). Adding a management token would
+create a chicken-and-egg problem: you need a token to create the first token.
+Document in ADR 0006.
+
+## Files to change
+
+1. `src/agent_auth/server.py` — add 5 handler methods + route entries
+2. `design/functional_decomposition.yaml` — add 5 leaf functions under HTTP API
+3. `tests/test_server.py` — unit tests for each new endpoint (happy path + errors)
+4. `tests/integration/test_token_management.py` — Docker integration tests
+5. `scripts/verify-standards.sh` — CLI→HTTP route mapping regression check
+6. `design/decisions/0006-management-endpoint-no-auth.md` — ADR for auth decision
+7. `design/DESIGN.md` — document new endpoints
+
+## Regression check design (verify-standards.sh)
+
+Inline Python script that:
+- Imports `COMMAND_HANDLERS` from `agent_auth.cli` to enumerate token subcommands
+- Inspects `AgentAuthHandler.do_POST` / `do_GET` source to find `/agent-auth/token/<cmd>` routes
+- Fails if any subcommand has no matching route
+
+## Post-implementation checklist (from plan-template.md)
+
+- [ ] Verify implementation against DESIGN.md; reconcile drift
+- [ ] Refresh threat model in SECURITY.md (new unauthenticated write surface)
+- [ ] Write ADR 0006 (management endpoint auth decision)
+- [ ] Apply coding-standards.md review
+- [ ] Apply service-design.md review (stable error taxonomy, API versioning)
+- [ ] Apply testing-standards.md review
+- [ ] Apply tooling-and-ci.md review

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -392,6 +392,7 @@ echo "verify-standards: CONTRIBUTING.md exists with dev-setup, testing, release,
 if [[ -f pyproject.toml ]] && command -v uv >/dev/null 2>&1; then
   cli_http_check_output="$(
     uv run python3 - <<'PY'
+import inspect
 import sys
 
 try:
@@ -401,14 +402,22 @@ except ImportError as e:
     print(f"verify-standards: could not import agent_auth modules: {e}", file=sys.stderr)
     sys.exit(1)
 
+routing_source = (
+    inspect.getsource(AgentAuthHandler.do_POST)
+    + inspect.getsource(AgentAuthHandler.do_GET)
+)
+
 missing = []
 for cmd in sorted(COMMAND_HANDLERS):
     method = f"_handle_token_{cmd}"
+    route = f"/agent-auth/token/{cmd}"
     if not hasattr(AgentAuthHandler, method):
-        missing.append(f"  token {cmd!r} has no handler method {method!r} on AgentAuthHandler")
+        missing.append(f"  token {cmd!r}: no handler method {method!r}")
+    elif route not in routing_source:
+        missing.append(f"  token {cmd!r}: method exists but route {route!r} is not wired in do_POST/do_GET")
 
 if missing:
-    print("verify-standards: agent-auth token subcommands missing HTTP handler methods:", file=sys.stderr)
+    print("verify-standards: agent-auth token subcommands missing HTTP routes:", file=sys.stderr)
     for line in missing:
         print(line, file=sys.stderr)
     sys.exit(1)

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -384,3 +384,40 @@ if [[ ${contributing_missing} -ne 0 ]]; then
 fi
 
 echo "verify-standards: CONTRIBUTING.md exists with dev-setup, testing, release, and commit-signing sections."
+
+# Verify every `agent-auth token *` CLI subcommand has a corresponding HTTP
+# route registered in the server. This prevents adding a new CLI subcommand
+# without exposing it over HTTP (or vice versa).
+
+if [[ -f pyproject.toml ]] && command -v uv >/dev/null 2>&1; then
+  cli_http_check_output="$(
+    uv run python3 - <<'PY'
+import sys
+
+try:
+    from agent_auth.cli import COMMAND_HANDLERS
+    from agent_auth.server import AgentAuthHandler
+except ImportError as e:
+    print(f"verify-standards: could not import agent_auth modules: {e}", file=sys.stderr)
+    sys.exit(1)
+
+missing = []
+for cmd in sorted(COMMAND_HANDLERS):
+    method = f"_handle_token_{cmd}"
+    if not hasattr(AgentAuthHandler, method):
+        missing.append(f"  token {cmd!r} has no handler method {method!r} on AgentAuthHandler")
+
+if missing:
+    print("verify-standards: agent-auth token subcommands missing HTTP handler methods:", file=sys.stderr)
+    for line in missing:
+        print(line, file=sys.stderr)
+    sys.exit(1)
+PY
+  )"
+  cli_http_exit=$?
+  if [[ ${cli_http_exit} -ne 0 ]]; then
+    [[ -n "${cli_http_check_output}" ]] && echo "${cli_http_check_output}" >&2
+    exit 1
+  fi
+  echo "verify-standards: every 'agent-auth token *' subcommand has a matching HTTP route."
+fi

--- a/scripts/verify-token-cli-http-parity.sh
+++ b/scripts/verify-token-cli-http-parity.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Verify every `agent-auth token *` CLI subcommand has a corresponding HTTP
+# route registered on AgentAuthHandler. Prevents adding a new CLI subcommand
+# without exposing it over HTTP (or vice versa).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+if [[ ! -f pyproject.toml ]]; then
+  echo "verify-token-cli-http-parity: pyproject.toml not found; run from repo root" >&2
+  exit 1
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "verify-token-cli-http-parity: 'uv' is required on PATH" >&2
+  exit 1
+fi
+
+uv run python3 - <<'PY'
+import inspect
+import sys
+
+try:
+    from agent_auth.cli import COMMAND_HANDLERS
+    from agent_auth.server import AgentAuthHandler
+except ImportError as e:
+    print(f"verify-token-cli-http-parity: could not import agent_auth modules: {e}", file=sys.stderr)
+    sys.exit(1)
+
+routing_source = (
+    inspect.getsource(AgentAuthHandler.do_POST)
+    + inspect.getsource(AgentAuthHandler.do_GET)
+)
+
+missing = []
+for cmd in sorted(COMMAND_HANDLERS):
+    method = f"_handle_token_{cmd}"
+    route = f"/agent-auth/token/{cmd}"
+    if not hasattr(AgentAuthHandler, method):
+        missing.append(f"  token {cmd!r}: no handler method {method!r}")
+    elif route not in routing_source:
+        missing.append(
+            f"  token {cmd!r}: method exists but route {route!r} is not wired in do_POST/do_GET"
+        )
+
+if missing:
+    print("verify-token-cli-http-parity: agent-auth token subcommands missing HTTP routes:", file=sys.stderr)
+    for line in missing:
+        print(line, file=sys.stderr)
+    sys.exit(1)
+
+print("verify-token-cli-http-parity: every 'agent-auth token *' subcommand has a matching HTTP route.")
+PY

--- a/src/agent_auth/cli.py
+++ b/src/agent_auth/cli.py
@@ -14,14 +14,14 @@ from agent_auth.tokens import create_token_pair, generate_token_id
 
 def _init_services(
     config_dir: str | None = None,
-) -> tuple[Config, SigningKey, TokenStore, AuditLogger]:
+) -> tuple[Config, SigningKey, TokenStore, AuditLogger, KeyManager]:
     config = load_config(config_dir)
     key_manager = KeyManager()
     signing_key = key_manager.get_or_create_signing_key()
     encryption_key = key_manager.get_or_create_encryption_key()
     store = TokenStore(config.db_path, encryption_key)
     audit = AuditLogger(config.log_path)
-    return config, signing_key, store, audit
+    return config, signing_key, store, audit, key_manager
 
 
 def handle_token_create(args, config, signing_key, store, audit):
@@ -182,11 +182,26 @@ def handle_token_rotate(args, config, signing_key, store, audit):
         print("WARNING: Tokens are displayed only once. Store them securely.")
 
 
-def handle_serve(args, config, signing_key, store, audit):
+def handle_serve(args, config, signing_key, store, audit, key_manager):
     """Start the agent-auth HTTP server."""
     from agent_auth.server import run_server
 
-    run_server(config, signing_key, store, audit)
+    run_server(config, signing_key, store, audit, key_manager)
+
+
+def handle_management_token_show(args, config, signing_key, store, audit, key_manager):
+    """Print the management refresh token from the keyring."""
+    refresh_token = key_manager.get_management_refresh_token()
+    if refresh_token is None:
+        print(
+            "Error: no management token found. Start the server at least once first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if args.json:
+        print(json.dumps({"refresh_token": refresh_token}))
+    else:
+        print(refresh_token)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -238,6 +253,13 @@ def build_parser() -> argparse.ArgumentParser:
     # the CLI has no override flags to keep exactly one source of truth.
     subparsers.add_parser("serve", help="Start the HTTP server")
 
+    # management-token subcommand
+    mgmt_parser = subparsers.add_parser(
+        "management-token", help="Manage the HTTP management credential"
+    )
+    mgmt_sub = mgmt_parser.add_subparsers(dest="management_token_command")
+    mgmt_sub.add_parser("show", help="Print the management refresh token")
+
     return parser
 
 
@@ -258,10 +280,10 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    config, signing_key, store, audit = _init_services(args.config_dir)
+    config, signing_key, store, audit, key_manager = _init_services(args.config_dir)
 
     if args.command == "serve":
-        handle_serve(args, config, signing_key, store, audit)
+        handle_serve(args, config, signing_key, store, audit, key_manager)
         return
 
     if args.command == "token":
@@ -276,6 +298,17 @@ def main():
             handler(args, config, signing_key, store, audit)
         else:
             print(f"Error: unknown token command '{args.token_command}'", file=sys.stderr)
+            sys.exit(1)
+        return
+
+    if args.command == "management-token":
+        if args.management_token_command == "show":
+            handle_management_token_show(args, config, signing_key, store, audit, key_manager)
+        else:
+            print(
+                "Error: specify a management-token subcommand (show)",
+                file=sys.stderr,
+            )
             sys.exit(1)
         return
 

--- a/src/agent_auth/cli.py
+++ b/src/agent_auth/cli.py
@@ -6,6 +6,7 @@ import sys
 
 from agent_auth.audit import AuditLogger
 from agent_auth.config import Config, load_config
+from agent_auth.errors import KeyringError
 from agent_auth.keys import KeyManager, SigningKey
 from agent_auth.scopes import parse_scope_arg
 from agent_auth.store import TokenStore
@@ -191,7 +192,11 @@ def handle_serve(args, config, signing_key, store, audit, key_manager):
 
 def handle_management_token_show(args, config, signing_key, store, audit, key_manager):
     """Print the management refresh token from the keyring."""
-    refresh_token = key_manager.get_management_refresh_token()
+    try:
+        refresh_token = key_manager.get_management_refresh_token()
+    except KeyringError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
     if refresh_token is None:
         print(
             "Error: no management token found. Start the server at least once first.",

--- a/src/agent_auth/keys.py
+++ b/src/agent_auth/keys.py
@@ -13,6 +13,7 @@ SERVICE_NAME = "agent-auth"
 # they are the names under which we store each key inside our service entry.
 SIGNING_KEY_NAME = "signing-key"
 ENCRYPTION_KEY_NAME = "encryption-key"
+MANAGEMENT_REFRESH_TOKEN_NAME = "management-refresh-token"
 KEY_SIZE_BYTES = 32
 
 # Distinguish the two 32-byte secrets at the type level so a signing key
@@ -54,3 +55,17 @@ class KeyManager:
     def get_or_create_encryption_key(self) -> EncryptionKey:
         """Return the AES-256-GCM encryption key, generating it on first use."""
         return EncryptionKey(self._get_or_create_key(ENCRYPTION_KEY_NAME))
+
+    def get_management_refresh_token(self) -> str | None:
+        """Return the stored management refresh token, or None if not yet bootstrapped."""
+        try:
+            return keyring.get_password(self._service, MANAGEMENT_REFRESH_TOKEN_NAME)
+        except Exception as e:
+            raise KeyringError(f"Failed to read management refresh token from keyring: {e}") from e
+
+    def set_management_refresh_token(self, token: str) -> None:
+        """Persist the management refresh token to the keyring."""
+        try:
+            keyring.set_password(self._service, MANAGEMENT_REFRESH_TOKEN_NAME, token)
+        except Exception as e:
+            raise KeyringError(f"Failed to store management refresh token in keyring: {e}") from e

--- a/src/agent_auth/server.py
+++ b/src/agent_auth/server.py
@@ -8,7 +8,7 @@ from agent_auth.approval import ApprovalManager
 from agent_auth.audit import AuditLogger
 from agent_auth.config import Config
 from agent_auth.errors import ScopeDeniedError, TokenInvalidError
-from agent_auth.keys import SigningKey
+from agent_auth.keys import KeyManager, SigningKey
 from agent_auth.plugins import load_plugin
 from agent_auth.scopes import VALID_TIERS, check_scope
 from agent_auth.store import TokenStore
@@ -19,6 +19,8 @@ from agent_auth.tokens import (
     generate_token_id,
     verify_token,
 )
+
+MANAGEMENT_SCOPE = "agent-auth:manage"
 
 
 class AgentAuthHandler(BaseHTTPRequestHandler):
@@ -312,6 +314,48 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             },
         )
 
+    def _require_management_auth(self) -> bool:
+        """Validate management bearer token. Sends 401/403 and returns False if invalid."""
+        auth_header = self.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            self._send_json(401, {"error": "missing_token"})
+            return False
+
+        token_raw = auth_header[7:]
+        store: TokenStore = self._server.store
+        signing_key: SigningKey = self._server.signing_key
+
+        try:
+            prefix, token_id = verify_token(token_raw, signing_key)
+        except TokenInvalidError:
+            self._send_json(401, {"error": "invalid_token"})
+            return False
+        if prefix != PREFIX_ACCESS:
+            self._send_json(401, {"error": "invalid_token"})
+            return False
+
+        token_record = store.get_token(token_id)
+        if token_record is None:
+            self._send_json(401, {"error": "invalid_token"})
+            return False
+
+        family = store.get_family(token_record["family_id"])
+        if family is None or family["revoked"]:
+            self._send_json(401, {"error": "invalid_token"})
+            return False
+
+        now = datetime.now(UTC)
+        expires_at = datetime.fromisoformat(token_record["expires_at"])
+        if now >= expires_at:
+            self._send_json(401, {"error": "token_expired"})
+            return False
+
+        if family["scopes"].get(MANAGEMENT_SCOPE) != "allow":
+            self._send_json(403, {"error": "scope_denied"})
+            return False
+
+        return True
+
     def _get_active_family(self, store: TokenStore, family_id: str) -> dict | None:
         """Return family if it exists and is not revoked; send 404/409 and return None otherwise."""
         family = store.get_family(family_id)
@@ -324,6 +368,8 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         return family
 
     def _handle_token_create(self):
+        if not self._require_management_auth():
+            return
         data = self._read_json()
         if data is None:
             self._send_json(400, {"error": "malformed_request"})
@@ -359,10 +405,15 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         )
 
     def _handle_token_list(self):
+        if not self._require_management_auth():
+            return
         store: TokenStore = self._server.store
-        self._send_json(200, store.list_families())
+        families = [f for f in store.list_families() if MANAGEMENT_SCOPE not in f.get("scopes", {})]
+        self._send_json(200, families)
 
     def _handle_token_modify(self):
+        if not self._require_management_auth():
+            return
         data = self._read_json()
         if data is None:
             self._send_json(400, {"error": "malformed_request"})
@@ -413,6 +464,8 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         self._send_json(200, {"family_id": family_id, "scopes": scopes})
 
     def _handle_token_revoke(self):
+        if not self._require_management_auth():
+            return
         data = self._read_json()
         if data is None:
             self._send_json(400, {"error": "malformed_request"})
@@ -436,6 +489,8 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         self._send_json(200, {"family_id": family_id, "revoked": True})
 
     def _handle_token_rotate(self):
+        if not self._require_management_auth():
+            return
         data = self._read_json()
         if data is None:
             self._send_json(400, {"error": "malformed_request"})
@@ -592,8 +647,40 @@ class AgentAuthServer(ThreadingHTTPServer):
         super().__init__((config.host, config.port), AgentAuthHandler)
 
 
-def run_server(config: Config, signing_key: SigningKey, store: TokenStore, audit: AuditLogger):
+def _bootstrap_management_token(
+    store: TokenStore,
+    signing_key: SigningKey,
+    config: Config,
+    key_manager: KeyManager,
+) -> None:
+    """Create the management token family on first startup if one does not already exist."""
+    existing_refresh = key_manager.get_management_refresh_token()
+    if existing_refresh is not None:
+        try:
+            _prefix, token_id = verify_token(existing_refresh, signing_key)
+            token_record = store.get_token(token_id)
+            if token_record is not None:
+                family = store.get_family(token_record["family_id"])
+                if family is not None and not family["revoked"]:
+                    return
+        except Exception:
+            pass
+
+    family_id = generate_token_id()
+    store.create_family(family_id, {MANAGEMENT_SCOPE: "allow"})
+    _access_token, refresh_token = create_token_pair(signing_key, store, family_id, config)
+    key_manager.set_management_refresh_token(refresh_token)
+
+
+def run_server(
+    config: Config,
+    signing_key: SigningKey,
+    store: TokenStore,
+    audit: AuditLogger,
+    key_manager: KeyManager,
+) -> None:
     """Start the agent-auth HTTP server."""
+    _bootstrap_management_token(store, signing_key, config, key_manager)
     plugin = load_plugin(config.notification_plugin, config.notification_plugin_config)
     approval_manager = ApprovalManager(plugin, store, audit)
     server = AgentAuthServer(config, signing_key, store, audit, approval_manager)

--- a/src/agent_auth/server.py
+++ b/src/agent_auth/server.py
@@ -367,16 +367,26 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         if data is None:
             self._send_json(400, {"error": "malformed_request"})
             return
-        family_id = data.get("family_id", "")
+        family_id = data.get("family_id")
+        if not isinstance(family_id, str) or not family_id:
+            self._send_json(400, {"error": "malformed_request"})
+            return
         add_scopes = data.get("add_scopes") or {}
         remove_scopes = data.get("remove_scopes") or []
         set_tiers = data.get("set_tiers") or {}
+        if (
+            not isinstance(add_scopes, dict)
+            or not isinstance(set_tiers, dict)
+            or not isinstance(remove_scopes, list)
+        ):
+            self._send_json(400, {"error": "malformed_request"})
+            return
 
         if not add_scopes and not remove_scopes and not set_tiers:
             self._send_json(400, {"error": "no_modifications"})
             return
-        merged = {**add_scopes, **set_tiers}
-        invalid_tiers = {k: v for k, v in merged.items() if v not in VALID_TIERS}
+        invalid_tiers = {k: v for k, v in add_scopes.items() if v not in VALID_TIERS}
+        invalid_tiers.update({k: v for k, v in set_tiers.items() if v not in VALID_TIERS})
         if invalid_tiers:
             self._send_json(400, {"error": "invalid_tier", "detail": invalid_tiers})
             return
@@ -407,7 +417,10 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         if data is None:
             self._send_json(400, {"error": "malformed_request"})
             return
-        family_id = data.get("family_id", "")
+        family_id = data.get("family_id")
+        if not isinstance(family_id, str) or not family_id:
+            self._send_json(400, {"error": "malformed_request"})
+            return
 
         store: TokenStore = self._server.store
         audit: AuditLogger = self._server.audit
@@ -427,7 +440,10 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         if data is None:
             self._send_json(400, {"error": "malformed_request"})
             return
-        old_family_id = data.get("family_id", "")
+        old_family_id = data.get("family_id")
+        if not isinstance(old_family_id, str) or not old_family_id:
+            self._send_json(400, {"error": "malformed_request"})
+            return
 
         store: TokenStore = self._server.store
         signing_key: SigningKey = self._server.signing_key
@@ -439,11 +455,10 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             return
 
         scopes = old_family["scopes"]
-        store.mark_family_revoked(old_family_id)
-
         new_family_id = generate_token_id()
         store.create_family(new_family_id, scopes)
         access_token, refresh_token = create_token_pair(signing_key, store, new_family_id, config)
+        store.mark_family_revoked(old_family_id)
 
         audit.log_token_operation(
             "token_rotated",

--- a/src/agent_auth/server.py
+++ b/src/agent_auth/server.py
@@ -658,13 +658,16 @@ def _bootstrap_management_token(
     if existing_refresh is not None:
         try:
             _prefix, token_id = verify_token(existing_refresh, signing_key)
+        except TokenInvalidError:
+            # Signing key was rotated (or the keyring entry is corrupt); fall
+            # through to regenerate. DB errors below intentionally propagate.
+            pass
+        else:
             token_record = store.get_token(token_id)
             if token_record is not None:
                 family = store.get_family(token_record["family_id"])
                 if family is not None and not family["revoked"]:
                     return
-        except Exception:
-            pass
 
     family_id = generate_token_id()
     store.create_family(family_id, {MANAGEMENT_SCOPE: "allow"})

--- a/src/agent_auth/server.py
+++ b/src/agent_auth/server.py
@@ -10,12 +10,13 @@ from agent_auth.config import Config
 from agent_auth.errors import ScopeDeniedError, TokenInvalidError
 from agent_auth.keys import SigningKey
 from agent_auth.plugins import load_plugin
-from agent_auth.scopes import check_scope
+from agent_auth.scopes import VALID_TIERS, check_scope
 from agent_auth.store import TokenStore
 from agent_auth.tokens import (
     PREFIX_ACCESS,
     PREFIX_REFRESH,
     create_token_pair,
+    generate_token_id,
     verify_token,
 )
 
@@ -59,6 +60,14 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             self._handle_refresh()
         elif self.path == "/agent-auth/token/reissue":
             self._handle_reissue()
+        elif self.path == "/agent-auth/token/create":
+            self._handle_token_create()
+        elif self.path == "/agent-auth/token/modify":
+            self._handle_token_modify()
+        elif self.path == "/agent-auth/token/revoke":
+            self._handle_token_revoke()
+        elif self.path == "/agent-auth/token/rotate":
+            self._handle_token_rotate()
         else:
             self._send_json(404, {"error": "not_found"})
 
@@ -67,6 +76,8 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             self._handle_status()
         elif self.path == "/agent-auth/health":
             self._handle_health()
+        elif self.path == "/agent-auth/token/list":
+            self._handle_token_list()
         else:
             self._send_json(404, {"error": "not_found"})
 
@@ -298,6 +309,158 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
                 "refresh_token": new_refresh_token,
                 "expires_in": config.access_token_ttl_seconds,
                 "scopes": family["scopes"],
+            },
+        )
+
+    def _get_active_family(self, store: TokenStore, family_id: str) -> dict | None:
+        """Return family if it exists and is not revoked; send 404/409 and return None otherwise."""
+        family = store.get_family(family_id)
+        if family is None:
+            self._send_json(404, {"error": "family_not_found"})
+            return None
+        if family["revoked"]:
+            self._send_json(409, {"error": "family_revoked"})
+            return None
+        return family
+
+    def _handle_token_create(self):
+        data = self._read_json()
+        if data is None:
+            self._send_json(400, {"error": "malformed_request"})
+            return
+        scopes = data.get("scopes")
+        if not isinstance(scopes, dict) or not scopes:
+            self._send_json(400, {"error": "no_scopes"})
+            return
+        invalid_tiers = {k: v for k, v in scopes.items() if v not in VALID_TIERS}
+        if invalid_tiers:
+            self._send_json(400, {"error": "invalid_tier", "detail": invalid_tiers})
+            return
+
+        store: TokenStore = self._server.store
+        signing_key: SigningKey = self._server.signing_key
+        config: Config = self._server.config
+        audit: AuditLogger = self._server.audit
+
+        family_id = generate_token_id()
+        store.create_family(family_id, scopes)
+        access_token, refresh_token = create_token_pair(signing_key, store, family_id, config)
+        audit.log_token_operation("token_created", family_id=family_id, scopes=scopes)
+
+        self._send_json(
+            200,
+            {
+                "family_id": family_id,
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "scopes": scopes,
+                "expires_in": config.access_token_ttl_seconds,
+            },
+        )
+
+    def _handle_token_list(self):
+        store: TokenStore = self._server.store
+        self._send_json(200, store.list_families())
+
+    def _handle_token_modify(self):
+        data = self._read_json()
+        if data is None:
+            self._send_json(400, {"error": "malformed_request"})
+            return
+        family_id = data.get("family_id", "")
+        add_scopes = data.get("add_scopes") or {}
+        remove_scopes = data.get("remove_scopes") or []
+        set_tiers = data.get("set_tiers") or {}
+
+        if not add_scopes and not remove_scopes and not set_tiers:
+            self._send_json(400, {"error": "no_modifications"})
+            return
+        merged = {**add_scopes, **set_tiers}
+        invalid_tiers = {k: v for k, v in merged.items() if v not in VALID_TIERS}
+        if invalid_tiers:
+            self._send_json(400, {"error": "invalid_tier", "detail": invalid_tiers})
+            return
+
+        store: TokenStore = self._server.store
+        audit: AuditLogger = self._server.audit
+
+        family = self._get_active_family(store, family_id)
+        if family is None:
+            return
+
+        scopes = dict(family["scopes"])
+        for name, tier in add_scopes.items():
+            scopes[name] = tier
+        for name in remove_scopes:
+            scopes.pop(name, None)
+        for name, tier in set_tiers.items():
+            if name in scopes:
+                scopes[name] = tier
+
+        store.update_family_scopes(family_id, scopes)
+        audit.log_token_operation("scopes_modified", family_id=family_id, scopes=scopes)
+
+        self._send_json(200, {"family_id": family_id, "scopes": scopes})
+
+    def _handle_token_revoke(self):
+        data = self._read_json()
+        if data is None:
+            self._send_json(400, {"error": "malformed_request"})
+            return
+        family_id = data.get("family_id", "")
+
+        store: TokenStore = self._server.store
+        audit: AuditLogger = self._server.audit
+
+        family = store.get_family(family_id)
+        if family is None:
+            self._send_json(404, {"error": "family_not_found"})
+            return
+
+        store.mark_family_revoked(family_id)
+        audit.log_token_operation("token_revoked", family_id=family_id)
+
+        self._send_json(200, {"family_id": family_id, "revoked": True})
+
+    def _handle_token_rotate(self):
+        data = self._read_json()
+        if data is None:
+            self._send_json(400, {"error": "malformed_request"})
+            return
+        old_family_id = data.get("family_id", "")
+
+        store: TokenStore = self._server.store
+        signing_key: SigningKey = self._server.signing_key
+        config: Config = self._server.config
+        audit: AuditLogger = self._server.audit
+
+        old_family = self._get_active_family(store, old_family_id)
+        if old_family is None:
+            return
+
+        scopes = old_family["scopes"]
+        store.mark_family_revoked(old_family_id)
+
+        new_family_id = generate_token_id()
+        store.create_family(new_family_id, scopes)
+        access_token, refresh_token = create_token_pair(signing_key, store, new_family_id, config)
+
+        audit.log_token_operation(
+            "token_rotated",
+            old_family_id=old_family_id,
+            new_family_id=new_family_id,
+            scopes=scopes,
+        )
+
+        self._send_json(
+            200,
+            {
+                "old_family_id": old_family_id,
+                "new_family_id": new_family_id,
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "scopes": scopes,
+                "expires_in": config.access_token_ttl_seconds,
             },
         )
 

--- a/tests/_http.py
+++ b/tests/_http.py
@@ -20,9 +20,11 @@ def post(
     url: str,
     data: dict | None = None,
     raw: bytes | None = None,
+    headers: dict | None = None,
 ) -> tuple[int, dict]:
     body = raw if raw is not None else json.dumps(data or {}).encode("utf-8")
-    req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"})
+    req_headers = {"Content-Type": "application/json", **(headers or {})}
+    req = urllib.request.Request(url, data=body, headers=req_headers)
     try:
         resp = urllib.request.urlopen(req)
         return resp.status, json.loads(resp.read())

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,12 +18,13 @@ import os
 import subprocess
 import uuid
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
 from testcontainers.compose import DockerCompose
 
+from tests._http import post
 from tests.integration._support import (
     DOCKER_DIR,
     build_test_image,
@@ -58,10 +59,19 @@ class AgentAuthContainer:
     base_url: str
     compose: DockerCompose
     service: str = "agent-auth"
+    _mgmt_token_cache: str | None = field(default=None, init=False, repr=False, compare=False)
 
     def url(self, path: str) -> str:
         """Return ``{base_url}/agent-auth/{path}``."""
         return f"{self.base_url}/agent-auth/{path.lstrip('/')}"
+
+    def management_token(self) -> str:
+        """Return a valid management access token, refreshed from keyring on first call."""
+        if self._mgmt_token_cache is None:
+            result = json.loads(self.exec_cli("--json", "management-token", "show"))
+            _, body = post(self.url("token/refresh"), {"refresh_token": result["refresh_token"]})
+            self._mgmt_token_cache = body["access_token"]
+        return self._mgmt_token_cache
 
     def exec_cli(self, *args: str) -> str:
         """Run ``agent-auth <args>`` inside the container and return stdout.

--- a/tests/integration/test_token_management.py
+++ b/tests/integration/test_token_management.py
@@ -88,6 +88,33 @@ def test_token_modify_add_scope_is_reflected_in_validation(agent_auth_container)
     assert body["valid"] is True
 
 
+@pytest.mark.covers_function("Serve Token Modify Endpoint")
+def test_token_modify_returns_404_for_unknown_family(agent_auth_container):
+    status, body = post(
+        agent_auth_container.url("token/modify"),
+        {"family_id": "no-such-family", "add_scopes": {"x": "allow"}},
+    )
+    assert status == 404
+    assert body["error"] == "family_not_found"
+
+
+@pytest.mark.covers_function("Serve Token Modify Endpoint")
+def test_token_modify_returns_409_for_revoked_family(agent_auth_container):
+    _, create_body = post(
+        agent_auth_container.url("token/create"),
+        {"scopes": {"things:read": "allow"}},
+    )
+    family_id = create_body["family_id"]
+    post(agent_auth_container.url("token/revoke"), {"family_id": family_id})
+
+    status, body = post(
+        agent_auth_container.url("token/modify"),
+        {"family_id": family_id, "add_scopes": {"things:write": "allow"}},
+    )
+    assert status == 409
+    assert body["error"] == "family_revoked"
+
+
 @pytest.mark.covers_function("Serve Token Revoke Endpoint")
 def test_token_revoke_makes_access_token_invalid(agent_auth_container):
     _, create_body = post(

--- a/tests/integration/test_token_management.py
+++ b/tests/integration/test_token_management.py
@@ -1,4 +1,4 @@
-"""Integration tests for the token management HTTP endpoints (create, list, modify, revoke, rotate)."""
+"""Integration tests for the token management HTTP endpoints."""
 
 import pytest
 

--- a/tests/integration/test_token_management.py
+++ b/tests/integration/test_token_management.py
@@ -1,0 +1,172 @@
+"""Integration tests for the token management HTTP endpoints (create, list, modify, revoke, rotate)."""
+
+import pytest
+
+from tests._http import get, post
+
+
+@pytest.mark.covers_function("Serve Token Create Endpoint")
+def test_token_create_returns_valid_token_pair(agent_auth_container):
+    status, body = post(
+        agent_auth_container.url("token/create"),
+        {"scopes": {"things:read": "allow"}},
+    )
+    assert status == 200
+    assert body["family_id"]
+    assert body["access_token"].startswith("aa_")
+    assert body["refresh_token"].startswith("rt_")
+    assert body["scopes"] == {"things:read": "allow"}
+
+
+@pytest.mark.covers_function("Serve Token Create Endpoint")
+def test_token_create_token_is_immediately_usable_for_validation(agent_auth_container):
+    _, create_body = post(
+        agent_auth_container.url("token/create"),
+        {"scopes": {"things:read": "allow"}},
+    )
+    status, body = post(
+        agent_auth_container.url("validate"),
+        {"token": create_body["access_token"], "required_scope": "things:read"},
+    )
+    assert status == 200
+    assert body["valid"] is True
+
+
+@pytest.mark.covers_function("Serve Token Create Endpoint")
+def test_token_create_rejects_empty_scopes(agent_auth_container):
+    status, body = post(agent_auth_container.url("token/create"), {"scopes": {}})
+    assert status == 400
+    assert body["error"] == "no_scopes"
+
+
+@pytest.mark.covers_function("Serve Token List Endpoint")
+def test_token_list_includes_family_created_via_http(agent_auth_container):
+    _, create_body = post(
+        agent_auth_container.url("token/create"),
+        {"scopes": {"things:read": "allow"}},
+    )
+    family_id = create_body["family_id"]
+
+    status, body = get(agent_auth_container.url("token/list"))
+    assert status == 200
+    assert any(f["id"] == family_id for f in body)
+
+
+@pytest.mark.covers_function("Serve Token List Endpoint")
+def test_token_list_includes_family_created_via_cli(agent_auth_container):
+    cli_result = agent_auth_container.create_token("things:write=allow")
+    family_id = cli_result["family_id"]
+
+    status, body = get(agent_auth_container.url("token/list"))
+    assert status == 200
+    assert any(f["id"] == family_id for f in body)
+
+
+@pytest.mark.covers_function("Serve Token Modify Endpoint")
+def test_token_modify_add_scope_is_reflected_in_validation(agent_auth_container):
+    _, create_body = post(
+        agent_auth_container.url("token/create"),
+        {"scopes": {"things:read": "allow"}},
+    )
+    family_id = create_body["family_id"]
+
+    post(
+        agent_auth_container.url("token/modify"),
+        {"family_id": family_id, "add_scopes": {"things:write": "allow"}},
+    )
+
+    # Refresh to get new access token reflecting updated scopes
+    _, refresh_body = post(
+        agent_auth_container.url("token/refresh"),
+        {"refresh_token": create_body["refresh_token"]},
+    )
+    status, body = post(
+        agent_auth_container.url("validate"),
+        {"token": refresh_body["access_token"], "required_scope": "things:write"},
+    )
+    assert status == 200
+    assert body["valid"] is True
+
+
+@pytest.mark.covers_function("Serve Token Revoke Endpoint")
+def test_token_revoke_makes_access_token_invalid(agent_auth_container):
+    _, create_body = post(
+        agent_auth_container.url("token/create"),
+        {"scopes": {"things:read": "allow"}},
+    )
+    family_id = create_body["family_id"]
+    access_token = create_body["access_token"]
+
+    status, body = post(agent_auth_container.url("token/revoke"), {"family_id": family_id})
+    assert status == 200
+    assert body["revoked"] is True
+
+    status, body = post(
+        agent_auth_container.url("validate"),
+        {"token": access_token, "required_scope": "things:read"},
+    )
+    assert status == 401
+    assert body["valid"] is False
+
+
+@pytest.mark.covers_function("Serve Token Revoke Endpoint")
+def test_token_revoke_returns_404_for_unknown_family(agent_auth_container):
+    status, body = post(agent_auth_container.url("token/revoke"), {"family_id": "no-such"})
+    assert status == 404
+    assert body["error"] == "family_not_found"
+
+
+@pytest.mark.covers_function("Serve Token Rotate Endpoint")
+def test_token_rotate_old_token_is_invalid_new_token_is_valid(agent_auth_container):
+    _, create_body = post(
+        agent_auth_container.url("token/create"),
+        {"scopes": {"things:read": "allow"}},
+    )
+    old_access_token = create_body["access_token"]
+
+    _, rotate_body = post(
+        agent_auth_container.url("token/rotate"),
+        {"family_id": create_body["family_id"]},
+    )
+    new_access_token = rotate_body["access_token"]
+
+    old_status, old_body = post(
+        agent_auth_container.url("validate"),
+        {"token": old_access_token, "required_scope": "things:read"},
+    )
+    assert old_status == 401
+    assert old_body["valid"] is False
+
+    new_status, new_body = post(
+        agent_auth_container.url("validate"),
+        {"token": new_access_token, "required_scope": "things:read"},
+    )
+    assert new_status == 200
+    assert new_body["valid"] is True
+
+
+@pytest.mark.covers_function("Serve Token Rotate Endpoint")
+def test_token_rotate_preserves_scopes(agent_auth_container):
+    _, create_body = post(
+        agent_auth_container.url("token/create"),
+        {"scopes": {"things:read": "allow", "things:write": "prompt"}},
+    )
+    _, rotate_body = post(
+        agent_auth_container.url("token/rotate"),
+        {"family_id": create_body["family_id"]},
+    )
+    assert rotate_body["scopes"] == {"things:read": "allow", "things:write": "prompt"}
+
+
+@pytest.mark.covers_function("Serve Token Rotate Endpoint")
+def test_token_rotate_returns_409_for_revoked_family(agent_auth_container):
+    _, create_body = post(
+        agent_auth_container.url("token/create"),
+        {"scopes": {"things:read": "allow"}},
+    )
+    family_id = create_body["family_id"]
+    post(agent_auth_container.url("token/revoke"), {"family_id": family_id})
+
+    status, body = post(agent_auth_container.url("token/rotate"), {"family_id": family_id})
+    assert status == 409
+    assert body["error"] == "family_revoked"

--- a/tests/integration/test_token_management.py
+++ b/tests/integration/test_token_management.py
@@ -6,10 +6,22 @@ from tests._http import get, post
 
 
 @pytest.mark.covers_function("Serve Token Create Endpoint")
-def test_token_create_returns_valid_token_pair(agent_auth_container):
+def test_token_create_requires_management_auth(agent_auth_container):
     status, body = post(
         agent_auth_container.url("token/create"),
         {"scopes": {"things:read": "allow"}},
+    )
+    assert status == 401
+    assert body["error"] == "missing_token"
+
+
+@pytest.mark.covers_function("Serve Token Create Endpoint")
+def test_token_create_returns_valid_token_pair(agent_auth_container):
+    auth = {"Authorization": f"Bearer {agent_auth_container.management_token()}"}
+    status, body = post(
+        agent_auth_container.url("token/create"),
+        {"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     assert status == 200
     assert body["family_id"]
@@ -20,9 +32,11 @@ def test_token_create_returns_valid_token_pair(agent_auth_container):
 
 @pytest.mark.covers_function("Serve Token Create Endpoint")
 def test_token_create_token_is_immediately_usable_for_validation(agent_auth_container):
+    auth = {"Authorization": f"Bearer {agent_auth_container.management_token()}"}
     _, create_body = post(
         agent_auth_container.url("token/create"),
         {"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     status, body = post(
         agent_auth_container.url("validate"),
@@ -34,20 +48,30 @@ def test_token_create_token_is_immediately_usable_for_validation(agent_auth_cont
 
 @pytest.mark.covers_function("Serve Token Create Endpoint")
 def test_token_create_rejects_empty_scopes(agent_auth_container):
-    status, body = post(agent_auth_container.url("token/create"), {"scopes": {}})
+    auth = {"Authorization": f"Bearer {agent_auth_container.management_token()}"}
+    status, body = post(agent_auth_container.url("token/create"), {"scopes": {}}, headers=auth)
     assert status == 400
     assert body["error"] == "no_scopes"
 
 
 @pytest.mark.covers_function("Serve Token List Endpoint")
+def test_token_list_requires_management_auth(agent_auth_container):
+    status, body = get(agent_auth_container.url("token/list"))
+    assert status == 401
+    assert body["error"] == "missing_token"
+
+
+@pytest.mark.covers_function("Serve Token List Endpoint")
 def test_token_list_includes_family_created_via_http(agent_auth_container):
+    auth = {"Authorization": f"Bearer {agent_auth_container.management_token()}"}
     _, create_body = post(
         agent_auth_container.url("token/create"),
         {"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     family_id = create_body["family_id"]
 
-    status, body = get(agent_auth_container.url("token/list"))
+    status, body = get(agent_auth_container.url("token/list"), auth)
     assert status == 200
     assert any(f["id"] == family_id for f in body)
 
@@ -57,22 +81,26 @@ def test_token_list_includes_family_created_via_cli(agent_auth_container):
     cli_result = agent_auth_container.create_token("things:write=allow")
     family_id = cli_result["family_id"]
 
-    status, body = get(agent_auth_container.url("token/list"))
+    auth = {"Authorization": f"Bearer {agent_auth_container.management_token()}"}
+    status, body = get(agent_auth_container.url("token/list"), auth)
     assert status == 200
     assert any(f["id"] == family_id for f in body)
 
 
 @pytest.mark.covers_function("Serve Token Modify Endpoint")
 def test_token_modify_add_scope_is_reflected_in_validation(agent_auth_container):
+    auth = {"Authorization": f"Bearer {agent_auth_container.management_token()}"}
     _, create_body = post(
         agent_auth_container.url("token/create"),
         {"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     family_id = create_body["family_id"]
 
     post(
         agent_auth_container.url("token/modify"),
         {"family_id": family_id, "add_scopes": {"things:write": "allow"}},
+        headers=auth,
     )
 
     # Refresh to get new access token reflecting updated scopes
@@ -90,9 +118,11 @@ def test_token_modify_add_scope_is_reflected_in_validation(agent_auth_container)
 
 @pytest.mark.covers_function("Serve Token Modify Endpoint")
 def test_token_modify_returns_404_for_unknown_family(agent_auth_container):
+    auth = {"Authorization": f"Bearer {agent_auth_container.management_token()}"}
     status, body = post(
         agent_auth_container.url("token/modify"),
         {"family_id": "no-such-family", "add_scopes": {"x": "allow"}},
+        headers=auth,
     )
     assert status == 404
     assert body["error"] == "family_not_found"
@@ -100,16 +130,19 @@ def test_token_modify_returns_404_for_unknown_family(agent_auth_container):
 
 @pytest.mark.covers_function("Serve Token Modify Endpoint")
 def test_token_modify_returns_409_for_revoked_family(agent_auth_container):
+    auth = {"Authorization": f"Bearer {agent_auth_container.management_token()}"}
     _, create_body = post(
         agent_auth_container.url("token/create"),
         {"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     family_id = create_body["family_id"]
-    post(agent_auth_container.url("token/revoke"), {"family_id": family_id})
+    post(agent_auth_container.url("token/revoke"), {"family_id": family_id}, headers=auth)
 
     status, body = post(
         agent_auth_container.url("token/modify"),
         {"family_id": family_id, "add_scopes": {"things:write": "allow"}},
+        headers=auth,
     )
     assert status == 409
     assert body["error"] == "family_revoked"
@@ -117,14 +150,18 @@ def test_token_modify_returns_409_for_revoked_family(agent_auth_container):
 
 @pytest.mark.covers_function("Serve Token Revoke Endpoint")
 def test_token_revoke_makes_access_token_invalid(agent_auth_container):
+    auth = {"Authorization": f"Bearer {agent_auth_container.management_token()}"}
     _, create_body = post(
         agent_auth_container.url("token/create"),
         {"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     family_id = create_body["family_id"]
     access_token = create_body["access_token"]
 
-    status, body = post(agent_auth_container.url("token/revoke"), {"family_id": family_id})
+    status, body = post(
+        agent_auth_container.url("token/revoke"), {"family_id": family_id}, headers=auth
+    )
     assert status == 200
     assert body["revoked"] is True
 
@@ -138,22 +175,28 @@ def test_token_revoke_makes_access_token_invalid(agent_auth_container):
 
 @pytest.mark.covers_function("Serve Token Revoke Endpoint")
 def test_token_revoke_returns_404_for_unknown_family(agent_auth_container):
-    status, body = post(agent_auth_container.url("token/revoke"), {"family_id": "no-such"})
+    auth = {"Authorization": f"Bearer {agent_auth_container.management_token()}"}
+    status, body = post(
+        agent_auth_container.url("token/revoke"), {"family_id": "no-such"}, headers=auth
+    )
     assert status == 404
     assert body["error"] == "family_not_found"
 
 
 @pytest.mark.covers_function("Serve Token Rotate Endpoint")
 def test_token_rotate_old_token_is_invalid_new_token_is_valid(agent_auth_container):
+    auth = {"Authorization": f"Bearer {agent_auth_container.management_token()}"}
     _, create_body = post(
         agent_auth_container.url("token/create"),
         {"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     old_access_token = create_body["access_token"]
 
     _, rotate_body = post(
         agent_auth_container.url("token/rotate"),
         {"family_id": create_body["family_id"]},
+        headers=auth,
     )
     new_access_token = rotate_body["access_token"]
 
@@ -174,26 +217,33 @@ def test_token_rotate_old_token_is_invalid_new_token_is_valid(agent_auth_contain
 
 @pytest.mark.covers_function("Serve Token Rotate Endpoint")
 def test_token_rotate_preserves_scopes(agent_auth_container):
+    auth = {"Authorization": f"Bearer {agent_auth_container.management_token()}"}
     _, create_body = post(
         agent_auth_container.url("token/create"),
         {"scopes": {"things:read": "allow", "things:write": "prompt"}},
+        headers=auth,
     )
     _, rotate_body = post(
         agent_auth_container.url("token/rotate"),
         {"family_id": create_body["family_id"]},
+        headers=auth,
     )
     assert rotate_body["scopes"] == {"things:read": "allow", "things:write": "prompt"}
 
 
 @pytest.mark.covers_function("Serve Token Rotate Endpoint")
 def test_token_rotate_returns_409_for_revoked_family(agent_auth_container):
+    auth = {"Authorization": f"Bearer {agent_auth_container.management_token()}"}
     _, create_body = post(
         agent_auth_container.url("token/create"),
         {"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     family_id = create_body["family_id"]
-    post(agent_auth_container.url("token/revoke"), {"family_id": family_id})
+    post(agent_auth_container.url("token/revoke"), {"family_id": family_id}, headers=auth)
 
-    status, body = post(agent_auth_container.url("token/rotate"), {"family_id": family_id})
+    status, body = post(
+        agent_auth_container.url("token/rotate"), {"family_id": family_id}, headers=auth
+    )
     assert status == 409
     assert body["error"] == "family_revoked"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 import pytest
 
 from agent_auth.cli import main
+from agent_auth.errors import KeyringError
 
 
 @pytest.fixture
@@ -125,6 +126,18 @@ def test_token_rotate(cli_env):
     assert families[old_family_id]["revoked"] is True
     assert families[data["new_family_id"]]["revoked"] is False
     assert families[data["new_family_id"]]["scopes"] == {"a:read": "allow"}
+
+
+@pytest.mark.covers_function("Handle Management Token Show Command")
+def test_management_token_show_keyring_error(cli_env):
+    """A keyring backend failure surfaces as a clean error, not a traceback."""
+    with patch(
+        "agent_auth.keys.KeyManager.get_management_refresh_token",
+        side_effect=KeyringError("keyring backend unavailable"),
+    ):
+        out, err = _run_cli("management-token", "show", config_dir=cli_env)
+    assert out == ""
+    assert "keyring backend unavailable" in err
 
 
 @pytest.mark.covers_function("Handle Token Modify Command", "Modify Token Family Scopes")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -317,6 +317,36 @@ def test_token_modify_set_tiers_silently_skips_unknown_scope(in_process_server):
     assert body["scopes"] == {"things:read": "allow"}
 
 
+@pytest.mark.covers_function("Serve Token Modify Endpoint")
+def test_token_modify_rejects_malformed_json(in_process_server):
+    _, base, _ = in_process_server
+    status, body = post(f"{base}/agent-auth/token/modify", raw=b"{bad")
+    assert status == 400
+    assert body["error"] == "malformed_request"
+
+
+@pytest.mark.covers_function("Serve Token Modify Endpoint")
+def test_token_modify_rejects_missing_family_id(in_process_server):
+    _, base, _ = in_process_server
+    status, body = post(f"{base}/agent-auth/token/modify", data={"add_scopes": {"x": "allow"}})
+    assert status == 400
+    assert body["error"] == "malformed_request"
+
+
+@pytest.mark.covers_function("Serve Token Modify Endpoint")
+def test_token_modify_rejects_wrong_type_for_add_scopes(in_process_server):
+    _, base, _ = in_process_server
+    _, create_body = post(
+        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+    )
+    status, body = post(
+        f"{base}/agent-auth/token/modify",
+        data={"family_id": create_body["family_id"], "add_scopes": "not-a-dict"},
+    )
+    assert status == 400
+    assert body["error"] == "malformed_request"
+
+
 # --- token revoke ---
 
 
@@ -361,6 +391,22 @@ def test_token_revoke_returns_404_for_unknown_family(in_process_server):
     status, body = post(f"{base}/agent-auth/token/revoke", data={"family_id": "no-such"})
     assert status == 404
     assert body["error"] == "family_not_found"
+
+
+@pytest.mark.covers_function("Serve Token Revoke Endpoint")
+def test_token_revoke_rejects_malformed_json(in_process_server):
+    _, base, _ = in_process_server
+    status, body = post(f"{base}/agent-auth/token/revoke", raw=b"{bad")
+    assert status == 400
+    assert body["error"] == "malformed_request"
+
+
+@pytest.mark.covers_function("Serve Token Revoke Endpoint")
+def test_token_revoke_rejects_missing_family_id(in_process_server):
+    _, base, _ = in_process_server
+    status, body = post(f"{base}/agent-auth/token/revoke", data={})
+    assert status == 400
+    assert body["error"] == "malformed_request"
 
 
 # --- token rotate ---
@@ -418,3 +464,19 @@ def test_token_rotate_returns_409_for_revoked_family(in_process_server):
     status, body = post(f"{base}/agent-auth/token/rotate", data={"family_id": family_id})
     assert status == 409
     assert body["error"] == "family_revoked"
+
+
+@pytest.mark.covers_function("Serve Token Rotate Endpoint")
+def test_token_rotate_rejects_malformed_json(in_process_server):
+    _, base, _ = in_process_server
+    status, body = post(f"{base}/agent-auth/token/rotate", raw=b"{bad")
+    assert status == 400
+    assert body["error"] == "malformed_request"
+
+
+@pytest.mark.covers_function("Serve Token Rotate Endpoint")
+def test_token_rotate_rejects_missing_family_id(in_process_server):
+    _, base, _ = in_process_server
+    status, body = post(f"{base}/agent-auth/token/rotate", data={})
+    assert status == 400
+    assert body["error"] == "malformed_request"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,7 +9,7 @@ from agent_auth.approval import ApprovalManager
 from agent_auth.audit import AuditLogger
 from agent_auth.config import Config
 from agent_auth.plugins import ApprovalResult, NotificationPlugin
-from agent_auth.server import AgentAuthHandler, AgentAuthServer
+from agent_auth.server import MANAGEMENT_SCOPE, AgentAuthHandler, AgentAuthServer
 from agent_auth.store import TokenStore
 from agent_auth.tokens import create_token_pair
 from tests._http import get, post
@@ -121,15 +121,34 @@ def test_oversize_body_returns_400(in_process_server):
     assert body["error"] == "malformed_request"
 
 
+@pytest.fixture
+def management_session(in_process_server):
+    server, base, store = in_process_server
+    family_id = "fam-mgmt-test"
+    store.create_family(family_id, {MANAGEMENT_SCOPE: "allow"})
+    access_token, _ = create_token_pair(server.signing_key, store, family_id, server.config)
+    return base, store, access_token
+
+
 # --- token create ---
 
 
 @pytest.mark.covers_function("Serve Token Create Endpoint")
-def test_token_create_returns_tokens_and_family(in_process_server):
+def test_token_create_requires_management_auth(in_process_server):
     _, base, _ = in_process_server
+    status, body = post(f"{base}/agent-auth/token/create", data={"scopes": {"x": "allow"}})
+    assert status == 401
+    assert body["error"] == "missing_token"
+
+
+@pytest.mark.covers_function("Serve Token Create Endpoint")
+def test_token_create_returns_tokens_and_family(management_session):
+    base, _, mgmt_token = management_session
+    auth = {"Authorization": f"Bearer {mgmt_token}"}
     status, body = post(
         f"{base}/agent-auth/token/create",
         data={"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     assert status == 200
     assert body["family_id"]
@@ -140,35 +159,48 @@ def test_token_create_returns_tokens_and_family(in_process_server):
 
 
 @pytest.mark.covers_function("Serve Token Create Endpoint")
-def test_token_create_rejects_empty_scopes(in_process_server):
-    _, base, _ = in_process_server
-    status, body = post(f"{base}/agent-auth/token/create", data={"scopes": {}})
+def test_token_create_rejects_empty_scopes(management_session):
+    base, _, mgmt_token = management_session
+    status, body = post(
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {}},
+        headers={"Authorization": f"Bearer {mgmt_token}"},
+    )
     assert status == 400
     assert body["error"] == "no_scopes"
 
 
 @pytest.mark.covers_function("Serve Token Create Endpoint")
-def test_token_create_rejects_missing_scopes_field(in_process_server):
-    _, base, _ = in_process_server
-    status, body = post(f"{base}/agent-auth/token/create", data={})
+def test_token_create_rejects_missing_scopes_field(management_session):
+    base, _, mgmt_token = management_session
+    status, body = post(
+        f"{base}/agent-auth/token/create",
+        data={},
+        headers={"Authorization": f"Bearer {mgmt_token}"},
+    )
     assert status == 400
     assert body["error"] == "no_scopes"
 
 
 @pytest.mark.covers_function("Serve Token Create Endpoint")
-def test_token_create_rejects_malformed_json(in_process_server):
-    _, base, _ = in_process_server
-    status, body = post(f"{base}/agent-auth/token/create", raw=b"{bad")
+def test_token_create_rejects_malformed_json(management_session):
+    base, _, mgmt_token = management_session
+    status, body = post(
+        f"{base}/agent-auth/token/create",
+        raw=b"{bad",
+        headers={"Authorization": f"Bearer {mgmt_token}"},
+    )
     assert status == 400
     assert body["error"] == "malformed_request"
 
 
 @pytest.mark.covers_function("Serve Token Create Endpoint")
-def test_token_create_rejects_invalid_tier(in_process_server):
-    _, base, _ = in_process_server
+def test_token_create_rejects_invalid_tier(management_session):
+    base, _, mgmt_token = management_session
     status, body = post(
         f"{base}/agent-auth/token/create",
         data={"scopes": {"things:read": "banana"}},
+        headers={"Authorization": f"Bearer {mgmt_token}"},
     )
     assert status == 400
     assert body["error"] == "invalid_tier"
@@ -178,170 +210,241 @@ def test_token_create_rejects_invalid_tier(in_process_server):
 
 
 @pytest.mark.covers_function("Serve Token List Endpoint")
-def test_token_list_returns_empty_array_when_no_families(in_process_server):
+def test_token_list_requires_management_auth(in_process_server):
     _, base, _ = in_process_server
     status, body = get(f"{base}/agent-auth/token/list")
+    assert status == 401
+    assert body["error"] == "missing_token"
+
+
+@pytest.mark.covers_function("Serve Token List Endpoint")
+def test_token_list_returns_empty_array_when_no_families(management_session):
+    base, _, mgmt_token = management_session
+    status, body = get(f"{base}/agent-auth/token/list", {"Authorization": f"Bearer {mgmt_token}"})
     assert status == 200
     assert body == []
 
 
 @pytest.mark.covers_function("Serve Token List Endpoint")
-def test_token_list_returns_created_family(in_process_server):
-    _, base, store = in_process_server
-    post(f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}})
-    status, body = get(f"{base}/agent-auth/token/list")
+def test_token_list_returns_created_family(management_session):
+    base, _, mgmt_token = management_session
+    auth = {"Authorization": f"Bearer {mgmt_token}"}
+    post(
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {"things:read": "allow"}},
+        headers=auth,
+    )
+    status, body = get(f"{base}/agent-auth/token/list", auth)
     assert status == 200
     assert len(body) == 1
     assert body[0]["scopes"] == {"things:read": "allow"}
 
 
 @pytest.mark.covers_function("Serve Token List Endpoint")
-def test_token_list_includes_revoked_families(in_process_server):
-    _, base, _ = in_process_server
+def test_token_list_includes_revoked_families(management_session):
+    base, _, mgmt_token = management_session
+    auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     family_id = create_body["family_id"]
-    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id})
+    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id}, headers=auth)
 
-    status, body = get(f"{base}/agent-auth/token/list")
+    status, body = get(f"{base}/agent-auth/token/list", auth)
     assert status == 200
     assert any(f["id"] == family_id and f["revoked"] for f in body)
+
+
+@pytest.mark.covers_function("Serve Token List Endpoint")
+def test_token_list_excludes_management_token_family(management_session):
+    base, _, mgmt_token = management_session
+    status, body = get(f"{base}/agent-auth/token/list", {"Authorization": f"Bearer {mgmt_token}"})
+    assert status == 200
+    assert not any(MANAGEMENT_SCOPE in f.get("scopes", {}) for f in body)
 
 
 # --- token modify ---
 
 
 @pytest.mark.covers_function("Serve Token Modify Endpoint")
-def test_token_modify_adds_scope(in_process_server):
+def test_token_modify_requires_management_auth(in_process_server):
     _, base, _ = in_process_server
+    status, body = post(
+        f"{base}/agent-auth/token/modify",
+        data={"family_id": "x", "add_scopes": {"y": "allow"}},
+    )
+    assert status == 401
+    assert body["error"] == "missing_token"
+
+
+@pytest.mark.covers_function("Serve Token Modify Endpoint")
+def test_token_modify_adds_scope(management_session):
+    base, _, mgmt_token = management_session
+    auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     family_id = create_body["family_id"]
 
     status, body = post(
         f"{base}/agent-auth/token/modify",
         data={"family_id": family_id, "add_scopes": {"things:write": "prompt"}},
+        headers=auth,
     )
     assert status == 200
     assert body["scopes"] == {"things:read": "allow", "things:write": "prompt"}
 
 
 @pytest.mark.covers_function("Serve Token Modify Endpoint")
-def test_token_modify_removes_scope(in_process_server):
-    _, base, _ = in_process_server
+def test_token_modify_removes_scope(management_session):
+    base, _, mgmt_token = management_session
+    auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
         f"{base}/agent-auth/token/create",
         data={"scopes": {"things:read": "allow", "things:write": "prompt"}},
+        headers=auth,
     )
     family_id = create_body["family_id"]
 
     status, body = post(
         f"{base}/agent-auth/token/modify",
         data={"family_id": family_id, "remove_scopes": ["things:write"]},
+        headers=auth,
     )
     assert status == 200
     assert body["scopes"] == {"things:read": "allow"}
 
 
 @pytest.mark.covers_function("Serve Token Modify Endpoint")
-def test_token_modify_returns_404_for_unknown_family(in_process_server):
-    _, base, _ = in_process_server
+def test_token_modify_returns_404_for_unknown_family(management_session):
+    base, _, mgmt_token = management_session
     status, body = post(
         f"{base}/agent-auth/token/modify",
         data={"family_id": "no-such-family", "add_scopes": {"x": "allow"}},
+        headers={"Authorization": f"Bearer {mgmt_token}"},
     )
     assert status == 404
     assert body["error"] == "family_not_found"
 
 
 @pytest.mark.covers_function("Serve Token Modify Endpoint")
-def test_token_modify_returns_409_for_revoked_family(in_process_server):
-    _, base, _ = in_process_server
+def test_token_modify_returns_409_for_revoked_family(management_session):
+    base, _, mgmt_token = management_session
+    auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     family_id = create_body["family_id"]
-    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id})
+    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id}, headers=auth)
 
     status, body = post(
         f"{base}/agent-auth/token/modify",
         data={"family_id": family_id, "add_scopes": {"x": "allow"}},
+        headers=auth,
     )
     assert status == 409
     assert body["error"] == "family_revoked"
 
 
 @pytest.mark.covers_function("Serve Token Modify Endpoint")
-def test_token_modify_returns_400_when_no_modifications_provided(in_process_server):
-    _, base, _ = in_process_server
+def test_token_modify_returns_400_when_no_modifications_provided(management_session):
+    base, _, mgmt_token = management_session
+    auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     status, body = post(
         f"{base}/agent-auth/token/modify",
         data={"family_id": create_body["family_id"]},
+        headers=auth,
     )
     assert status == 400
     assert body["error"] == "no_modifications"
 
 
 @pytest.mark.covers_function("Serve Token Modify Endpoint")
-def test_token_modify_rejects_invalid_tier_in_add_scopes(in_process_server):
-    _, base, _ = in_process_server
+def test_token_modify_rejects_invalid_tier_in_add_scopes(management_session):
+    base, _, mgmt_token = management_session
+    auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     status, body = post(
         f"{base}/agent-auth/token/modify",
         data={"family_id": create_body["family_id"], "add_scopes": {"things:write": "banana"}},
+        headers=auth,
     )
     assert status == 400
     assert body["error"] == "invalid_tier"
 
 
 @pytest.mark.covers_function("Serve Token Modify Endpoint")
-def test_token_modify_set_tiers_silently_skips_unknown_scope(in_process_server):
-    _, base, _ = in_process_server
+def test_token_modify_set_tiers_silently_skips_unknown_scope(management_session):
+    base, _, mgmt_token = management_session
+    auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     family_id = create_body["family_id"]
 
     status, body = post(
         f"{base}/agent-auth/token/modify",
         data={"family_id": family_id, "set_tiers": {"no-such-scope": "prompt"}},
+        headers=auth,
     )
     assert status == 200
     assert body["scopes"] == {"things:read": "allow"}
 
 
 @pytest.mark.covers_function("Serve Token Modify Endpoint")
-def test_token_modify_rejects_malformed_json(in_process_server):
-    _, base, _ = in_process_server
-    status, body = post(f"{base}/agent-auth/token/modify", raw=b"{bad")
+def test_token_modify_rejects_malformed_json(management_session):
+    base, _, mgmt_token = management_session
+    status, body = post(
+        f"{base}/agent-auth/token/modify",
+        raw=b"{bad",
+        headers={"Authorization": f"Bearer {mgmt_token}"},
+    )
     assert status == 400
     assert body["error"] == "malformed_request"
 
 
 @pytest.mark.covers_function("Serve Token Modify Endpoint")
-def test_token_modify_rejects_missing_family_id(in_process_server):
-    _, base, _ = in_process_server
-    status, body = post(f"{base}/agent-auth/token/modify", data={"add_scopes": {"x": "allow"}})
+def test_token_modify_rejects_missing_family_id(management_session):
+    base, _, mgmt_token = management_session
+    status, body = post(
+        f"{base}/agent-auth/token/modify",
+        data={"add_scopes": {"x": "allow"}},
+        headers={"Authorization": f"Bearer {mgmt_token}"},
+    )
     assert status == 400
     assert body["error"] == "malformed_request"
 
 
 @pytest.mark.covers_function("Serve Token Modify Endpoint")
-def test_token_modify_rejects_wrong_type_for_add_scopes(in_process_server):
-    _, base, _ = in_process_server
+def test_token_modify_rejects_wrong_type_for_add_scopes(management_session):
+    base, _, mgmt_token = management_session
+    auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     status, body = post(
         f"{base}/agent-auth/token/modify",
         data={"family_id": create_body["family_id"], "add_scopes": "not-a-dict"},
+        headers=auth,
     )
     assert status == 400
     assert body["error"] == "malformed_request"
@@ -351,15 +454,28 @@ def test_token_modify_rejects_wrong_type_for_add_scopes(in_process_server):
 
 
 @pytest.mark.covers_function("Serve Token Revoke Endpoint")
-def test_token_revoke_marks_family_revoked(in_process_server):
+def test_token_revoke_requires_management_auth(in_process_server):
     _, base, _ = in_process_server
+    status, body = post(f"{base}/agent-auth/token/revoke", data={"family_id": "x"})
+    assert status == 401
+    assert body["error"] == "missing_token"
+
+
+@pytest.mark.covers_function("Serve Token Revoke Endpoint")
+def test_token_revoke_marks_family_revoked(management_session):
+    base, _, mgmt_token = management_session
+    auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     family_id = create_body["family_id"]
     access_token = create_body["access_token"]
 
-    status, body = post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id})
+    status, body = post(
+        f"{base}/agent-auth/token/revoke", data={"family_id": family_id}, headers=auth
+    )
     assert status == 200
     assert body == {"family_id": family_id, "revoked": True}
 
@@ -372,39 +488,56 @@ def test_token_revoke_marks_family_revoked(in_process_server):
 
 
 @pytest.mark.covers_function("Serve Token Revoke Endpoint")
-def test_token_revoke_is_idempotent_on_already_revoked_family(in_process_server):
-    _, base, _ = in_process_server
+def test_token_revoke_is_idempotent_on_already_revoked_family(management_session):
+    base, _, mgmt_token = management_session
+    auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     family_id = create_body["family_id"]
-    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id})
+    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id}, headers=auth)
 
-    status, body = post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id})
+    status, body = post(
+        f"{base}/agent-auth/token/revoke", data={"family_id": family_id}, headers=auth
+    )
     assert status == 200
     assert body["revoked"] is True
 
 
 @pytest.mark.covers_function("Serve Token Revoke Endpoint")
-def test_token_revoke_returns_404_for_unknown_family(in_process_server):
-    _, base, _ = in_process_server
-    status, body = post(f"{base}/agent-auth/token/revoke", data={"family_id": "no-such"})
+def test_token_revoke_returns_404_for_unknown_family(management_session):
+    base, _, mgmt_token = management_session
+    status, body = post(
+        f"{base}/agent-auth/token/revoke",
+        data={"family_id": "no-such"},
+        headers={"Authorization": f"Bearer {mgmt_token}"},
+    )
     assert status == 404
     assert body["error"] == "family_not_found"
 
 
 @pytest.mark.covers_function("Serve Token Revoke Endpoint")
-def test_token_revoke_rejects_malformed_json(in_process_server):
-    _, base, _ = in_process_server
-    status, body = post(f"{base}/agent-auth/token/revoke", raw=b"{bad")
+def test_token_revoke_rejects_malformed_json(management_session):
+    base, _, mgmt_token = management_session
+    status, body = post(
+        f"{base}/agent-auth/token/revoke",
+        raw=b"{bad",
+        headers={"Authorization": f"Bearer {mgmt_token}"},
+    )
     assert status == 400
     assert body["error"] == "malformed_request"
 
 
 @pytest.mark.covers_function("Serve Token Revoke Endpoint")
-def test_token_revoke_rejects_missing_family_id(in_process_server):
-    _, base, _ = in_process_server
-    status, body = post(f"{base}/agent-auth/token/revoke", data={})
+def test_token_revoke_rejects_missing_family_id(management_session):
+    base, _, mgmt_token = management_session
+    status, body = post(
+        f"{base}/agent-auth/token/revoke",
+        data={},
+        headers={"Authorization": f"Bearer {mgmt_token}"},
+    )
     assert status == 400
     assert body["error"] == "malformed_request"
 
@@ -413,15 +546,28 @@ def test_token_revoke_rejects_missing_family_id(in_process_server):
 
 
 @pytest.mark.covers_function("Serve Token Rotate Endpoint")
-def test_token_rotate_revokes_old_and_creates_new_family(in_process_server):
+def test_token_rotate_requires_management_auth(in_process_server):
     _, base, _ = in_process_server
+    status, body = post(f"{base}/agent-auth/token/rotate", data={"family_id": "x"})
+    assert status == 401
+    assert body["error"] == "missing_token"
+
+
+@pytest.mark.covers_function("Serve Token Rotate Endpoint")
+def test_token_rotate_revokes_old_and_creates_new_family(management_session):
+    base, _, mgmt_token = management_session
+    auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     old_family_id = create_body["family_id"]
     old_access_token = create_body["access_token"]
 
-    status, body = post(f"{base}/agent-auth/token/rotate", data={"family_id": old_family_id})
+    status, body = post(
+        f"{base}/agent-auth/token/rotate", data={"family_id": old_family_id}, headers=auth
+    )
     assert status == 200
     assert body["old_family_id"] == old_family_id
     assert body["new_family_id"] != old_family_id
@@ -445,38 +591,55 @@ def test_token_rotate_revokes_old_and_creates_new_family(in_process_server):
 
 
 @pytest.mark.covers_function("Serve Token Rotate Endpoint")
-def test_token_rotate_returns_404_for_unknown_family(in_process_server):
-    _, base, _ = in_process_server
-    status, body = post(f"{base}/agent-auth/token/rotate", data={"family_id": "no-such"})
+def test_token_rotate_returns_404_for_unknown_family(management_session):
+    base, _, mgmt_token = management_session
+    status, body = post(
+        f"{base}/agent-auth/token/rotate",
+        data={"family_id": "no-such"},
+        headers={"Authorization": f"Bearer {mgmt_token}"},
+    )
     assert status == 404
     assert body["error"] == "family_not_found"
 
 
 @pytest.mark.covers_function("Serve Token Rotate Endpoint")
-def test_token_rotate_returns_409_for_revoked_family(in_process_server):
-    _, base, _ = in_process_server
+def test_token_rotate_returns_409_for_revoked_family(management_session):
+    base, _, mgmt_token = management_session
+    auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {"things:read": "allow"}},
+        headers=auth,
     )
     family_id = create_body["family_id"]
-    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id})
+    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id}, headers=auth)
 
-    status, body = post(f"{base}/agent-auth/token/rotate", data={"family_id": family_id})
+    status, body = post(
+        f"{base}/agent-auth/token/rotate", data={"family_id": family_id}, headers=auth
+    )
     assert status == 409
     assert body["error"] == "family_revoked"
 
 
 @pytest.mark.covers_function("Serve Token Rotate Endpoint")
-def test_token_rotate_rejects_malformed_json(in_process_server):
-    _, base, _ = in_process_server
-    status, body = post(f"{base}/agent-auth/token/rotate", raw=b"{bad")
+def test_token_rotate_rejects_malformed_json(management_session):
+    base, _, mgmt_token = management_session
+    status, body = post(
+        f"{base}/agent-auth/token/rotate",
+        raw=b"{bad",
+        headers={"Authorization": f"Bearer {mgmt_token}"},
+    )
     assert status == 400
     assert body["error"] == "malformed_request"
 
 
 @pytest.mark.covers_function("Serve Token Rotate Endpoint")
-def test_token_rotate_rejects_missing_family_id(in_process_server):
-    _, base, _ = in_process_server
-    status, body = post(f"{base}/agent-auth/token/rotate", data={})
+def test_token_rotate_rejects_missing_family_id(management_session):
+    base, _, mgmt_token = management_session
+    status, body = post(
+        f"{base}/agent-auth/token/rotate",
+        data={},
+        headers={"Authorization": f"Bearer {mgmt_token}"},
+    )
     assert status == 400
     assert body["error"] == "malformed_request"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,14 +2,21 @@
 
 import os
 import threading
+from unittest.mock import Mock
 
 import pytest
 
 from agent_auth.approval import ApprovalManager
 from agent_auth.audit import AuditLogger
 from agent_auth.config import Config
+from agent_auth.keys import KeyManager
 from agent_auth.plugins import ApprovalResult, NotificationPlugin
-from agent_auth.server import MANAGEMENT_SCOPE, AgentAuthHandler, AgentAuthServer
+from agent_auth.server import (
+    MANAGEMENT_SCOPE,
+    AgentAuthHandler,
+    AgentAuthServer,
+    _bootstrap_management_token,
+)
 from agent_auth.store import TokenStore
 from agent_auth.tokens import create_token_pair
 from tests._http import get, post
@@ -119,6 +126,51 @@ def test_oversize_body_returns_400(in_process_server):
     status, body = post(f"{base}/agent-auth/validate", raw=payload)
     assert status == 400
     assert body["error"] == "malformed_request"
+
+
+# --- management-token bootstrap ---
+
+
+def _fake_key_manager(initial_refresh=None):
+    km = Mock(spec=KeyManager)
+    km.get_management_refresh_token.return_value = initial_refresh
+    return km
+
+
+@pytest.mark.covers_function("Bootstrap Management Token")
+def test_bootstrap_creates_fresh_family_when_keyring_token_is_malformed(
+    test_config, signing_key, store
+):
+    """A corrupt/stale token in the keyring must not block recreation of the management family."""
+    km = _fake_key_manager(initial_refresh="rt_garbage_not-a-real-signature")
+    _bootstrap_management_token(store, signing_key, test_config, km)
+    km.set_management_refresh_token.assert_called_once()
+    # The new refresh token's family must be active and carry the management scope.
+    families = store.list_families()
+    assert len(families) == 1
+    assert families[0]["scopes"] == {MANAGEMENT_SCOPE: "allow"}
+    assert families[0]["revoked"] is False
+
+
+@pytest.mark.covers_function("Bootstrap Management Token")
+def test_bootstrap_propagates_store_errors_instead_of_creating_duplicate_family(
+    test_config, signing_key, store
+):
+    """DB errors during the validity check must propagate rather than being swallowed.
+
+    Swallowing them would silently create a second management family on top of the
+    existing one, orphaning the keyring-persisted refresh token.
+    """
+    # Seed a valid management token so get_token would succeed if reached.
+    fam = "fam-preexisting"
+    store.create_family(fam, {MANAGEMENT_SCOPE: "allow"})
+    _, refresh = create_token_pair(signing_key, store, fam, test_config)
+    km = _fake_key_manager(initial_refresh=refresh)
+    broken_store = Mock(wraps=store)
+    broken_store.get_token.side_effect = RuntimeError("db locked")
+    with pytest.raises(RuntimeError, match="db locked"):
+        _bootstrap_management_token(broken_store, signing_key, test_config, km)
+    km.set_management_refresh_token.assert_not_called()
 
 
 @pytest.fixture

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -119,3 +119,302 @@ def test_oversize_body_returns_400(in_process_server):
     status, body = post(f"{base}/agent-auth/validate", raw=payload)
     assert status == 400
     assert body["error"] == "malformed_request"
+
+
+# --- token create ---
+
+
+@pytest.mark.covers_function("Serve Token Create Endpoint")
+def test_token_create_returns_tokens_and_family(in_process_server):
+    _, base, _ = in_process_server
+    status, body = post(
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {"things:read": "allow"}},
+    )
+    assert status == 200
+    assert body["family_id"]
+    assert body["access_token"].startswith("aa_")
+    assert body["refresh_token"].startswith("rt_")
+    assert body["scopes"] == {"things:read": "allow"}
+    assert isinstance(body["expires_in"], int)
+
+
+@pytest.mark.covers_function("Serve Token Create Endpoint")
+def test_token_create_rejects_empty_scopes(in_process_server):
+    _, base, _ = in_process_server
+    status, body = post(f"{base}/agent-auth/token/create", data={"scopes": {}})
+    assert status == 400
+    assert body["error"] == "no_scopes"
+
+
+@pytest.mark.covers_function("Serve Token Create Endpoint")
+def test_token_create_rejects_missing_scopes_field(in_process_server):
+    _, base, _ = in_process_server
+    status, body = post(f"{base}/agent-auth/token/create", data={})
+    assert status == 400
+    assert body["error"] == "no_scopes"
+
+
+@pytest.mark.covers_function("Serve Token Create Endpoint")
+def test_token_create_rejects_malformed_json(in_process_server):
+    _, base, _ = in_process_server
+    status, body = post(f"{base}/agent-auth/token/create", raw=b"{bad")
+    assert status == 400
+    assert body["error"] == "malformed_request"
+
+
+@pytest.mark.covers_function("Serve Token Create Endpoint")
+def test_token_create_rejects_invalid_tier(in_process_server):
+    _, base, _ = in_process_server
+    status, body = post(
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {"things:read": "banana"}},
+    )
+    assert status == 400
+    assert body["error"] == "invalid_tier"
+
+
+# --- token list ---
+
+
+@pytest.mark.covers_function("Serve Token List Endpoint")
+def test_token_list_returns_empty_array_when_no_families(in_process_server):
+    _, base, _ = in_process_server
+    status, body = get(f"{base}/agent-auth/token/list")
+    assert status == 200
+    assert body == []
+
+
+@pytest.mark.covers_function("Serve Token List Endpoint")
+def test_token_list_returns_created_family(in_process_server):
+    _, base, store = in_process_server
+    post(f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}})
+    status, body = get(f"{base}/agent-auth/token/list")
+    assert status == 200
+    assert len(body) == 1
+    assert body[0]["scopes"] == {"things:read": "allow"}
+
+
+@pytest.mark.covers_function("Serve Token List Endpoint")
+def test_token_list_includes_revoked_families(in_process_server):
+    _, base, _ = in_process_server
+    _, create_body = post(
+        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+    )
+    family_id = create_body["family_id"]
+    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id})
+
+    status, body = get(f"{base}/agent-auth/token/list")
+    assert status == 200
+    assert any(f["id"] == family_id and f["revoked"] for f in body)
+
+
+# --- token modify ---
+
+
+@pytest.mark.covers_function("Serve Token Modify Endpoint")
+def test_token_modify_adds_scope(in_process_server):
+    _, base, _ = in_process_server
+    _, create_body = post(
+        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+    )
+    family_id = create_body["family_id"]
+
+    status, body = post(
+        f"{base}/agent-auth/token/modify",
+        data={"family_id": family_id, "add_scopes": {"things:write": "prompt"}},
+    )
+    assert status == 200
+    assert body["scopes"] == {"things:read": "allow", "things:write": "prompt"}
+
+
+@pytest.mark.covers_function("Serve Token Modify Endpoint")
+def test_token_modify_removes_scope(in_process_server):
+    _, base, _ = in_process_server
+    _, create_body = post(
+        f"{base}/agent-auth/token/create",
+        data={"scopes": {"things:read": "allow", "things:write": "prompt"}},
+    )
+    family_id = create_body["family_id"]
+
+    status, body = post(
+        f"{base}/agent-auth/token/modify",
+        data={"family_id": family_id, "remove_scopes": ["things:write"]},
+    )
+    assert status == 200
+    assert body["scopes"] == {"things:read": "allow"}
+
+
+@pytest.mark.covers_function("Serve Token Modify Endpoint")
+def test_token_modify_returns_404_for_unknown_family(in_process_server):
+    _, base, _ = in_process_server
+    status, body = post(
+        f"{base}/agent-auth/token/modify",
+        data={"family_id": "no-such-family", "add_scopes": {"x": "allow"}},
+    )
+    assert status == 404
+    assert body["error"] == "family_not_found"
+
+
+@pytest.mark.covers_function("Serve Token Modify Endpoint")
+def test_token_modify_returns_409_for_revoked_family(in_process_server):
+    _, base, _ = in_process_server
+    _, create_body = post(
+        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+    )
+    family_id = create_body["family_id"]
+    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id})
+
+    status, body = post(
+        f"{base}/agent-auth/token/modify",
+        data={"family_id": family_id, "add_scopes": {"x": "allow"}},
+    )
+    assert status == 409
+    assert body["error"] == "family_revoked"
+
+
+@pytest.mark.covers_function("Serve Token Modify Endpoint")
+def test_token_modify_returns_400_when_no_modifications_provided(in_process_server):
+    _, base, _ = in_process_server
+    _, create_body = post(
+        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+    )
+    status, body = post(
+        f"{base}/agent-auth/token/modify",
+        data={"family_id": create_body["family_id"]},
+    )
+    assert status == 400
+    assert body["error"] == "no_modifications"
+
+
+@pytest.mark.covers_function("Serve Token Modify Endpoint")
+def test_token_modify_rejects_invalid_tier_in_add_scopes(in_process_server):
+    _, base, _ = in_process_server
+    _, create_body = post(
+        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+    )
+    status, body = post(
+        f"{base}/agent-auth/token/modify",
+        data={"family_id": create_body["family_id"], "add_scopes": {"things:write": "banana"}},
+    )
+    assert status == 400
+    assert body["error"] == "invalid_tier"
+
+
+@pytest.mark.covers_function("Serve Token Modify Endpoint")
+def test_token_modify_set_tiers_silently_skips_unknown_scope(in_process_server):
+    _, base, _ = in_process_server
+    _, create_body = post(
+        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+    )
+    family_id = create_body["family_id"]
+
+    status, body = post(
+        f"{base}/agent-auth/token/modify",
+        data={"family_id": family_id, "set_tiers": {"no-such-scope": "prompt"}},
+    )
+    assert status == 200
+    assert body["scopes"] == {"things:read": "allow"}
+
+
+# --- token revoke ---
+
+
+@pytest.mark.covers_function("Serve Token Revoke Endpoint")
+def test_token_revoke_marks_family_revoked(in_process_server):
+    _, base, _ = in_process_server
+    _, create_body = post(
+        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+    )
+    family_id = create_body["family_id"]
+    access_token = create_body["access_token"]
+
+    status, body = post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id})
+    assert status == 200
+    assert body == {"family_id": family_id, "revoked": True}
+
+    validate_status, validate_body = post(
+        f"{base}/agent-auth/validate",
+        data={"token": access_token, "required_scope": "things:read"},
+    )
+    assert validate_status == 401
+    assert validate_body["valid"] is False
+
+
+@pytest.mark.covers_function("Serve Token Revoke Endpoint")
+def test_token_revoke_is_idempotent_on_already_revoked_family(in_process_server):
+    _, base, _ = in_process_server
+    _, create_body = post(
+        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+    )
+    family_id = create_body["family_id"]
+    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id})
+
+    status, body = post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id})
+    assert status == 200
+    assert body["revoked"] is True
+
+
+@pytest.mark.covers_function("Serve Token Revoke Endpoint")
+def test_token_revoke_returns_404_for_unknown_family(in_process_server):
+    _, base, _ = in_process_server
+    status, body = post(f"{base}/agent-auth/token/revoke", data={"family_id": "no-such"})
+    assert status == 404
+    assert body["error"] == "family_not_found"
+
+
+# --- token rotate ---
+
+
+@pytest.mark.covers_function("Serve Token Rotate Endpoint")
+def test_token_rotate_revokes_old_and_creates_new_family(in_process_server):
+    _, base, _ = in_process_server
+    _, create_body = post(
+        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+    )
+    old_family_id = create_body["family_id"]
+    old_access_token = create_body["access_token"]
+
+    status, body = post(f"{base}/agent-auth/token/rotate", data={"family_id": old_family_id})
+    assert status == 200
+    assert body["old_family_id"] == old_family_id
+    assert body["new_family_id"] != old_family_id
+    assert body["access_token"].startswith("aa_")
+    assert body["refresh_token"].startswith("rt_")
+    assert body["scopes"] == {"things:read": "allow"}
+
+    old_validate_status, old_validate_body = post(
+        f"{base}/agent-auth/validate",
+        data={"token": old_access_token, "required_scope": "things:read"},
+    )
+    assert old_validate_status == 401
+    assert old_validate_body["valid"] is False
+
+    new_validate_status, new_validate_body = post(
+        f"{base}/agent-auth/validate",
+        data={"token": body["access_token"], "required_scope": "things:read"},
+    )
+    assert new_validate_status == 200
+    assert new_validate_body["valid"] is True
+
+
+@pytest.mark.covers_function("Serve Token Rotate Endpoint")
+def test_token_rotate_returns_404_for_unknown_family(in_process_server):
+    _, base, _ = in_process_server
+    status, body = post(f"{base}/agent-auth/token/rotate", data={"family_id": "no-such"})
+    assert status == 404
+    assert body["error"] == "family_not_found"
+
+
+@pytest.mark.covers_function("Serve Token Rotate Endpoint")
+def test_token_rotate_returns_409_for_revoked_family(in_process_server):
+    _, base, _ = in_process_server
+    _, create_body = post(
+        f"{base}/agent-auth/token/create", data={"scopes": {"things:read": "allow"}}
+    )
+    family_id = create_body["family_id"]
+    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id})
+
+    status, body = post(f"{base}/agent-auth/token/rotate", data={"family_id": family_id})
+    assert status == 409
+    assert body["error"] == "family_revoked"


### PR DESCRIPTION
## Summary

Closes #3.

Adds HTTP endpoints for all five `agent-auth token *` CLI operations so that token lifecycle can be managed programmatically without requiring local CLI access on the host:

- `POST /agent-auth/token/create` — create a new token family; returns access + refresh token pair
- `GET /agent-auth/token/list` — list all token families (excluding the management family)
- `POST /agent-auth/token/modify` — add/remove/change-tier scopes on an existing family
- `POST /agent-auth/token/revoke` — revoke a token family (idempotent)
- `POST /agent-auth/token/rotate` — revoke old family, create new one with same scopes

**Authentication:** All five management endpoints require `Authorization: Bearer <token>` where the token family carries `agent-auth:manage=allow`. On first startup the server bootstraps a management token family directly via the store and stores the refresh token in the OS keyring. Operators retrieve it via `agent-auth management-token show` and exchange it for an access token via `POST /agent-auth/token/refresh`. This is full token-model unification — the management credential is a regular token, enabling future JIT approval support. See [ADR 0014](design/decisions/0014-management-endpoint-auth.md) for the full rationale.

**Regression check:** `scripts/verify-token-cli-http-parity.sh` (wired into CI as its own workflow and `task verify-token-cli-http-parity`) asserts that every `agent-auth token *` argparse subcommand has a corresponding `_handle_token_<cmd>` method on `AgentAuthHandler` wired into a route, preventing future CLI/HTTP drift. This check is project-specific and lives separately from the portable `verify-standards.sh`.

Also extends `SECURITY.md` with a "Token management endpoints" section covering the auth model and bootstrap flow.

## Test plan

- [x] Unit tests pass: `uv run pytest tests/test_server.py tests/test_cli.py` — covers the five management endpoints, auth-required branches, the bootstrap fast-path, and the `management-token show` KeyringError path
- [x] Full non-integration test suite passes: `uv run pytest tests/ --ignore=tests/integration`
- [x] All checks pass: `uv run task check` — lint, format, shellcheck, shfmt, integration isolation
- [x] `task verify-token-cli-http-parity` passes — CLI→HTTP route parity gate
- [x] `task verify-standards` passes — generic project standards gate
- [ ] Integration tests written in `tests/integration/test_token_management.py` (Docker-backed, run with `scripts/test.sh --integration`; validated in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)