### PR TITLE
docs(community): complete GitHub Community Profile

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -10,19 +10,19 @@ We pledge to act and interact in ways that contribute to an open, welcoming, div
 
 Examples of behavior that contributes to a positive environment for our community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall community
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Enforcement Responsibilities
 
@@ -72,12 +72,12 @@ Community leaders will follow these Community Impact Guidelines in determining t
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][mozilla coc].
 
-For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][faq]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
 
+[faq]: https://www.contributor-covenant.org/faq
 [homepage]: https://www.contributor-covenant.org
-[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/diversity
-[FAQ]: https://www.contributor-covenant.org/faq
+[mozilla coc]: https://github.com/mozilla/diversity
 [translations]: https://www.contributor-covenant.org/translations
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,83 +1,54 @@
-# Contributor Covenant Code of Conduct
+# Code of Conduct
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+We pledge to make our community welcoming, safe, and equitable for all.
 
-We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of everyone.
 
-## Our Standards
+## Encouraged Behaviors
 
-Examples of behavior that contributes to a positive environment for our community include:
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
 
-- Demonstrating empathy and kindness toward other people
-- Being respectful of differing opinions, viewpoints, and experiences
-- Giving and gracefully accepting constructive feedback
-- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
-- Focusing on what is best not just for us as individuals, but for the overall community
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
 
-Examples of unacceptable behavior include:
+1. Engaging **respectfully and honestly** with others.
+2. Respecting **different viewpoints** and experiences.
+3. **Taking responsibility** for our actions and contributions.
+4. Gracefully giving and accepting **constructive feedback**.
+5. Committing to **repairing harm** when it occurs.
+6. Behaving in other ways that promote and sustain the **well-being of our community**.
 
-- The use of sexualized language or imagery, and sexual attention or advances of any kind
-- Trolling, insulting or derogatory comments, and personal or political attacks
-- Public or private harassment
-- Publishing others' private information, such as a physical or email address, without their explicit permission
-- Other conduct which could reasonably be considered inappropriate in a professional setting
+## Discouraged Behaviors
 
-## Enforcement Responsibilities
+We agree to discourage the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
 
-Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+1. **Harassment.** Offensive, humiliating, or intimidating behavior that continues after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or harm toward any person or group.
+7. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+8. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+9. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
 
-Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+## Reporting an Issue
+
+When a violation of the Code of Conduct occurs, it is important to report it promptly. To report a possible violation, please email aidanns@gmail.com.
+
+## Addressing and Repairing Harm
+
+Code of Conduct violations will be addressed with either a Warning or a Ban, depending on the severity of the violation and an assessment of the liklihood of future violations.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
-
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at aidanns@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
-
-All community leaders are obligated to respect the privacy and security of the reporter of any incident.
-
-## Enforcement Guidelines
-
-Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
-
-### 1. Correction
-
-**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
-
-**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
-
-### 2. Warning
-
-**Community Impact**: A violation through a single incident or series of actions.
-
-**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
-
-### 3. Temporary Ban
-
-**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
-
-**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
-
-### 4. Permanent Ban
-
-**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
-
-**Consequence**: A permanent ban from any sort of public interaction within the community.
+This Code of Conduct applies within all community spaces, and also applied to individuals that are officially representing the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][mozilla coc].
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
 
-For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][faq]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
-
-[faq]: https://www.contributor-covenant.org/faq
-[homepage]: https://www.contributor-covenant.org
-[mozilla coc]: https://github.com/mozilla/diversity
-[translations]: https://www.contributor-covenant.org/translations
-[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at aidanns@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Report something that doesn't work the way the docs or CLI say it should.
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. For security vulnerabilities, see
+        [SECURITY.md](https://github.com/aidanns/agent-auth/blob/main/SECURITY.md) —
+        do not file publicly.
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `agent-auth --version` (or the commit SHA for a source checkout).
+      placeholder: e.g. 0.1.0 or 0f3fe31
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      description: OS + architecture (e.g. macOS 14.4 arm64, Ubuntu 22.04 x86_64, devcontainer).
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Exact commands or HTTP requests that trigger the bug, in order.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the full error message and stack trace if any.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Logs, config, screenshots — anything else that helps.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/aidanns/agent-auth/security/advisories/new
+    about: Report privately via GitHub Security. See SECURITY.md.
+  - name: Questions and usage help
+    url: https://github.com/aidanns/agent-auth/blob/main/.github/SUPPORT.md
+    about: See SUPPORT.md for where to ask questions and file bugs.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Propose a new capability or a change to existing behaviour.
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that isn't currently possible or is awkward?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What should the CLI, API, or config do instead?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you tried, or other designs you rejected and why.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to related issues, prior discussions, or external references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Summary
+
+<!-- 1-3 bullets describing what changes and why. Link related issues with `Closes #<n>` where applicable. -->
+
+## Test plan
+
+<!-- Checklist of verification steps the reviewer can re-run. Prefer concrete task commands (e.g. `task check`, `task test`) over prose. -->

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,22 @@
+# Support
+
+agent-auth is a personal project maintained by a single author. Support is
+best-effort.
+
+## Questions, usage help, and bug reports
+
+- Search existing [issues](https://github.com/aidanns/agent-auth/issues) first.
+- If nothing matches, open a
+  [new issue](https://github.com/aidanns/agent-auth/issues/new/choose) using
+  the **Bug report** or **Feature request** template — whichever is closer.
+  Include the version (`agent-auth --version`) and the exact command that
+  reproduces the problem.
+
+## Security vulnerabilities
+
+See [`SECURITY.md`](../SECURITY.md). Do not file public issues for security
+reports.
+
+## Code of Conduct
+
+Participation is governed by the project [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Community-health files to complete the GitHub Community Profile: Contributor
+  Covenant v2.1 Code of Conduct, issue templates (bug report, feature request,
+  security redirect), pull-request template, and SUPPORT.md. CoC and SUPPORT
+  are referenced from `README.md` and `CONTRIBUTING.md`.
+
 ## [0.1.0] - 2026-04-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Community-health files to complete the GitHub Community Profile: Contributor
-  Covenant v2.1 Code of Conduct, issue templates (bug report, feature request,
+  Covenant v3.0 Code of Conduct, issue templates (bug report, feature request,
   security redirect), pull-request template, and SUPPORT.md. CoC and SUPPORT
   are referenced from `README.md` and `CONTRIBUTING.md`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,10 @@
 # Contributing
 
+Participation in this project — issues, pull requests, discussions — is
+governed by the [Code of Conduct](.github/CODE_OF_CONDUCT.md). See
+[SECURITY.md](SECURITY.md) for vulnerability reporting and
+[SUPPORT.md](.github/SUPPORT.md) for where to ask questions or file bugs.
+
 ## Dev setup
 
 01. Install [uv](https://docs.astral.sh/uv/) — the project's canonical

--- a/README.md
+++ b/README.md
@@ -248,6 +248,15 @@ See [SECURITY.md](SECURITY.md) for the full threat model, trust boundaries, key
 handling, revocation flow, audit surface, vulnerability reporting, and the chosen
 cybersecurity standard (NIST SP 800-53 Rev 5).
 
+## Contributing
+
+Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup,
+task runner usage, commit conventions, and the release process. Participation
+is governed by the project
+[Code of Conduct](.github/CODE_OF_CONDUCT.md).
+[SUPPORT.md](.github/SUPPORT.md) covers where to ask questions, file bugs, and
+report vulnerabilities.
+
 ## License
 
 [MIT](LICENSE.md)


### PR DESCRIPTION
## Summary

- Add the community-health files GitHub's Community Profile checks for so the repo reads as 100% complete (was 71% — missing CoC, issue templates, PR template).
- `.github/CODE_OF_CONDUCT.md` — Contributor Covenant v2.1 verbatim, with `aidanns@gmail.com` as the CoC enforcement contact. Kept distinct from the private vulnerability reporting channel in `SECURITY.md`.
- `.github/ISSUE_TEMPLATE/{bug_report.yml,feature_request.yml,config.yml}` — issue forms plus a chooser config that disables blank issues and routes security reports to `SECURITY.md` / private advisories and general questions to `SUPPORT.md`.
- `.github/PULL_REQUEST_TEMPLATE.md` — Summary + Test plan prompts matching the conventions used by recent PRs.
- `.github/SUPPORT.md` — where to ask questions, file bugs, and report vulnerabilities.
- `README.md` and `CONTRIBUTING.md` reference the CoC and SUPPORT files. CHANGELOG entry added under `[Unreleased]`.

CODEOWNERS is intentionally omitted — the Community Profile doesn't require it and the project is single-maintainer, as noted in #120.

Closes #121. Closes #120.

## Test plan

- [x] `task format -- --check` passes.
- [x] `task lint` passes.
- [x] `task verify-standards` passes.
- [ ] `gh api repos/aidanns/agent-auth/community/profile --jq .health_percentage` returns `100` after merge.
- [ ] Relative links resolve: `README.md` → `.github/CODE_OF_CONDUCT.md`, `.github/SUPPORT.md`, `CONTRIBUTING.md`; `CONTRIBUTING.md` → `.github/CODE_OF_CONDUCT.md`, `SECURITY.md`, `.github/SUPPORT.md`; `.github/SUPPORT.md` → `../SECURITY.md`, `CODE_OF_CONDUCT.md`.
- [ ] GitHub renders the CoC on the repo Community tab and the issue chooser shows Bug report / Feature request plus the Security and Questions contact links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)