### PR TITLE
feat(release): add --yes flag and document non-interactive signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,5 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tag is in the `0.x` range the API is not considered stable (SemVer 2.0.0 §4),
   so a detected major bump is demoted to a minor bump; pass an explicit
   `task release -- 1.0.0` to graduate.
+- **`task release -- -y` skips the confirmation prompt** so the release can
+  run hands-off (e.g. `task release -- -y 1.2.3`). The signed-tag step still
+  needs your signing key; see `CONTRIBUTING.md` § "Non-interactive signing
+  for `task release`" for gpg-agent / ssh-agent pre-warm instructions.
 
 [unreleased]: https://github.com/aidanns/agent-auth/compare/HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,8 @@ which:
 2. Validates the working tree is clean and local `main` matches `origin/main`.
 3. Checks that `CHANGELOG.md` contains a `## [X.Y.Z]` section with content for
    the resolved version.
-4. Prompts for confirmation, then creates a signed git tag (`vX.Y.Z`).
+4. Prompts for confirmation (pass `-y` / `--yes` to skip), then creates a
+   signed git tag (`vX.Y.Z`).
 5. Pushes the tag to `origin`.
 6. Creates a GitHub release from the CHANGELOG entry for that version.
 
@@ -127,6 +128,10 @@ To cut a release:
 2. Leave a fresh empty `## [Unreleased]` section above the new version.
 3. Commit and push: `git commit -m "chore: prepare release vX.Y.Z"`.
 4. Run `task release` (auto-detect) or `task release -- X.Y.Z` (explicit).
+   Add `-y` / `--yes` to skip the confirmation prompt
+   (e.g. `task release -- -y X.Y.Z`) when you want a hands-off run — the
+   signed-tag step still needs your signing key, so pre-warm `gpg-agent`
+   or `ssh-agent` first (see [Commit signing](#commit-signing)).
 
 The version string embedded in the distributed package is derived from the git
 tag at build time via `setuptools-scm`; no other version file needs updating.
@@ -152,4 +157,40 @@ Verify signing is working:
 
 ```bash
 git log --show-signature -1
+```
+
+### Non-interactive signing for `task release`
+
+`scripts/release.sh` creates a signed tag (`git tag -s`). If your signing
+key has a passphrase, the tag step pops a pinentry prompt — which blocks
+`task release -- -y` from running hands-off. Configure the agent so the
+passphrase is cached for the duration of the release.
+
+**GPG:** put a cache policy in `~/.gnupg/gpg-agent.conf` and pick a
+pinentry that doesn't require a graphical session if you're on a headless
+box:
+
+```text
+# ~/.gnupg/gpg-agent.conf
+default-cache-ttl 28800          # cache for 8 hours
+max-cache-ttl     86400          # but at most 24 hours
+pinentry-program  /usr/bin/pinentry-curses   # or pinentry-mac on macOS
+```
+
+Reload the agent and pre-warm the cache with a throwaway signature before
+running the release:
+
+```bash
+gpgconf --kill gpg-agent
+echo | gpg --clearsign > /dev/null   # enter passphrase once
+task release -- -y X.Y.Z             # runs hands-off from here
+```
+
+**SSH:** if signing with an SSH key, load it into `ssh-agent` once per
+session so `git tag -s` doesn't prompt:
+
+```bash
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519            # passphrase prompted once
+task release -- -y X.Y.Z
 ```

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,9 +6,10 @@
 # running. Version string is derived from VCS tags at build time via
 # setuptools-scm; this script creates the authoritative tag.
 #
-# Usage: scripts/release.sh [<version>]
+# Usage: scripts/release.sh [-y|--yes] [<version>]
 #   scripts/release.sh            # auto-detect from conventional commits since last tag
 #   scripts/release.sh 1.2.3      # override with an explicit version
+#   scripts/release.sh -y         # skip the "Proceed?" confirmation prompt
 #
 # When no version is passed, the next version is computed from the commits
 # between the latest v* tag and HEAD using Conventional Commits + SemVer:
@@ -34,10 +35,43 @@ source "${SCRIPT_DIR}/lib/semver.sh"
 
 cd "${REPO_ROOT}"
 
+usage() {
+  cat <<'EOF' >&2
+Usage: scripts/release.sh [-y|--yes] [<version>]
+  scripts/release.sh            # auto-detect from conventional commits
+  scripts/release.sh 1.2.3      # override with an explicit version
+  scripts/release.sh -y         # skip the "Proceed?" confirmation prompt
+EOF
+}
+
+ASSUME_YES=0
+while [[ $# -gt 0 ]]; do
+  case "${1}" in
+    -y | --yes)
+      ASSUME_YES=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "release: unknown flag '${1}'" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 if [[ $# -gt 1 ]]; then
-  echo "Usage: scripts/release.sh [<version>]" >&2
-  echo "  scripts/release.sh            # auto-detect from conventional commits" >&2
-  echo "  scripts/release.sh 1.2.3      # override with an explicit version" >&2
+  usage
   exit 1
 fi
 
@@ -163,10 +197,14 @@ echo "------------------------------------------------------------------------"
 echo "${changelog_body}"
 echo "------------------------------------------------------------------------"
 echo ""
-read -r -p "Proceed? [y/N] " confirm
-if [[ "${confirm}" != "y" && "${confirm}" != "Y" ]]; then
-  echo "release: aborted." >&2
-  exit 1
+if [[ "${ASSUME_YES}" -eq 1 ]]; then
+  echo "--yes supplied; skipping confirmation."
+else
+  read -r -p "Proceed? [y/N] " confirm
+  if [[ "${confirm}" != "y" && "${confirm}" != "Y" ]]; then
+    echo "release: aborted." >&2
+    exit 1
+  fi
 fi
 
 echo "Creating tag ${TAG} ..."


### PR DESCRIPTION
## Summary

- Add `-y` / `--yes` to `scripts/release.sh` that bypasses the "Proceed? [y/N]" confirmation so `task release -- -y X.Y.Z` can run hands-off.
- Document the flag in `CONTRIBUTING.md` and add a new "Non-interactive signing for `task release`" subsection with pre-warm instructions for `gpg-agent` (cache-ttl + pinentry) and `ssh-agent` (`ssh-add`). The signed-tag step still needs a signing key — pre-warming the agent is the lowest-risk way to avoid the pinentry popping mid-release.
- CHANGELOG entry under Unreleased.

Follow-up to #122 (first release prep).

## Test plan

- [ ] `scripts/release.sh --help` prints usage including the `-y` flag and exits 0.
- [ ] `scripts/release.sh --bogus` rejects unknown flags with exit 1 and prints usage.
- [ ] `scripts/release.sh 1 2` rejects more than one positional with exit 1.
- [ ] Flag order works: `scripts/release.sh -y 0.0.1` and `scripts/release.sh --yes 0.0.1` are both accepted by the flag parser (smoke-tested via `bash -n` + the help/error paths).
- [ ] `task check` passes (lint, format, verify-integration-isolation).
- [ ] CHANGELOG.md entry appears under `## [Unreleased]` → `### Changed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)