### PR TITLE
chore: prepare release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,5 +37,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so a detected major bump is demoted to a minor bump; pass an explicit
   `task release -- 1.0.0` to graduate.
 
-[unreleased]: https://github.com/aidanns/agent-auth/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/aidanns/agent-auth/releases/tag/v0.1.0
+[unreleased]: https://github.com/aidanns/agent-auth/compare/v0.1.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-04-19
+
 ### Added
 
 - **agent-auth server and CLI** — HTTP validation server (`agent-auth serve`) with full
@@ -35,4 +37,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so a detected major bump is demoted to a minor bump; pass an explicit
   `task release -- 1.0.0` to graduate.
 
-[unreleased]: https://github.com/aidanns/agent-auth/compare/HEAD
+[unreleased]: https://github.com/aidanns/agent-auth/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/aidanns/agent-auth/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

- Move the `## [Unreleased]` entries in `CHANGELOG.md` into a dated `## [0.1.0] - 2026-04-19` section per the release process in `CONTRIBUTING.md`.
- Leave a fresh empty `## [Unreleased]` header above it so subsequent user-facing PRs have somewhere to land.
- Update the compare links: `[unreleased]` now diffs against `v0.1.0`; `[0.1.0]` links to the release tag.

This is the first release, so `task release` cannot auto-detect (no prior `v*` tag). After this PR merges, cut the tag with `task release -- 0.1.0` on `main`.

## Test plan

- [x] `CHANGELOG.md` has a `## [0.1.0] - 2026-04-19` section containing the original Unreleased bullets, with a fresh empty `## [Unreleased]` above it.
- [x] Compare links at the bottom resolve: `[unreleased]` → `compare/v0.1.0...HEAD`, `[0.1.0]` → `releases/tag/v0.1.0`.
- [x] After merge, `scripts/release.sh 0.1.0` extracts the non-empty `## [0.1.0]` section body (dry-run mentally by reading the awk in `scripts/release.sh:141-147`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)