### PR TITLE
docs(design): add ASSURANCE.md + ADR template, index, and backfill ADRs 0006-0013

### DIFF
--- a/design/ASSURANCE.md
+++ b/design/ASSURANCE.md
@@ -87,9 +87,6 @@ For any given release:
   report).
 - ADR index `design/decisions/README.md` lists every file in
   `design/decisions/` (other than `README.md` / `TEMPLATE.md`).
-- Audit log retained on the host for at least one release cycle —
-  operator responsibility, not automated today (tracked as a
-  follow-up: add a rotation / retention policy).
 - `scripts/verify-standards.sh` passes, asserting portable project
   standards are met — including the QM/ASSURANCE gate that proves
   this file exists with the required sections.

--- a/design/ASSURANCE.md
+++ b/design/ASSURANCE.md
@@ -1,0 +1,115 @@
+# agent-auth Assurance Level
+
+## Level
+
+**QM** — Quality Management, per ISO 9000-style practice.
+
+Declared: 2026-04-19. This is a project-level decision; changing it
+requires an ADR under `design/decisions/` that supersedes this file.
+
+## Rationale
+
+agent-auth gates AI-agent access to user-facing host applications
+(Things 3 today, more to come). A failure of agent-auth leaks or
+denies access to the user's own data via the user's own applications
+— it does not cause physical harm, regulated-data exposure beyond the
+user's own scope, or financial settlement. The blast radius of a
+defect is bounded by what the connected applications themselves
+expose.
+
+The project therefore does not warrant a safety-integrity level
+(IEC 61508 SIL 1–4 exist for functional safety in E/E/PE systems
+where failure causes physical harm) or an automotive-style ASIL
+classification. It does warrant disciplined quality management: the
+keyring handling, refresh-token reuse detection, and JIT-approval
+plumbing all need to be correct or the security posture collapses.
+
+The QM declaration here exists so each implementation plan has a
+concrete bar to verify against in the *Verify QM / SIL compliance*
+step of `.claude/instructions/plan-template.md`.
+
+## Required activities
+
+Every change that lands on `main` must include, where applicable:
+
+- **Code review** — every change ships via pull request with at least
+  one reviewer (self-review + Claude reviewer agents count for this
+  solo-developer project; see the PR-review workflow in
+  `~/.claude/CLAUDE.md`).
+- **Architecture Decision Records** — significant design decisions
+  recorded in `design/decisions/` following `TEMPLATE.md`; the ADR
+  gate in `scripts/verify-standards.sh` blocks drift.
+- **Threat modelling** — security-relevant changes refresh
+  `SECURITY.md` before landing (see plan-template.md "Threat
+  model").
+- **Testing** — new behaviour covered by unit tests that drive the
+  public API only; integration tests that cross process boundaries
+  use the per-test Docker harness (ADR 0004 / 0005). Coverage and
+  mutation thresholds live in `.claude/instructions/testing-standards.md`.
+- **CI gating** — `task check`, `task test`, `task verify-standards`, `task verify-function-tests`, and
+  `task verify-dependencies` all run on every PR. Gates are
+  non-advisory: a red check blocks merge.
+- **Audit logging** — every token operation and authorization
+  decision inside `agent-auth serve` emits a structured audit log
+  line. Changes that add a new token-lifecycle operation also add
+  an audit entry.
+- **Dependency hygiene** — `pip-audit` runs in CI; Dependabot opens
+  grouped minor/patch PRs per ecosystem.
+- **Plan for each change** — non-trivial PRs commit a plan under
+  `plans/` following `plan-template.md`. Small docs / config fixes
+  may skip the plan (see `~/.claude/CLAUDE.md` "Starting
+  Implementation Work").
+
+## Required documentation
+
+The following artefacts are kept current as the system evolves:
+
+- `README.md` — scope, install, usage.
+- `CONTRIBUTING.md` — dev setup, testing, release, commit signing.
+- `SECURITY.md` — threat model, cybersecurity-standard selection.
+- `design/DESIGN.md` — system architecture, interfaces, behaviour.
+- `design/ASSURANCE.md` — this file.
+- `design/decisions/` — ADR per significant decision, indexed by
+  `design/decisions/README.md`.
+- `design/functional_decomposition.yaml` — functions traceable to
+  tests.
+- `design/product_breakdown.yaml` — components and deliverables.
+- `CHANGELOG.md` — keep-a-changelog entries per release.
+- `plans/<feature>.md` — implementation plans for every non-trivial
+  change.
+
+## Required evidence
+
+For any given release:
+
+- Green CI on the merge commit (all gates above).
+- Test artefacts retained in the CI run (pytest output, coverage
+  report).
+- ADR index `design/decisions/README.md` lists every file in
+  `design/decisions/` (other than `README.md` / `TEMPLATE.md`).
+- Audit log retained on the host for at least one release cycle —
+  operator responsibility, not automated today (tracked as a
+  follow-up: add a rotation / retention policy).
+- `scripts/verify-standards.sh` passes, asserting portable project
+  standards are met — including the QM/ASSURANCE gate that proves
+  this file exists with the required sections.
+
+## Per-change conformance
+
+`.claude/instructions/plan-template.md` mandates a *Verify QM / SIL
+compliance* step in every implementation plan. That step walks this
+document's Required-activities list against the PR and records any
+gaps (or justified skips) in the plan's *Design and verification*
+section.
+
+## Changing this declaration
+
+Promoting to SIL 1 or above, or downgrading below QM, is a
+significant design decision. It requires:
+
+1. A new ADR under `design/decisions/` superseding this one,
+   covering the new level, its rationale, and the migration plan.
+2. Updates to the Required-activities / documentation / evidence
+   lists to reflect the new level's demands.
+3. Updates to `scripts/verify-standards.sh` if the new level
+   introduces regression-checkable invariants.

--- a/design/decisions/0006-token-format.md
+++ b/design/decisions/0006-token-format.md
@@ -1,0 +1,99 @@
+# ADR 0006 — Token format
+
+## Status
+
+Accepted — 2026-04-19.
+
+Backfilled ADR: the decision was made when the token store was first
+implemented; this record captures the rationale after the fact.
+
+## Context
+
+agent-auth issues bearer tokens that bridges forward to the
+`/agent-auth/validate` endpoint. The format has to:
+
+1. Let the server tell access and refresh tokens apart on the wire so
+   a mistakenly-presented refresh token is rejected at the parse
+   layer rather than after an expensive database lookup.
+2. Survive an attacker with the SQLite token store but *not* the
+   signing key — the token they forge must not validate.
+3. Be trivial to log and debug without leaking secrets. Opaque opaque
+   blobs (a random 64-byte string keyed by ID in the DB) would force
+   log redaction everywhere tokens surface; self-describing strings
+   carry their own provenance.
+4. Stay short enough to paste in a shell and pass around as a CLI
+   argument.
+
+## Considered alternatives
+
+### Random opaque bearer tokens (DB lookup on every validate)
+
+Generate 32 bytes of CSPRNG output, base64url-encode, store the
+hash in the DB, validate by hashing and looking up.
+
+**Rejected** because:
+
+- Requires a DB round-trip even to decide whether the string is
+  syntactically a token of ours. Bridges routinely see noise
+  (expired tokens, typos, stale `.env` files) — parsing them out at
+  the string level is cheaper and leaks less to disk.
+- No wire-level access/refresh disambiguation.
+- Doesn't satisfy the "attacker with DB but not key can't forge"
+  property — if an attacker has the DB, they also have the stored
+  hash's preimage target and only need to brute-force the input
+  space, not the key space.
+
+### JWT (signed or encrypted)
+
+**Rejected** because:
+
+- Claims payload carries scope metadata in the token, meaning a
+  refreshed-or-modified token has to be reissued to change scopes.
+  agent-auth deliberately keeps scope state in the DB so
+  `token modify` takes effect on the next validate without
+  re-issuing (see DESIGN.md "Scope modification").
+- Ecosystem complexity (alg confusion, `none` alg, library CVEs) is
+  not worth it for a tool with exactly one issuer and one verifier,
+  both in the same process.
+
+## Decision
+
+Tokens are self-describing strings of the shape:
+
+```
+<prefix>_<token-id>_<hmac-signature>
+```
+
+where:
+
+- `<prefix>` is `aa` for access tokens and `rt` for refresh tokens
+  (`PREFIX_ACCESS` / `PREFIX_REFRESH` in `src/agent_auth/tokens.py`).
+- `<token-id>` is `uuid.uuid4().hex` (a 32-character hex string).
+- `<hmac-signature>` is `HMAC-SHA256(signing_key, prefix + "_" + token_id)`
+  hex-encoded.
+
+The prefix is covered by the signature. An attacker who knows a valid
+access token can't downgrade it to a refresh token (or vice versa)
+without recomputing the HMAC under the signing key. The signing key
+lives in the system keyring (see ADR 0008), never on disk next to the
+token store.
+
+## Consequences
+
+- Token validation is a single HMAC verify plus a DB lookup keyed on
+  `token_id`. The HMAC short-circuits invalid strings before the DB
+  is touched.
+- Scope changes do not require reissuing tokens — scopes live in
+  `token_families`, keyed by family ID, and are loaded on every
+  validate (see ADR 0010).
+- The token format is part of the public surface. Clients and
+  bridges parse it on sight (for error messages and for routing
+  wire-level errors before the server is called). Changing the
+  shape is a breaking change requiring dual-support.
+- A stolen access token is usable until it expires (default 15
+  minutes). A stolen refresh token is subject to reuse detection
+  (ADR 0011).
+- The signature covers `prefix_token-id` rather than the raw
+  `token_id` specifically to bind the role to the signature; this
+  is a minor defence against future format extensions that might
+  otherwise share a signing domain.

--- a/design/decisions/0007-sqlite-field-level-encryption.md
+++ b/design/decisions/0007-sqlite-field-level-encryption.md
@@ -1,0 +1,104 @@
+# ADR 0007 — SQLite with field-level AES-256-GCM encryption
+
+## Status
+
+Accepted — 2026-04-19.
+
+Backfilled ADR.
+
+## Context
+
+The token store holds the primary material an attacker needs to
+impersonate a user to agent-auth — HMAC signatures for every live
+access and refresh token, plus the scope grants tied to each family.
+It lives on disk on the host, where:
+
+- The user's other tools, backup agents, Time Machine snapshots, and
+  cloud sync daemons can all reach it.
+- A compromised process running as the user (a VS Code extension, a
+  browser extension spawning a helper) can read arbitrary files under
+  `$HOME`.
+
+The threat model therefore assumes the attacker can exfiltrate the
+SQLite file. What's required is that the file alone is not enough to
+forge or validate tokens. At the same time, the server itself must
+stay ergonomic — queries by token ID and family ID must remain
+efficient, timestamps must remain queryable for expiry sweeps, and the
+audit log of token operations must remain analysable.
+
+## Considered alternatives
+
+### SQLCipher (whole-DB encryption)
+
+Encrypt the entire database page layer. Standard, well-trodden
+approach.
+
+**Rejected** because:
+
+- Adds a non-pure-Python C dependency that doesn't ship on the PyPI
+  `sqlite3` wheel. Installation story on macOS/Linux diverges.
+- Coarse-grained: a compromised server process has to hold the key
+  for the life of the process anyway, so the attacker who gets code
+  execution inside agent-auth still reads everything. The attacker
+  we're defending against is the *file exfiltrator*, and a
+  field-level scheme handles that case without giving up SQLite's
+  standard tooling (`.dump`, `sqlite3` REPL, the built-in
+  `sqlite3` module).
+
+### Encrypt the whole row, decrypt on read
+
+Serialise each row to JSON, encrypt, store a single ciphertext blob.
+
+**Rejected** because:
+
+- Breaks indexing — a family-wide revoke sweep or an expired-token
+  GC would have to decrypt every row.
+- Opaque rows defeat low-tech triage (`sqlite3 tokens.db .schema`).
+
+### Plaintext DB, rely on file permissions only
+
+**Rejected** because the threat model explicitly assumes the DB can
+be exfiltrated. File permissions protect only against *same-host,
+different-user* access, which is not the attack we're worried about.
+
+## Decision
+
+Use SQLite at `$XDG_DATA_HOME/agent-auth/tokens.db` (see ADR 0012)
+with AES-256-GCM field-level encryption on the sensitive columns
+only. Concretely (see the schema in `src/agent_auth/store.py`):
+
+- `token_families` stores `id`, `created_at`, and `revoked` in
+  plaintext (so family-revocation sweeps and audit queries remain
+  efficient). `scopes` is an encrypted `BLOB`.
+- `tokens` stores `id`, `family_id`, `type`, `expires_at`, and
+  `consumed` in plaintext (so expiry sweeps, foreign-key joins, and
+  reuse detection remain efficient). `hmac_signature` is an
+  encrypted `BLOB`.
+- Sensitive columns are encrypted with AES-256-GCM via the
+  `cryptography` library's `AESGCM` primitive. Marked with `(E)` in
+  the `DESIGN.md` schema tables.
+- The encryption key is a 32-byte AES key held in the system keyring
+  (see ADR 0008), generated on first startup.
+- Encrypt / decrypt helpers live in `src/agent_auth/crypto.py`;
+  `src/agent_auth/store.py` wraps every DB write/read through them.
+
+## Consequences
+
+- An attacker with the SQLite file but not the keyring can see *that*
+  tokens exist (and when they expire), but cannot forge them or read
+  the scope grants.
+- The server holds the encryption key in memory for its lifetime.
+  A compromised server process reads plaintext; that's the accepted
+  threat boundary.
+- Expiry sweeps, family-wide revocation, and reuse detection all
+  operate on plaintext columns — the encryption scheme does not
+  degrade those paths.
+- Every sensitive column write is `encrypt_field(...)` producing a
+  `nonce || ciphertext || tag` blob stored as a SQLite `BLOB`; every
+  read is the reverse. Acceptable overhead at agent-auth's expected
+  request rates (human-driven, not bulk).
+- `cryptography` is a C-extension dependency; it's listed in
+  `pyproject.toml` and picks up wheels on all supported platforms.
+- Changing the encryption key (rotation) is not automated — the
+  store is rekeyed by wiping and reissuing all tokens. Tracked as a
+  follow-up if it becomes necessary.

--- a/design/decisions/0008-system-keyring-for-key-material.md
+++ b/design/decisions/0008-system-keyring-for-key-material.md
@@ -1,0 +1,104 @@
+# ADR 0008 — System keyring for signing and encryption keys
+
+## Status
+
+Accepted — 2026-04-19.
+
+Backfilled ADR.
+
+## Context
+
+agent-auth holds two long-lived secrets in production:
+
+1. The **HMAC signing key** used to sign and verify token strings
+   (see ADR 0006). Anyone with this key can forge valid access and
+   refresh tokens for any family.
+2. The **AES-256-GCM encryption key** used for field-level
+   encryption in the token store (see ADR 0007). Anyone with this
+   key plus the SQLite file can read every token's signature and
+   every family's scope grants.
+
+Both are 32-byte symmetric keys. They must survive server restarts
+(otherwise every client's existing tokens are invalidated) and must
+not share disk location with the SQLite store (otherwise the "attacker
+with the DB" threat-model assumption is violated).
+
+## Considered alternatives
+
+### Keys in config file at a different path
+
+Store keys as hex-encoded strings in a YAML file under
+`$XDG_CONFIG_HOME/agent-auth/`, separate from the SQLite file in
+`$XDG_DATA_HOME/agent-auth/`.
+
+**Rejected** because:
+
+- Path separation defeats *co-location*, not *exfiltration*. An
+  attacker who walks the user's home directory picks up both paths.
+- File permissions (`0600`) protect against same-host other-user,
+  which isn't the threat.
+- Forces agent-auth to own key-file lifecycle (atomic writes, umask,
+  backup opt-out). The OS already provides this for keyring entries.
+
+### HashiCorp Vault / cloud KMS
+
+**Rejected** as over-scoped for a local-host tool. Adds network
+dependency and a second trust domain.
+
+### Per-startup ephemeral key
+
+Generate a fresh key at server start, re-issue tokens on restart.
+
+**Rejected** because it makes restarting the server a breaking
+operation for every connected client — unacceptable usability
+regression.
+
+## Decision
+
+Store both keys in the system keyring, behind a narrow wrapper in
+`src/agent_auth/keys.py`:
+
+- `KeyManager.get_or_create_signing_key()` — returns the signing
+  key, generating 32 bytes of CSPRNG and persisting to the keyring
+  if absent.
+- `KeyManager.get_or_create_encryption_key()` — same shape for the
+  AES key.
+
+The keys are typed (`SigningKey` and `EncryptionKey` newtypes) so
+they cannot be passed to the wrong primitive at type-check time
+(static check only — Python has no compile-time type enforcement). The
+keyring backend is selected automatically:
+
+- **macOS Keychain** on macOS hosts.
+- **libsecret / gnome-keyring** on Linux hosts (including the
+  devcontainer, where the Secret Service D-Bus backend is available).
+- **File-backed fallback (`keyrings.alt`)** inside the integration-test
+  container, where no interactive backend is present. Only used in
+  the test image (see ADR 0004 for the plumbing) — never in production
+  installs.
+
+The CLI client reuses the same keyring abstraction for its own
+credential storage, but with different entry names and a
+`--credential-store=file` escape hatch (see DESIGN.md "CLI Credential
+Storage").
+
+## Consequences
+
+- Key material never lives on disk in a form the file-level attacker
+  can read. On macOS the Keychain applies additional ACLs; on Linux
+  the D-Bus layer requires the desktop session to be unlocked.
+- Installing / moving the server between hosts requires the operator
+  to transfer the keyring entries explicitly — there's no "copy one
+  file" migration. Acceptable: this is a security property, not a
+  friction to smooth over.
+- The integration-test Docker image uses `keyrings.alt` with
+  file-backed storage so tests can run without a desktop session.
+  That backend is explicitly limited to the test image and is not
+  on the production installation path.
+- A compromised user session on the host can prompt the keyring to
+  unlock and read the keys. That is within the threat boundary
+  (same-user same-host code execution); defence is via audit
+  logging of every token operation, not via the keyring.
+- Key rotation is manual: delete the keyring entry, restart the
+  server, reissue all tokens. Tracked as a follow-up if / when it
+  becomes necessary.

--- a/design/decisions/0009-cli-server-split.md
+++ b/design/decisions/0009-cli-server-split.md
@@ -1,0 +1,102 @@
+# ADR 0009 — CLI / server split with a single trust boundary
+
+## Status
+
+Accepted — 2026-04-19.
+
+Backfilled ADR.
+
+## Context
+
+agent-auth performs two classes of operation:
+
+1. **Administrative writes** — creating, revoking, rotating tokens,
+   modifying scopes. These happen on the host, driven by the user
+   explicitly at the keyboard. They need direct access to the token
+   store and the signing key.
+2. **Online validation** — bridges (`things-bridge` today, more to
+   come) forward bearer tokens to `POST /agent-auth/validate` on
+   every request. This runs constantly, exposed over HTTP on
+   loopback, and must neither block on human input for allow-tier
+   scopes nor miss the JIT approval plugin for prompt-tier scopes.
+
+Shipping both behind a single process simplifies the trust story:
+one thing owns the keyring, one thing owns the SQLite file, one
+thing logs audit events, and an attacker who compromises a bridge
+gets no ambient access to key material.
+
+## Considered alternatives
+
+### Single CLI with a subcommand that forks a daemon
+
+Have `agent-auth` operate both as an admin CLI and, via a
+`daemon`-style subcommand, fork itself into a background validation
+server. Avoids the "two binaries" feel but complicates signal
+handling, foregrounding, and log plumbing.
+
+**Rejected** because the forking dance adds complexity without
+removing the split — we'd still have a process-boundary between
+admin and online paths, just obscured behind a fork(2). Users would
+still need an obvious mental model for "is the server running"; an
+explicit `agent-auth serve` expresses that directly.
+
+### Library-mode validation (no server)
+
+Have bridges statically link an in-process validator that reads the
+same DB.
+
+**Rejected** because:
+
+- Each bridge would need the signing/encryption keys in its own
+  address space, multiplying the blast radius of a bridge
+  compromise by the number of bridges.
+- JIT approval would require every bridge to own its own
+  notification UI, violating the "one approval plugin, configured
+  once" property (see ADR 0010).
+- Concurrent writers to the token store (CLI `revoke` racing with a
+  bridge's validate) would need a distributed-lock story the server
+  already provides.
+
+## Decision
+
+Ship agent-auth as a single Python package exposing two
+entrypoints, both in `src/agent_auth/cli.py`:
+
+- `agent-auth serve` — long-running HTTP server on `127.0.0.1:9100`.
+  Owns the token store, the keyring, the audit log, and the
+  notification plugin. This is the *only* process that reads the
+  signing or encryption keys.
+- `agent-auth token <create|list|revoke|rotate|modify> …` — admin
+  subcommands that read/write the same SQLite file directly. Invoked
+  interactively by the user; no long-lived state. (There is a
+  `GET /agent-auth/token/status` HTTP endpoint for introspection — see
+  DESIGN.md — but no `token status` CLI verb.)
+
+Both entrypoints live in the same package and share the same config
+loader, the same XDG paths, and the same keyring wrapper — but the
+server is the only process that runs under a network listener. The
+CLI never opens a socket.
+
+Bridges (see DESIGN.md) talk to the server over HTTP. They never
+hold the signing key, never read the SQLite file, and can only
+validate / request approval.
+
+## Consequences
+
+- Single trust boundary: any attacker who wants signing-key access
+  must compromise the `agent-auth serve` process. Bridges and CLIs
+  live outside that boundary.
+- The CLI and the server can race on SQLite — mitigated by SQLite's
+  built-in WAL / transaction locking. Admin operations are low-rate
+  and the server's hot path is short (single transaction per
+  validate), so the race window is small.
+- `agent-auth serve` running as a user-session process is the
+  intended deployment — no systemd unit, no launchd plist yet. A
+  production-style install story is a follow-up.
+- Health and diagnostic HTTP endpoints
+  (`GET /agent-auth/health`, `GET /agent-auth/token/status`) expose
+  just enough to run readiness probes and debug tokens without
+  leaking secrets (see DESIGN.md).
+- Expanding to more bridges (future outlook bridge, etc.) is a
+  pure-addition operation: each new bridge ships independently, talks
+  only to agent-auth over HTTP, and inherits the same trust story.

--- a/design/decisions/0010-three-tier-scope-model.md
+++ b/design/decisions/0010-three-tier-scope-model.md
@@ -1,0 +1,104 @@
+# ADR 0010 — Three-tier scope model with JIT approval
+
+## Status
+
+Accepted — 2026-04-19.
+
+Backfilled ADR.
+
+## Context
+
+AI agents want access to local applications with varying levels of
+sensitivity. Reading the user's inbox is noise — the user doesn't want
+a prompt every time. Sending mail or completing a to-do on the user's
+behalf is consequential and shouldn't go through without explicit
+consent. Permanently removing a capability isn't expressible in a
+prompt model — it's a policy decision.
+
+The simplest permission model ("token has scope X → allowed")
+collapses these three cases into one, forcing either blanket grant
+(and a loud audit trail that catches problems only after the fact) or
+blanket prompt (and an alert-fatigued user who clicks "approve" on
+autopilot).
+
+## Considered alternatives
+
+### Per-operation policy configuration
+
+Let the user configure policy per-scope in a config file, enumerating
+endpoints and their required approval mode.
+
+**Rejected** because:
+
+- Puts policy in a static config file, making "grant this one-off
+  for the next 10 minutes" hard to express.
+- Doesn't compose well with token modification — changing policy
+  then requires restarting the server or reloading config.
+
+### Out-of-band approval (Slack / email)
+
+Send a link to Slack or email for prompt-tier operations.
+
+**Rejected** as a default because the whole point of JIT approval is
+the user is physically present at the host. Plugin surface (see
+below) lets an operator wire Slack in if they want, without making
+it the default.
+
+## Decision
+
+Every scope granted on a token family carries a **tier**:
+
+- **allow** — request executes immediately, logged only.
+- **prompt** — request blocks at the `agent-auth/validate` call
+  while the configured notification plugin asks the user. On
+  approval, the request proceeds; on denial, the bridge returns 403.
+- **deny** — request is rejected without prompting.
+
+Tiers are per-family, not per-token: running
+`agent-auth token modify <family-id> --set-tier things:write=prompt`
+takes effect on the next validate call without reissuing tokens
+(see DESIGN.md "Scope modification").
+
+The approval plugin is loaded out of the agent-auth config as a
+Python module path (similar to Claude Code hooks). The default
+(`Config.notification_plugin = "terminal"`) is an interactive
+terminal prompt that displays the request description and waits on
+stdin for a yes/no — appropriate for the solo-developer deployment
+the project is built around. Operators can swap in a desktop
+notification plugin, Touch ID plugin, YubiKey plugin, or custom
+script as fits their setup. Plugin loading is `importlib.import_module` inside the
+agent-auth server process today — the plugin trust caveat is tracked
+as [#6](https://github.com/aidanns/agent-auth/issues/6) for future
+migration to out-of-process execution.
+
+Approval grants can be:
+
+- **Once** — only the specific invocation executes.
+- **Time-boxed** — all subsequent requests for the same scope within
+  a duration pass without re-prompting. Held in memory on the server
+  only; lost on restart.
+
+Time-boxed grants do not persist and do not modify the token's
+scope tier — they're a UX shortcut, not a policy change.
+
+## Consequences
+
+- Day-to-day reads (things:read, outlook:mail:read) run at `allow`
+  with zero interaction, letting agents operate fluidly.
+- Writes (things:write, outlook:mail:send) default to `prompt`, so
+  the user sees and approves each consequential action with full
+  context — the notification plugin shows the `description` the
+  bridge forwards along the validate call.
+- Operations the user never wants to delegate (e.g.
+  outlook:mail:delete) can sit at `deny` and the token simply can't
+  be used for them.
+- Time-boxed grants give the user a "for the next hour" escape hatch
+  when they're driving many small actions, without permanently
+  downgrading policy.
+- Plugin trust sits inside the server process for now; the plugin
+  authors write Python that runs in the same memory as the signing
+  key. Mitigated by keeping the default plugin surface small and
+  documented, and tracked for out-of-process migration.
+- `tests_support.always_approve` and `tests_support.always_deny`
+  plugins live under `src/tests_support/` for integration testing
+  (see ADR 0004). Not shipped in the `agent-auth` wheel.

--- a/design/decisions/0011-refresh-token-reuse-family-revocation.md
+++ b/design/decisions/0011-refresh-token-reuse-family-revocation.md
@@ -1,0 +1,107 @@
+# ADR 0011 — Refresh-token reuse triggers family revocation
+
+## Status
+
+Accepted — 2026-04-19.
+
+Backfilled ADR.
+
+## Context
+
+Access tokens are short-lived (default 15 minutes) so a compromised
+access token has a bounded usefulness window. Refresh tokens, by
+contrast, are long-lived (default 8 hours) and powerful: holding one
+is equivalent to holding a current credential for the whole duration.
+
+The threat: a refresh token leaks (sloppy logging, backup exposure,
+credential-stealing malware). Without detection, the attacker can
+silently refresh forever, producing a continuous stream of valid
+access tokens. Scope modification and manual rotation help, but only
+if the user *notices* the compromise — something a silent attacker is
+motivated to avoid.
+
+OAuth 2.0's refresh-token rotation family (RFC 6819 §5.2.2.3,
+OAuth 2.1 draft §6.1) gives us the standard hook: make refresh tokens
+single-use, and use a second refresh attempt on the same token as a
+detector.
+
+## Considered alternatives
+
+### Long-lived non-rotating refresh tokens
+
+Simpler client code; accept the detection gap.
+
+**Rejected** because the detection gap *is* the reason this model
+exists. Without rotation, a stolen refresh token is indistinguishable
+from a live one.
+
+### Short-lived refresh tokens with no reuse detection
+
+Reduce refresh TTL to 15 minutes, force the client through
+re-issuance frequently.
+
+**Rejected** because re-issuance requires JIT approval (see below).
+Prompting the user every 15 minutes defeats the purpose of having
+refresh tokens at all.
+
+## Decision
+
+Refresh tokens are single-use. The store records a `consumed` flag
+per token; the first successful `POST /agent-auth/token/refresh`
+flips it atomically:
+
+- On success: return a new access/refresh token pair in the same
+  family; the old refresh token is marked consumed.
+- On second use of the same refresh token: the `mark_consumed`
+  transaction reports it was already consumed. agent-auth treats
+  this as a reuse event and calls `mark_family_revoked` on the
+  entire token family. Both the attacker's and the legitimate
+  client's in-flight and future tokens are now invalid.
+
+The legitimate client detects revocation via 401 with
+`{"error": "refresh_token_reuse_detected"}` on the next refresh (or
+`{"error": "token_revoked"}` on a validate call against an
+already-revoked family — see `_handle_validate` in
+`src/agent_auth/server.py`) and falls through to the re-issuance
+path:
+
+- `POST /agent-auth/token/reissue` with the family ID blocks on JIT
+  approval.
+- On approval, a fresh access/refresh pair is issued in the
+  **same** family (the family ID is preserved). The new tokens
+  inherit the family's existing scopes.
+- Re-issuance is blocked if the family was revoked because the
+  refresh-token reuse detection fired — the user must explicitly
+  create a new token via the CLI. Re-issuance is only available
+  when the family's refresh token *expired*, not when it was
+  consumed-via-reuse.
+
+The logic is implemented in `src/agent_auth/server.py`
+(`POST /agent-auth/token/refresh` handler — see
+`store.mark_consumed` and `store.mark_family_revoked`).
+
+## Consequences
+
+- A stolen refresh token grants the attacker exactly one refresh
+  before the legitimate client's next refresh (or vice versa) blows
+  the whole family away. Both parties are then locked out until the
+  user approves re-issuance on the host.
+- The user experiences the lock-out as a JIT approval prompt
+  describing "refresh token reuse detected; re-issue tokens?" The
+  notification plugin surfaces the family ID so the user can
+  correlate with their own expectations of what's logged in.
+- Clients must handle the reuse-detected error distinctly from the
+  expired error. The CLI helper library does this centrally so
+  individual commands don't re-implement the logic.
+- Re-issuance requires physical presence at the host, so a refresh-
+  token thief can't trigger re-issuance even if they happen to also
+  know the family ID.
+- Edge case: the legitimate client and a legitimate backup CLI on
+  the same host both try to refresh in a close race. One succeeds;
+  the other hits the consumed state and revokes the family. This is
+  accepted collateral — the alternative (letting parallel refresh
+  succeed) loses reuse detection. A real-world workaround is to
+  provision separate token families for parallel clients.
+- Audit log records every revocation with reason
+  (`refresh_reuse_detected`, `token_modify`, `manual_rotate`), so
+  the user can distinguish an attack from a self-inflicted wipe.

--- a/design/decisions/0012-xdg-path-layout.md
+++ b/design/decisions/0012-xdg-path-layout.md
@@ -1,0 +1,95 @@
+# ADR 0012 — XDG path layout
+
+## Status
+
+Accepted — 2026-04-19.
+
+Backfilled ADR.
+
+## Context
+
+agent-auth (and the adjacent `things-bridge`) write three distinct
+classes of file to the user's home directory:
+
+- **Config** — user-editable settings (TTLs, approval plugin
+  selection, bridge URLs). Read on startup; not written by the
+  server at runtime.
+- **Data** — the SQLite token store. Owned by agent-auth; the user
+  shouldn't edit it.
+- **State** — the audit log. Append-only, grows over time, can be
+  rotated or archived.
+
+Shoving all three into `~/.config/agent-auth/` (or worse,
+`~/.agent-auth/`) conflates them. The user backing up `~/.config`
+picks up the SQLite file and the growing audit log; a tool truncating
+"state" directories deletes their tokens.
+
+The
+[XDG Base Directory spec](https://specifications.freedesktop.org/basedir-spec/latest/)
+defines the right distinction
+(`$XDG_CONFIG_HOME` / `$XDG_DATA_HOME` / `$XDG_STATE_HOME`) and
+standard defaults for all three.
+
+## Considered alternatives
+
+### Single `~/.agent-auth/` dotfile directory
+
+Minimal. Defeats backup / sync tool heuristics that treat XDG paths
+specifically. Doesn't match what `service-design.md` requires.
+
+**Rejected.**
+
+### Respect XDG but fall through to `~/.config/agent-auth/` only
+
+Drop state/data distinction, collapse everything under config.
+
+**Rejected** — makes backing up "just my config" either lose the
+audit log or pick up the SQLite DB. The user's mental model of
+"config is the stuff I want synced" breaks.
+
+## Decision
+
+Follow the XDG Base Directory spec. Every agent-auth service
+computes its paths via small helpers (`src/agent_auth/config.py`,
+mirrored in `src/things_bridge/config.py`):
+
+- `_default_config_dir()` → `$XDG_CONFIG_HOME/agent-auth` (default
+  `~/.config/agent-auth`). Holds `config.json`.
+- `_default_data_dir()` → `$XDG_DATA_HOME/agent-auth` (default
+  `~/.local/share/agent-auth`). Holds `tokens.db`.
+- `_default_state_dir()` → `$XDG_STATE_HOME/agent-auth` (default
+  `~/.local/state/agent-auth`). Holds the audit log.
+
+All three helpers read the env var and fall back to the XDG-specified
+default. `things-bridge` does not own a data directory (it's
+stateless w.r.t. Things 3 — the upstream state lives in Things 3
+itself) and so only defines config and state.
+
+Directories are created on first use with `Path.mkdir(parents=True, exist_ok=True)` (default umask applies). Config files are not
+written by the server (it reads defaults and overlays the user's
+`config.json` if present) — the server does not own the user's
+config.
+
+## Consequences
+
+- Standard tooling respects the separation: `borgbackup`-style tools
+  can be configured to archive `$XDG_DATA_HOME`, cloud sync tools
+  can target `$XDG_CONFIG_HOME`, log rotators can chew through
+  `$XDG_STATE_HOME/agent-auth/audit.log` without touching data.
+- Defaults are explicit: on macOS (where XDG isn't the platform
+  convention) the defaults still place the SQLite DB at
+  `~/.local/share/agent-auth/tokens.db`. Users who want the
+  platform-native `~/Library/Application Support/agent-auth/tokens.db`
+  can set `XDG_DATA_HOME` to that path explicitly. Tracked as a
+  follow-up if it becomes a usability issue.
+- Integration tests override all three env vars to a per-test
+  tempdir via bind mount (see ADR 0004) so container tests can't
+  collide with the host's files.
+- Multi-user installs on a shared host get separate agent-auth
+  instances naturally — every user has their own `$HOME` and
+  therefore their own paths, tokens, and keyring entries.
+- The CLI client follows the same scheme for its own config at
+  `$XDG_CONFIG_HOME/<app>-cli/`. The optional
+  `--credential-store=file` escape hatch writes to
+  `$XDG_CONFIG_HOME/<app>-cli/credentials.yaml` with `0600` perms
+  (see DESIGN.md).

--- a/design/decisions/0013-applescript-things-bridge.md
+++ b/design/decisions/0013-applescript-things-bridge.md
@@ -1,0 +1,112 @@
+# ADR 0013 — AppleScript-based Things bridge
+
+## Status
+
+Accepted — 2026-04-19.
+
+Backfilled ADR. Pairs with ADR 0001 / 0003 for the in-process-vs-
+subprocess client layout.
+
+## Context
+
+Cultured Code Things 3 has no public HTTP API, no database export, no
+native Python bindings. The only supported programmatic interface is
+Apple Events — i.e. AppleScript talking to the Things 3 application
+via `osascript`. A Things-bridge has to go through this interface or
+it doesn't talk to Things 3 at all.
+
+AppleScript access raises two tensions against
+`.claude/instructions/service-design.md`:
+
+1. **Plugin / subprocess trust** — `service-design.md` prefers
+   out-of-process execution of third-party code reachable by a
+   network-facing service. The bridge's Things-client used to live
+   in-process (in `src/things_bridge/things.py`), violating that
+   preference.
+2. **Ambient macOS coupling** — the AppleScript path only works on
+   macOS hosts with Things 3 installed and granted TCC automation
+   permission. CI and devcontainer workflows can't exercise the real
+   path directly.
+
+## Considered alternatives
+
+### Read the Things 3 SQLite database directly
+
+Things 3 stores data in a SQLite database under
+`~/Library/Group Containers/…`. Reading it doesn't require Apple
+Events or TCC approval.
+
+**Rejected** because:
+
+- Undocumented schema. Things 3 updates have rewritten tables in
+  the past; the bridge would silently break on a Things 3 update.
+- Read-only only. We explicitly want writes (completing todos,
+  adding new items) as a future capability, and AppleScript is the
+  only supported write path.
+- Bypasses the user's TCC prompt, which is part of the intended
+  consent UX — the user should be able to revoke automation
+  permission to cut off the bridge.
+
+### Browser automation / a Things-web companion
+
+Doesn't exist — Things 3 is native macOS only.
+
+**Rejected.**
+
+## Decision
+
+Accept AppleScript as the production Things-3 transport and
+compensate for the trust concerns at the *boundary*, not the
+transport:
+
+1. The bridge itself contains no Things 3 logic. It treats its
+   configured `things_client_command` as a black box: fork a
+   subprocess per request, pass the call arguments on the command
+   line (`stdin` is closed), parse a JSON envelope on stdout (see
+   ADR 0003 — Split Things clients into sibling CLIs, which
+   supersedes ADR 0001's in-process fake).
+2. The production client is `things-client-cli-applescript`
+   (`src/things_client_applescript/`). It emits AppleScript to
+   `osascript`, parses the TSV output, and prints JSON on stdout.
+   It runs in its own process with no knowledge of agent-auth
+   tokens, HTTP, or the bridge's configuration.
+3. The test-only client is `python -m tests.things_client_fake`
+   (under `tests/things_client_fake/`). It reads fixtures from YAML
+   and emits the same JSON envelope. Used for Linux devcontainer
+   e2e and per-test Docker integration tests (ADR 0005).
+4. The shared argparse / JSON envelope plumbing lives in
+   `src/things_client_common/cli.py` so both clients stay wire-
+   compatible.
+
+The bridge is configured to point `things_client_command` at
+whichever client fits the host. Operators on macOS leave it at the
+default; Linux dev environments point it at the fake.
+
+## Consequences
+
+- The bridge's trust surface shrinks: a Things-3 API change, a TCC
+  prompt, or a misbehaving AppleScript runner stays confined to the
+  client subprocess. The bridge sees only a stdout JSON envelope
+  and an exit code.
+- The AppleScript client carries the macOS-only dependency. It
+  doesn't ship with the `agent-auth` wheel on Linux (it's a
+  separate entry point, guarded by platform checks at import time).
+- Subprocess overhead per request is acceptable for a tool running
+  at human-driven rates. Latency-sensitive batched reads (e.g.
+  `list_todos` on a large Things database) are mitigated at the
+  AppleScript layer via batching (see ADR 0002 — Batch AppleScript
+  property reads in `list_todos`).
+- Client swap-outs are a config change, not a code change: a future
+  "persistent AppleScript host" (to amortise the per-request
+  `osascript` startup) can ship as a sibling CLI without touching
+  the bridge.
+- The bridge never leaks subprocess stderr to HTTP callers —
+  stderr goes to the bridge's own logs (DESIGN.md error-response
+  table), so local paths and usernames don't cross the HTTP
+  boundary.
+- Real-Things-3 coverage via GitHub Actions' macOS runner is a
+  follow-up (tracked in ADR 0001's follow-ups list). Until then,
+  the AppleScript generator is covered by unit tests stubbing
+  `AppleScriptRunner.run()` with sample TSV; the HTTP/authz/config
+  chain is covered by the Docker integration suite against the
+  fake client.

--- a/design/decisions/README.md
+++ b/design/decisions/README.md
@@ -1,0 +1,43 @@
+# Architecture Decision Records
+
+Short records of the significant design decisions made on this project.
+Each ADR captures the forces behind a decision (Context), the decision
+itself, and its consequences, so the rationale survives beyond commit
+messages. See [`.claude/instructions/design.md`](../../.claude/instructions/design.md)
+for the standard that mandates them and
+[`TEMPLATE.md`](TEMPLATE.md) for the skeleton new ADRs should follow.
+
+The regression check in
+[`scripts/verify-standards.sh`](../../scripts/verify-standards.sh)
+enforces that every file in this directory (other than `README.md` and
+`TEMPLATE.md`) contains Context / Decision / Consequences sections and
+is linked from this index.
+
+## Index
+
+- [ADR 0001 — Client-level fake for things-bridge](0001-things-client-fake.md)
+  — superseded by 0003; kept for history.
+- [ADR 0002 — Batch AppleScript property reads in `list_todos`](0002-list-todos-batched-applescript.md)
+  — performance fix for unfiltered todo listing on a real Things 3 database.
+- [ADR 0003 — Split Things clients into sibling CLIs](0003-things-client-cli-split.md)
+  — production and fake Things clients ship as separate `things-client-cli-*` binaries.
+- [ADR 0004 — Docker-based HTTP integration tests](0004-docker-integration-tests.md)
+  — per-test Compose project driving `agent-auth` through its public HTTP surface.
+- [ADR 0005 — Per-service Docker integration tests for the things-\* surface](0005-things-services-docker-tests.md)
+  — extends the ADR 0004 pattern to `things-bridge`, `things-cli`, and `things-client-cli-applescript`.
+- [ADR 0006 — Token format](0006-token-format.md)
+  — `aa_<id>_<sig>` / `rt_<id>_<sig>` with HMAC-SHA256 over the typed ID.
+- [ADR 0007 — SQLite with field-level AES-256-GCM encryption](0007-sqlite-field-level-encryption.md)
+  — encrypt sensitive columns only; keep IDs and timestamps queryable.
+- [ADR 0008 — System keyring for signing and encryption keys](0008-system-keyring-for-key-material.md)
+  — key material lives in Keychain / libsecret, never on disk.
+- [ADR 0009 — CLI / server split with a single trust boundary](0009-cli-server-split.md)
+  — `agent-auth serve` owns the keyring; the CLI is a thin client.
+- [ADR 0010 — Three-tier scope model with JIT approval](0010-three-tier-scope-model.md)
+  — allow / prompt / deny tiers and a configurable approval plugin.
+- [ADR 0011 — Refresh-token reuse triggers family revocation](0011-refresh-token-reuse-family-revocation.md)
+  — single-use refresh tokens with reuse detection and a JIT re-issuance path.
+- [ADR 0012 — XDG path layout](0012-xdg-path-layout.md)
+  — config under `$XDG_CONFIG_HOME`, data under `$XDG_DATA_HOME`, state under `$XDG_STATE_HOME`.
+- [ADR 0013 — AppleScript-based Things bridge](0013-applescript-things-bridge.md)
+  — accept in-process AppleScript for now; out-of-process split is staged via the `ThingsClient` subprocess contract.

--- a/design/decisions/TEMPLATE.md
+++ b/design/decisions/TEMPLATE.md
@@ -1,0 +1,47 @@
+# ADR NNNN — Short, imperative title
+
+## Status
+
+Proposed | Accepted — YYYY-MM-DD | Superseded by ADR XXXX — YYYY-MM-DD.
+
+If this ADR supersedes or is superseded by another, name it here with a
+short note on which parts carry over.
+
+## Context
+
+What prompted the decision? Describe the forces at play — the problem,
+the constraints, the threat-model or standards pressure, the user-
+visible failure mode. Prefer a handful of short paragraphs over a long
+narrative. Link the issue or PR that raised the question where one
+exists.
+
+## Considered alternatives
+
+Optional but recommended for any non-obvious decision. One subsection
+per rejected option, each closing with the reason it was rejected.
+
+### Option name
+
+Short description of the alternative.
+
+**Rejected** because:
+
+- …
+
+## Decision
+
+The decision itself, stated clearly. One paragraph for the headline,
+plus any sub-decisions that fall out of it (e.g. names, file locations,
+APIs). Keep this short — detail belongs in `design/DESIGN.md`.
+
+## Consequences
+
+What changes because of this decision? Cover both positive and negative
+consequences, trade-offs accepted, and any new constraints imposed on
+future work. Call out known gaps or follow-up issues explicitly — an
+ADR that silently defers work is worse than one that doesn't mention
+the gap.
+
+## Follow-ups
+
+Optional. Link issues tracking work this ADR defers.

--- a/plans/design-assurance-adrs.md
+++ b/plans/design-assurance-adrs.md
@@ -1,0 +1,171 @@
+# Plan: ASSURANCE.md + ADR template, index, and backfill
+
+Issues: [#21](https://github.com/aidanns/agent-auth/issues/21),
+[#22](https://github.com/aidanns/agent-auth/issues/22).
+
+Source standard: `.claude/instructions/design.md` — *Architecture
+Decision Records* and *Quality management / safety integrity level*.
+
+## Goal
+
+Bring the `design/` directory up to the standards defined in
+`design.md`:
+
+1. Declare the project's QM level (ISO 9000-style) in
+   `design/ASSURANCE.md` with rationale and the required activities,
+   documentation, and evidence the implementation plans must verify
+   against.
+2. Add a committed ADR template and an index `README.md` to
+   `design/decisions/`.
+3. Backfill ADRs for every significant design decision already made
+   that is not yet captured in an ADR (token format, SQLite + field-
+   level AES-256-GCM encryption, system keyring for signing / encryption
+   keys, CLI/server split, three-tier scope model + JIT approval,
+   refresh-token reuse → family revocation, XDG path layout,
+   AppleScript-based Things bridge).
+4. Wire both into `scripts/verify-standards.sh` so regressions fail
+   CI rather than drifting.
+
+## Non-goals
+
+- Refactoring any of the existing ADRs (`0001`–`0005`). They already
+  follow the Context / Decision / Consequences shape the template
+  codifies; updating them is out of scope.
+- Selecting a cybersecurity standard — that's a separate follow-up
+  tracked under its own issue.
+- Populating `plans/` ADR-template sections beyond this one.
+- Introducing SIL-style (IEC 61508) evidence requirements. Per the
+  decision captured in `ASSURANCE.md`, agent-auth is not
+  safety-critical and adopts a QM-level posture.
+
+## Deliverables
+
+1. **`design/ASSURANCE.md`** — declares QM (ISO 9000-style) as the
+   project's assurance level, with rationale, required activities
+   (code review, testing, CI gating, audit logging, ADRs for
+   significant decisions), required documentation, and required
+   evidence (test artefacts, CI runs, ADR index, audit log
+   retention). Each implementation plan verifies conformance per
+   the existing `plan-template.md` step.
+2. **`design/decisions/README.md`** — index listing every ADR by
+   number, title, and one-line summary. Links each ADR file. Opens
+   with a short paragraph describing the directory's purpose and
+   pointing at the template.
+3. **`design/decisions/TEMPLATE.md`** — the ADR skeleton. Required
+   sections: Status, Context, Decision, Consequences. Optional
+   sections (Considered alternatives, Follow-ups) documented inline.
+   The template file itself is explicitly excluded from the
+   `Context`/`Decision`/`Consequences` gate (it's the skeleton, not
+   an ADR).
+4. **Eight new ADRs** in `design/decisions/`, numbered `0006` to
+   `0013`, each linked from the index:
+   - `0006-token-format.md` — `aa_<id>_<sig>` / `rt_<id>_<sig>` with
+     prefix-in-signature HMAC-SHA256.
+   - `0007-sqlite-field-level-encryption.md` — SQLite at XDG data
+     path with AES-256-GCM encryption of sensitive columns only.
+   - `0008-system-keyring-for-key-material.md` — signing and
+     encryption keys held in macOS Keychain / libsecret, never on
+     disk.
+   - `0009-cli-server-split.md` — CLI writes + server validates;
+     why agent-auth ships as two binaries sharing one process's
+     keyring.
+   - `0010-three-tier-scope-model.md` — allow / prompt / deny tiers
+     and the JIT approval plugin surface.
+   - `0011-refresh-token-reuse-family-revocation.md` — single-use
+     refresh tokens, reuse triggers family-wide revocation, re-issuance
+     path requires JIT approval.
+   - `0012-xdg-path-layout.md` — config at `$XDG_CONFIG_HOME`, data
+     (tokens.db) at `$XDG_DATA_HOME`, state (audit log) at
+     `$XDG_STATE_HOME`.
+   - `0013-applescript-things-bridge.md` — why the bridge talks to
+     Things 3 via `osascript` despite the in-process plugin caveat,
+     and the out-of-process migration boundary it sets up (see
+     `src/things_client_common/`).
+5. **`scripts/verify-standards.sh`** gains two new gates:
+   - **ADR gate** — iterate every file under `design/decisions/`
+     whose name is neither `README.md` nor `TEMPLATE.md`, assert each
+     contains `## Context`, `## Decision`, and `## Consequences`
+     sections (case-insensitive header match anchored to start of
+     line), and assert each is linked from `design/decisions/README.md`
+     (link target matches the filename).
+   - **ASSURANCE gate** — assert `design/ASSURANCE.md` exists and
+     contains at least one of `QM` / `SIL` as a declared level plus
+     headings for required activities and evidence (`## Required activities`, `## Required evidence`).
+
+`CHANGELOG.md` does not yet exist in the repo; bootstrapping it is
+out of scope for this PR and tracked as
+[#98](https://github.com/aidanns/agent-auth/issues/98) (see
+Follow-ups).
+
+## Approach
+
+**ADR template first.** Write `TEMPLATE.md` with the required
+sections, then the index `README.md` with an entry per existing ADR
+(`0001`–`0005`) so the gate is green before the new ADRs land.
+
+**Backfill second.** Work through the eight backfills in deliverable
+order. Each ADR records the decision as made *today* (present-tense
+Status: `Accepted — 2026-04-19`), with a Context paragraph summarising
+what prompted the decision (e.g. "threat model required signing key
+never touch disk"), the Decision itself (one-paragraph summary), and
+Consequences (trade-offs accepted, known gaps, follow-up issues).
+Cross-reference `design/DESIGN.md` sections where the decision is
+already documented to keep ADRs concise.
+
+**ASSURANCE.md third.** The QM declaration names the required
+activities (code review, ADRs for significant decisions, testing
+coverage thresholds, CI gating, audit logging, threat model in
+`SECURITY.md`), required documentation (DESIGN.md, ADRs, SECURITY.md,
+plans for each change), and required evidence (CI runs green, test
+artefacts, ADR index complete, audit-log retention). It closes with a
+pointer to `.claude/instructions/plan-template.md` "Verify QM / SIL
+compliance" as the per-change checkpoint.
+
+**Gates last.** Add the two regression checks to
+`scripts/verify-standards.sh`. Run `task verify-standards` locally to
+confirm a green baseline; temporarily introduce a violation (strip a
+Consequences heading, remove an index entry, rename `ASSURANCE.md`)
+and confirm each gate fails with a clear message before reverting.
+
+## Design and verification
+
+- **Verify implementation against design doc** — cross-check each
+  backfilled ADR against the corresponding section of `design/DESIGN.md`
+  to catch drift. If any ADR records a decision the code no longer
+  matches, update the ADR (or the code) before landing.
+- **Threat model** — no new security-relevant behaviour introduced;
+  `SECURITY.md` is not touched by this change. Skip.
+- **Architecture Decision Records** — the change *is* the ADR
+  backfill. Each new decision gets its own file.
+- **Cybersecurity standard compliance** — selecting the standard is
+  an explicit non-goal (tracked separately). Skip.
+- **Verify QM / SIL compliance** — the change adds the QM declaration
+  itself; conformance check is "does this PR match the declaration".
+  Validate by walking the Required-activities list in ASSURANCE.md
+  against this PR: ADRs written (yes), tests (not applicable — docs
+  only), CI gating (yes — new regression checks), audit logging
+  (unaffected).
+
+## Post-implementation standards review
+
+- **Coding standards** — docs only. No code changes beyond
+  `scripts/verify-standards.sh`. Verify the new gates use the existing
+  `strip_comments` helper and the same `fail_*_check` pattern as the
+  neighbouring checks.
+- **Service design standards** — docs only. Skip.
+- **Release and hygiene** — add CHANGELOG entry. No pinned schema
+  changes; no versioning impact.
+- **Testing standards** — no test files touched. The new
+  `verify-standards.sh` gates are exercised by the existing
+  `verify-standards` task, which runs in CI.
+- **Tooling and CI standards** — new gates run under `task verify-standards`, already wired into CI via `task check`.
+
+## Follow-ups
+
+- Bootstrap `CHANGELOG.md` at the repo root —
+  [#98](https://github.com/aidanns/agent-auth/issues/98).
+- Cybersecurity standard selection (ISM / NIST SP 800-53) — separate
+  issue.
+- If future ADRs start covering decisions that span multiple files,
+  consider adding a `supersedes` / `superseded by` cross-reference
+  convention (already used informally by ADR 0003 → 0001).

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -32,6 +32,14 @@
 #   7. CONTRIBUTING.md exists at repo root and contains dev-setup, testing,
 #      release, and commit-signing sections per
 #      .claude/instructions/release-and-hygiene.md.
+#   8. Every file under design/decisions/ (other than README.md and
+#      TEMPLATE.md) contains Context / Decision / Consequences sections
+#      and is linked from design/decisions/README.md, per
+#      .claude/instructions/design.md "Architecture Decision Records".
+#   9. design/ASSURANCE.md exists, declares a QM or SIL level, and lists
+#      the required activities and evidence for that level, per
+#      .claude/instructions/design.md "Quality management / safety
+#      integrity level".
 
 set -euo pipefail
 
@@ -384,3 +392,112 @@ if [[ ${contributing_missing} -ne 0 ]]; then
 fi
 
 echo "verify-standards: CONTRIBUTING.md exists with dev-setup, testing, release, and commit-signing sections."
+
+# ADR discipline per .claude/instructions/design.md. Every file under
+# design/decisions/ other than README.md / TEMPLATE.md must:
+#   - contain ## Context, ## Decision, and ## Consequences sections
+#     (case-insensitive, anchored to start of line),
+#   - be linked from design/decisions/README.md (filename appears as a
+#     markdown link target).
+
+adr_missing=0
+
+fail_adr_check() {
+  echo "verify-standards: $1" >&2
+  echo "  $2" >&2
+  adr_missing=1
+}
+
+ADR_DIR="design/decisions"
+ADR_INDEX="${ADR_DIR}/README.md"
+
+if [[ ! -d "${ADR_DIR}" ]]; then
+  fail_adr_check \
+    "${ADR_DIR}/ is missing." \
+    "Create ${ADR_DIR}/ with README.md, TEMPLATE.md, and at least one ADR."
+elif [[ ! -f "${ADR_INDEX}" ]]; then
+  fail_adr_check \
+    "${ADR_INDEX} is missing." \
+    "Create ${ADR_INDEX} listing every ADR by filename link."
+else
+  index_content="$(cat "${ADR_INDEX}")"
+  while IFS= read -r adr; do
+    [[ -f "${adr}" ]] || continue
+    base="$(basename "${adr}")"
+    [[ "${base}" == "README.md" || "${base}" == "TEMPLATE.md" ]] && continue
+
+    # strip_comments eats Markdown headings (they start with `#`), so the
+    # ADR gate reads the raw file. The required sections are unambiguous
+    # — no code-block fencing concern inside an ADR section heading.
+    for section in Context Decision Consequences; do
+      if ! grep -qiE "^##[[:space:]]+${section}([[:space:]]|$)" "${adr}"; then
+        fail_adr_check \
+          "${adr} is missing a '## ${section}' section." \
+          "Add a '## ${section}' heading (see ${ADR_DIR}/TEMPLATE.md)."
+      fi
+    done
+
+    # Match as a Markdown link target `](filename)` rather than a bare
+    # substring so a filename mentioned in prose doesn't spuriously
+    # satisfy the check, and a filename that happens to be a suffix of
+    # another entry can't substring-match it.
+    escaped_base="${base//./\\.}"
+    if ! grep -qE "\]\(${escaped_base}\)" <<<"${index_content}"; then
+      fail_adr_check \
+        "${adr} is not linked from ${ADR_INDEX}." \
+        "Add an entry to ${ADR_INDEX} with a Markdown link to ${base}."
+    fi
+  done < <(find "${ADR_DIR}" -type f -name '*.md' -print)
+fi
+
+if [[ ${adr_missing} -ne 0 ]]; then
+  exit 1
+fi
+
+echo "verify-standards: ADRs under ${ADR_DIR}/ all have Context/Decision/Consequences sections and are linked from ${ADR_INDEX}."
+
+# QM / SIL declaration per .claude/instructions/design.md. design/ASSURANCE.md
+# must exist, declare at least one of QM / SIL, and list required activities
+# and evidence.
+
+assurance_missing=0
+
+fail_assurance_check() {
+  echo "verify-standards: $1" >&2
+  echo "  $2" >&2
+  assurance_missing=1
+}
+
+ASSURANCE_FILE="design/ASSURANCE.md"
+
+if [[ ! -f "${ASSURANCE_FILE}" ]]; then
+  fail_assurance_check \
+    "${ASSURANCE_FILE} is missing." \
+    "Create ${ASSURANCE_FILE} declaring a QM (ISO 9000) or SIL (IEC 61508) level."
+else
+  # strip_comments eats Markdown headings (they start with `#`), so the
+  # ASSURANCE gate reads the raw file.
+  if ! grep -qE "\\b(QM|SIL)\\b" "${ASSURANCE_FILE}"; then
+    fail_assurance_check \
+      "${ASSURANCE_FILE} does not declare a QM or SIL level." \
+      "Name the chosen level (QM or SIL N) in a top-level heading or paragraph."
+  fi
+
+  if ! grep -qiE "^##[[:space:]]+Required activities" "${ASSURANCE_FILE}"; then
+    fail_assurance_check \
+      "${ASSURANCE_FILE} is missing a '## Required activities' section." \
+      "List the activities required by the declared level."
+  fi
+
+  if ! grep -qiE "^##[[:space:]]+Required evidence" "${ASSURANCE_FILE}"; then
+    fail_assurance_check \
+      "${ASSURANCE_FILE} is missing a '## Required evidence' section." \
+      "List the evidence that demonstrates conformance to the declared level."
+  fi
+fi
+
+if [[ ${assurance_missing} -ne 0 ]]; then
+  exit 1
+fi
+
+echo "verify-standards: ${ASSURANCE_FILE} declares a QM/SIL level with required activities and evidence."


### PR DESCRIPTION
## Summary

- Declare QM (ISO 9000-style) as the project's assurance level in `design/ASSURANCE.md` with rationale, required activities, required documentation, and required evidence.
- Add a committed ADR template (`design/decisions/TEMPLATE.md`) and an index `README.md` linking every ADR.
- Backfill 8 ADRs (`0006`–`0013`) covering decisions already implemented but not yet captured: token format, SQLite field-level encryption, system keyring for key material, CLI/server split, three-tier scope + JIT approval, refresh-token reuse → family revocation, XDG path layout, AppleScript Things bridge.
- Wire two regression gates into `scripts/verify-standards.sh` — ADR structure (Context/Decision/Consequences + index linkage) and ASSURANCE.md declaration — so regressions fail CI rather than drifting.

Closes #21. Closes #22.

Follow-up: CHANGELOG.md bootstrapping tracked as #98.

## Test plan

- [ ] `task verify-standards` passes locally (exercises both new gates).
- [ ] `task check` passes locally (lint + format + integration isolation checks).
- [ ] Sabotage test: temporarily strip `## Consequences` heading from one ADR and confirm the ADR gate fails with a clear message; revert.
- [ ] Sabotage test: temporarily remove an index link for one ADR and confirm the linkage gate fails; revert.
- [ ] Sabotage test: temporarily rename `design/ASSURANCE.md` and confirm the ASSURANCE gate fails; revert.
- [ ] CI (`check`, `pip-audit`, `verify-standards`, ...) green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)