### PR TITLE
feat: migrate config to YAML, version APIs at /v1/, and add error/audit contract tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ config, and images built inside DinD are not visible to the host
 `docker` CLI.
 
 The integration-test fixture chmods the bind-mounted config directory
-to `0755` and `config.json` to `0644` so the container user (UID 1001,
+to `0755` and `config.yaml` to `0644` so the container user (UID 1001,
 see `docker/Dockerfile.test`) can read it regardless of the host
 tmpdir's default mode or the host runner's UID.
 

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -55,15 +55,15 @@ The subprocess contract is stable and publicly documented so the bridge can adop
 
 Read-only endpoints. Read endpoints require the `things:read` scope; the health endpoint requires `things-bridge:health` (mirroring the agent-auth health pattern — see `GET /agent-auth/health` below).
 
-| Method | Path                                                     | Scope                  | Description                                   |
-| ------ | -------------------------------------------------------- | ---------------------- | --------------------------------------------- |
-| GET    | `/things-bridge/todos?list=&project=&area=&tag=&status=` | `things:read`          | List todos, optionally filtered               |
-| GET    | `/things-bridge/todos/{id}`                              | `things:read`          | Fetch one todo by Things id                   |
-| GET    | `/things-bridge/projects?area=`                          | `things:read`          | List projects, optionally filtered by area id |
-| GET    | `/things-bridge/projects/{id}`                           | `things:read`          | Fetch one project by Things id                |
-| GET    | `/things-bridge/areas`                                   | `things:read`          | List all areas                                |
-| GET    | `/things-bridge/areas/{id}`                              | `things:read`          | Fetch one area by Things id                   |
-| GET    | `/things-bridge/health`                                  | `things-bridge:health` | Liveness / readiness probe                    |
+| Method | Path                                                        | Scope                  | Description                                   |
+| ------ | ----------------------------------------------------------- | ---------------------- | --------------------------------------------- |
+| GET    | `/things-bridge/v1/todos?list=&project=&area=&tag=&status=` | `things:read`          | List todos, optionally filtered               |
+| GET    | `/things-bridge/v1/todos/{id}`                              | `things:read`          | Fetch one todo by Things id                   |
+| GET    | `/things-bridge/v1/projects?area=`                          | `things:read`          | List projects, optionally filtered by area id |
+| GET    | `/things-bridge/v1/projects/{id}`                           | `things:read`          | Fetch one project by Things id                |
+| GET    | `/things-bridge/v1/areas`                                   | `things:read`          | List all areas                                |
+| GET    | `/things-bridge/v1/areas/{id}`                              | `things:read`          | Fetch one area by Things id                   |
+| GET    | `/things-bridge/health`                                     | `things-bridge:health` | Liveness / readiness probe                    |
 
 Error responses from the bridge:
 
@@ -150,7 +150,7 @@ Both tokens are displayed once. The user configures the CLI client with these cr
 **Refresh:**
 
 ```
-POST /agent-auth/token/refresh
+POST /agent-auth/v1/token/refresh
 {"refresh_token": "rt_xxx_yyy"}
 → old refresh token revoked
 ← {"access_token": "aa_zzz_www", "refresh_token": "rt_zzz_www", "expires_in": 900}
@@ -189,7 +189,7 @@ agent-auth token revoke <token-id>
 When a CLI attempts to refresh and receives a `refresh_token_expired` error, it can request re-issuance of a new token pair for the same token family. This requires JIT approval from the user on the host.
 
 ```
-POST /agent-auth/token/reissue
+POST /agent-auth/v1/token/reissue
 {"family_id": "fff"}
 ← blocks — agent-auth triggers JIT approval via configured notification plugin
 ← {"access_token": "aa_zzz_www", "refresh_token": "rt_zzz_www", "expires_in": 900}
@@ -289,7 +289,7 @@ app-cli inbox
     Authorization: Bearer aa_xxx_yyy
 
   app-bridge:
-    → POST http://localhost:9100/agent-auth/validate
+    → POST http://localhost:9100/agent-auth/v1/validate
       {"token": "aa_xxx_yyy", "required_scope": "app:read"}
     ← {"valid": true, "tier": "allow"}
     → interacts with external system
@@ -305,7 +305,7 @@ app-cli inbox
   ← 401 Unauthorized
 
   app-cli:
-    → POST http://host:9100/agent-auth/token/refresh
+    → POST http://host:9100/agent-auth/v1/token/refresh
       {"refresh_token": "rt_xxx_yyy"}
     ← {"access_token": "aa_zzz_www", "refresh_token": "rt_zzz_www", "expires_in": 900}
     → saves new credentials
@@ -324,11 +324,11 @@ app-cli inbox
   ← 401 Unauthorized
 
   app-cli:
-    → POST http://host:9100/agent-auth/token/refresh
+    → POST http://host:9100/agent-auth/v1/token/refresh
       {"refresh_token": "rt_xxx_yyy"}
     ← 401 {"error": "refresh_token_expired"}
 
-    → POST http://host:9100/agent-auth/token/reissue
+    → POST http://host:9100/agent-auth/v1/token/reissue
       {"family_id": "fff"}
     ← blocks — agent-auth triggers JIT approval on the host
     ← {"access_token": "aa_zzz_www", "refresh_token": "rt_zzz_www", "expires_in": 900}
@@ -347,7 +347,7 @@ app-cli complete <id>
     Authorization: Bearer aa_xxx_yyy
 
   app-bridge:
-    → POST http://localhost:9100/agent-auth/validate
+    → POST http://localhost:9100/agent-auth/v1/validate
       {"token": "aa_xxx_yyy", "required_scope": "app:write", "description": "Complete todo: Buy milk"}
     ← blocks — agent-auth triggers notification via configured plugin and waits for user response
     ← {"valid": true}
@@ -391,11 +391,44 @@ Encrypted columns are marked with (E) in the table definitions below.
 
 Approval grants are held in memory on the agent-auth server (see the approval flow above) and have no persistent table.
 
+## API Versioning Policy
+
+All HTTP endpoints (both agent-auth and things-bridge) are versioned under a
+`/v1/` path segment. This allows breaking changes to be introduced under `/v2/`
+while existing clients continue to use `/v1/`.
+
+Health endpoints (`/agent-auth/health`, `/things-bridge/health`) are unversioned
+by convention — probes and monitoring tools should always be able to reach them
+regardless of API version.
+
+**What constitutes a breaking change (requires `/v2/`):**
+
+- Removing a field from a response body
+- Renaming a field or error code
+- Changing the meaning of a status code or field value
+- Removing an endpoint
+
+**Non-breaking changes (stay on current version):**
+
+- Adding new optional request fields
+- Adding new response fields (clients must ignore unknown fields)
+- Adding new endpoints
+- Adding new error codes
+
+**Deprecation window:** When a breaking change is required, the old version
+remains supported for 30 days before removal. The deprecation is announced
+via changelog and a `Sunset` response header.
+
+Error codes and audit-log event schemas are also part of the public API
+surface; see `design/error-codes.md` for the full error taxonomy.
+
 ## agent-auth HTTP API
 
-All endpoints are prefixed with `/agent-auth/` to allow hosting behind a shared reverse proxy alongside bridge servers.
+All endpoints are prefixed with `/agent-auth/v1/` to allow hosting behind a
+shared reverse proxy alongside bridge servers. The health endpoint is unversioned
+(see versioning policy above).
 
-### POST /agent-auth/validate
+### POST /agent-auth/v1/validate
 
 Validate a token and check scope authorization.
 
@@ -431,7 +464,7 @@ Response (403 — scope denied or JIT approval denied):
 {"valid": false, "error": "scope_denied"}
 ```
 
-### POST /agent-auth/token/refresh
+### POST /agent-auth/v1/token/refresh
 
 Exchange a refresh token for a new access/refresh token pair.
 
@@ -464,7 +497,7 @@ Response (401 — token consumed, family revoked):
 {"error": "refresh_token_reuse_detected", "detail": "Token family revoked"}
 ```
 
-### POST /agent-auth/token/reissue
+### POST /agent-auth/v1/token/reissue
 
 Request a new access/refresh token pair for a token family whose refresh token has expired. Requires JIT approval from the user on the host.
 
@@ -541,7 +574,7 @@ The integration-test fixture polls for *any* HTTP response (including
 401\) as its container-readiness signal, then issues a properly-scoped
 token for the actual health assertion.
 
-### GET /agent-auth/token/status
+### GET /agent-auth/v1/token/status
 
 Introspect a token (read-only, for debugging).
 

--- a/design/decisions/0004-docker-integration-tests.md
+++ b/design/decisions/0004-docker-integration-tests.md
@@ -72,7 +72,7 @@ to drive the Compose lifecycle instead of hand-rolled subprocess calls.
   `ENTRYPOINT` is just `agent-auth serve` — configuration is read from a
   bind-mounted `config.yaml`, not rendered from env vars by a shell
   entrypoint.
-- `docker/config.test.json` is the committed baseline test config
+- `docker/config.test.yaml` is the committed baseline test config
   (deny-by-default plugin, stock TTLs). The pytest fixture copies it
   into a per-test tmpdir, applies overrides (plugin choice, TTLs), and
   bind-mounts the tmpdir read-only at

--- a/design/decisions/0004-docker-integration-tests.md
+++ b/design/decisions/0004-docker-integration-tests.md
@@ -70,7 +70,7 @@ to drive the Compose lifecycle instead of hand-rolled subprocess calls.
   `/opt/tests-support/` and sets `PYTHONPATH=/opt/tests-support` so the
   running server can still `importlib.import_module` it. The
   `ENTRYPOINT` is just `agent-auth serve` — configuration is read from a
-  bind-mounted `config.json`, not rendered from env vars by a shell
+  bind-mounted `config.yaml`, not rendered from env vars by a shell
   entrypoint.
 - `docker/config.test.json` is the committed baseline test config
   (deny-by-default plugin, stock TTLs). The pytest fixture copies it
@@ -91,7 +91,7 @@ to drive the Compose lifecycle instead of hand-rolled subprocess calls.
   when they need to create / revoke tokens or inspect family state.
 - Two explicit notification plugins —
   `tests_support.always_approve` and `tests_support.always_deny` — are
-  written into the per-test `config.json`. They replace the earlier
+  written into the per-test `config.yaml`. They replace the earlier
   env-var-driven plugin: tests now opt in to an approval outcome by
   name rather than by threading an env var through the container.
 - `scripts/verify-integration-isolation.sh` enforces that

--- a/design/decisions/0005-things-services-docker-tests.md
+++ b/design/decisions/0005-things-services-docker-tests.md
@@ -9,7 +9,7 @@ Accepted — 2026-04-19.
 ADR `0004-docker-integration-tests.md` migrated `agent-auth`'s HTTP
 integration tests onto a per-test Compose pattern (one
 `testcontainers.compose.DockerCompose` project per test, ephemeral
-loopback port, bind-mounted `config.json`). The remaining services in
+loopback port, bind-mounted `config.yaml`). The remaining services in
 this repo —
 `things-bridge`, `things-cli`, and `things-client-cli-applescript` —
 still ran in-process, sharing host SQLite/keyring state and using

--- a/design/error-codes.md
+++ b/design/error-codes.md
@@ -1,0 +1,106 @@
+# Error Code Taxonomy
+
+This document is part of the project's **public API surface**. Error codes,
+HTTP statuses, and their meanings are stable within a major version. Adding a
+new code is non-breaking; removing or renaming one requires a major-version
+bump (see the versioning policy in `DESIGN.md`).
+
+All error responses use `Content-Type: application/json` and a body of the
+form `{"error": "<code>"}`. Validation endpoint responses additionally include
+a `"valid": false` field.
+
+## agent-auth server (`/agent-auth/v1/...`)
+
+### `POST /agent-auth/v1/validate`
+
+| Error code          | HTTP status | Meaning                                                                                                       |
+| ------------------- | ----------- | ------------------------------------------------------------------------------------------------------------- |
+| `malformed_request` | 400         | Request body is not valid JSON or exceeds the size limit.                                                     |
+| `invalid_token`     | 401         | Token is missing, malformed, has an invalid signature, is not an access token, or was not found in the store. |
+| `token_expired`     | 401         | Access token has passed its TTL.                                                                              |
+| `token_revoked`     | 401         | Token family has been revoked (e.g. after normal revocation).                                                 |
+| `scope_denied`      | 403         | The required scope is not granted, or a JIT approval prompt was denied.                                       |
+
+### `POST /agent-auth/v1/token/refresh`
+
+| Error code                     | HTTP status | Meaning                                                                                                  |
+| ------------------------------ | ----------- | -------------------------------------------------------------------------------------------------------- |
+| `malformed_request`            | 400         | Request body is not valid JSON or exceeds the size limit.                                                |
+| `invalid_token`                | 401         | Refresh token is missing, malformed, has an invalid signature, is not a refresh token, or was not found. |
+| `family_revoked`               | 401         | Token family has been revoked.                                                                           |
+| `refresh_token_expired`        | 401         | Refresh token has passed its TTL.                                                                        |
+| `refresh_token_reuse_detected` | 401         | The refresh token has already been consumed. The family is immediately revoked as a security response.   |
+
+### `POST /agent-auth/v1/token/reissue`
+
+| Error code                  | HTTP status | Meaning                                                                                                                 |
+| --------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `malformed_request`         | 400         | Request body is not valid JSON or exceeds the size limit.                                                               |
+| `refresh_token_still_valid` | 400         | Reissue is only available when the refresh token has expired; the current refresh token is still valid and un-consumed. |
+| `family_revoked`            | 401         | Token family has been revoked or no valid refresh token exists for the family.                                          |
+| `reissue_denied`            | 403         | JIT approval for reissue was denied by the host.                                                                        |
+
+### `GET /agent-auth/v1/token/status`
+
+No error codes — this endpoint does not return 4xx responses beyond the
+generic server-wide codes below.
+
+### `GET /agent-auth/health` *(unversioned)*
+
+| Error code      | HTTP status | Meaning                                            |
+| --------------- | ----------- | -------------------------------------------------- |
+| `missing_token` | 401         | No `Authorization: Bearer` header present.         |
+| `invalid_token` | 401         | Token is malformed or not an access token.         |
+| `token_expired` | 401         | Access token has passed its TTL.                   |
+| `scope_denied`  | 403         | Token does not have the `agent-auth:health` scope. |
+
+The health endpoint is unversioned by convention (see versioning policy in
+`DESIGN.md`). A 503 body of `{"status": "unhealthy"}` (not an error code)
+indicates the backing store is unreachable.
+
+### Server-wide codes (any endpoint)
+
+| Error code  | HTTP status | Meaning                                      |
+| ----------- | ----------- | -------------------------------------------- |
+| `not_found` | 404         | Path does not match any registered endpoint. |
+
+______________________________________________________________________
+
+## things-bridge server (`/things-bridge/v1/...`)
+
+### `GET /things-bridge/v1/todos`, `/things-bridge/v1/todos/{id}`, `/things-bridge/v1/projects`, `/things-bridge/v1/projects/{id}`, `/things-bridge/v1/areas`, `/things-bridge/v1/areas/{id}`
+
+All data endpoints share the same authorization and Things-layer error codes:
+
+**Authorization errors (from agent-auth delegation):**
+
+| Error code          | HTTP status | Meaning                                                                  |
+| ------------------- | ----------- | ------------------------------------------------------------------------ |
+| `unauthorized`      | 401         | No bearer token, or the token is invalid/missing.                        |
+| `token_expired`     | 401         | Access token has passed its TTL (delegated from agent-auth).             |
+| `scope_denied`      | 403         | Token does not have the `things:read` scope (delegated from agent-auth). |
+| `authz_unavailable` | 502         | The agent-auth service is unreachable.                                   |
+
+**Things-layer errors:**
+
+| Error code                 | HTTP status | Meaning                                                                                        |
+| -------------------------- | ----------- | ---------------------------------------------------------------------------------------------- |
+| `not_found`                | 404         | The requested resource id does not exist in Things. Also returned for malformed path segments. |
+| `things_permission_denied` | 503         | macOS automation permission for Things was denied.                                             |
+| `things_unavailable`       | 502         | The Things subprocess failed for an unclassified reason.                                       |
+
+### `GET /things-bridge/health` *(unversioned)*
+
+| Error code          | HTTP status | Meaning                                               |
+| ------------------- | ----------- | ----------------------------------------------------- |
+| `unauthorized`      | 401         | No bearer token present.                              |
+| `token_expired`     | 401         | Access token has passed its TTL.                      |
+| `scope_denied`      | 403         | Token does not have the `things-bridge:health` scope. |
+| `authz_unavailable` | 502         | The agent-auth service is unreachable.                |
+
+### Server-wide codes (any endpoint)
+
+| Error code           | HTTP status | Meaning                                            |
+| -------------------- | ----------- | -------------------------------------------------- |
+| `not_found`          | 404         | Path does not match any registered endpoint.       |
+| `method_not_allowed` | 405         | A non-GET method was used on a read-only endpoint. |

--- a/docker/config.test.json
+++ b/docker/config.test.json
@@ -1,8 +1,0 @@
-{
-  "host": "0.0.0.0",
-  "port": 9100,
-  "access_token_ttl_seconds": 900,
-  "refresh_token_ttl_seconds": 28800,
-  "notification_plugin": "tests_support.always_deny",
-  "notification_plugin_config": {}
-}

--- a/docker/config.test.yaml
+++ b/docker/config.test.yaml
@@ -1,0 +1,6 @@
+host: 0.0.0.0
+port: 9100
+access_token_ttl_seconds: 900
+refresh_token_ttl_seconds: 28800
+notification_plugin: tests_support.always_deny
+notification_plugin_config: {}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -14,8 +14,8 @@ services:
     ports:
       - "127.0.0.1::9100"
     volumes:
-      # Per-test tmpdir holding config.json. The fixture copies
-      # docker/config.test.json here and applies any per-test overrides
+      # Per-test tmpdir holding config.yaml. The fixture copies
+      # docker/config.test.yaml here and applies any per-test overrides
       # (TTLs, notification plugin) before starting the container.
       - {{ AGENT_AUTH_TEST_CONFIG_DIR }}:/home/agent-auth/.config/agent-auth:ro
     stop_grace_period: 5s

--- a/plans/api-stability-issues-20-24-27-28.md
+++ b/plans/api-stability-issues-20-24-27-28.md
@@ -1,0 +1,127 @@
+# Plan: API Stability Issues #20, #24, #27, #28
+
+Closes #20, #24, #27, #28 (all `1.0/api-stability`).
+
+## Summary
+
+Four inter-related API stability improvements:
+
+- **#24**: Migrate agent-auth config from JSON → YAML
+- **#27**: Version all HTTP endpoints under `/v1/`
+- **#20**: Pin audit-log schema with contract tests
+- **#28**: Document error taxonomy as public API with contract tests
+
+## Design verification
+
+All changes are additive hardening (tests + documentation) or mechanical
+migrations with no semantics change. No new ADR is needed; the versioning
+policy goes into `design/DESIGN.md`. The threat model is unaffected.
+
+## #24 — Config format migration
+
+**Files changed:**
+
+- `src/agent_auth/config.py`: switch to `yaml.safe_load("config.yaml")`, drop `import json`
+- `docker/config.test.json` → `docker/config.test.yaml`: rename + convert to YAML
+- `tests/integration/conftest.py`: update `BASELINE_CONFIG`, `_write_test_config` to read/write YAML
+- `docker/docker-compose.yaml`: fix comment
+- `tests/test_config.py`: ensure tests remain green
+- `README.md`, `CLAUDE.md`: update references from `config.json` → `config.yaml`
+
+**verify-standards.sh addition:**
+Assert no `config.json` reference and no `json.load`/`json.loads` on a config
+file path appears in `src/`.
+
+## #27 — URL-versioned API namespace
+
+**Route changes (server files):**
+
+| Old                                | New                                       |
+| ---------------------------------- | ----------------------------------------- |
+| `POST /agent-auth/validate`        | `POST /agent-auth/v1/validate`            |
+| `POST /agent-auth/token/refresh`   | `POST /agent-auth/v1/token/refresh`       |
+| `POST /agent-auth/token/reissue`   | `POST /agent-auth/v1/token/reissue`       |
+| `GET /agent-auth/token/status`     | `GET /agent-auth/v1/token/status`         |
+| `GET /agent-auth/health`           | **unchanged** (unversioned by convention) |
+| `GET /things-bridge/todos`         | `GET /things-bridge/v1/todos`             |
+| `GET /things-bridge/todos/{id}`    | `GET /things-bridge/v1/todos/{id}`        |
+| `GET /things-bridge/projects`      | `GET /things-bridge/v1/projects`          |
+| `GET /things-bridge/projects/{id}` | `GET /things-bridge/v1/projects/{id}`     |
+| `GET /things-bridge/areas`         | `GET /things-bridge/v1/areas`             |
+| `GET /things-bridge/areas/{id}`    | `GET /things-bridge/v1/areas/{id}`        |
+| `GET /things-bridge/health`        | **unchanged** (unversioned by convention) |
+
+**Files changed:**
+
+- `src/agent_auth/server.py`: update all route strings
+- `src/things_bridge/server.py`: update all route strings + prefix-strip logic
+- `src/things_cli/client.py`: update paths in `list_todos`, `get_todo`, etc.
+  and in `_refresh_access_token`/`_reissue_tokens`
+- `tests/test_server.py`: update path strings
+- `tests/test_things_bridge_server.py`: update path strings
+- `tests/test_things_cli_client.py`: update mock handler path checks
+- `tests/integration/conftest.py`: update `url()` to prepend `/agent-auth/v1/`,
+  add `health_url()` returning `/agent-auth/health`, update wait probe
+- `tests/integration/things_bridge/conftest.py`: same pattern for things-bridge
+- `design/DESIGN.md`: add versioning policy section
+
+**Versioning policy:**
+
+- Breaking changes (field removal, semantic change) bump to `/v2/`
+- Additive changes (new optional fields, new endpoints) stay on current version
+- `/health` and `/metrics` are always unversioned
+- One major version supported at a time; old version deprecated 30 days before removal
+
+**verify-standards.sh addition:**
+Assert every registered route (excluding `/health`) matches
+`^/(agent-auth|things-bridge)/v\d+/`.
+
+## #20 — Audit schema contract tests
+
+**New file: `tests/test_audit_schema.py`**
+
+For each of the 13 audit event kinds, assert:
+
+- Required fields present (`timestamp`, `event`, plus event-specific fields)
+- `timestamp` is ISO 8601 UTC (ends with `+00:00`)
+- `event` string matches exactly
+
+Event kinds:
+
+- Token operations: `token_created`, `token_refreshed`, `token_reissued`,
+  `token_revoked`, `token_rotated`, `scopes_modified`, `reissue_denied`
+- Auth decisions: `validation_allowed`, `validation_denied`,
+  `approval_granted`, `approval_denied`
+
+Tests call `AuditLogger.log_token_operation` / `log_authorization_decision`
+directly (the audit logger is public API), capture the JSON line, and validate
+field presence and types.
+
+**verify-standards.sh addition:**
+Assert `tests/test_audit_schema.py` exists and references each documented
+event kind as a string literal.
+
+## #28 — Error taxonomy contract tests
+
+**New file: `design/error-codes.md`**
+
+Enumerate every error code per endpoint: HTTP status, meaning, stability guarantee.
+
+**New file: `tests/test_error_taxonomy.py`**
+
+For each endpoint/error-code pair, start a minimal in-process server and assert
+the response body contains `{"error": "<code>"}` (and optionally `"valid": False`
+for validate errors). Uses the same lightweight HTTP-over-loopback fixture style
+as `tests/test_server.py`.
+
+**verify-standards.sh addition:**
+Assert `tests/test_error_taxonomy.py` exists and references each documented
+error code.
+
+## Post-implementation standards review
+
+- coding-standards: no new types or naming changes; n/a
+- service-design: verify config YAML path, health endpoints remain unversioned
+- release-and-hygiene: no new outputs
+- testing-standards: new tests exercise public API only; no mock leakage
+- tooling-and-ci: verify-standards.sh additions wired in

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -702,7 +702,11 @@ echo "verify-standards: config files use YAML (no config.json or json.load in co
 # API versioning: every registered HTTP route (outside /health) must match
 # ^/(agent-auth|things-bridge)/v[0-9]+/
 # (.claude/instructions/service-design.md — URL-versioned APIs).
-unversioned_routes=$(grep -rn 'self\.path ==' src/agent_auth/server.py src/things_bridge/server.py 2>/dev/null \
+# agent-auth/server.py uses `self.path ==`; things_bridge/server.py uses
+# bare `path ==` / `path.startswith` — both patterns are checked.
+unversioned_routes=$(grep -En \
+  '(self\.path|[^_]path) (==|\.startswith\() "/' \
+  src/agent_auth/server.py src/things_bridge/server.py 2>/dev/null \
   | grep -v '/health' \
   | grep -v '/v[0-9]\+/' \
   | grep -v '# unversioned' || true)

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -680,3 +680,95 @@ print(len(d.get('repositoryTopics', [])))
 else
   echo "verify-standards: 'gh' not available or not authenticated; skipping GitHub metadata check."
 fi
+
+# config format: config.py files must not reference config.json or use json.load
+# (.claude/instructions/service-design.md — YAML config).
+config_json_bad=0
+for cfg_file in src/agent_auth/config.py src/things_bridge/config.py; do
+  if [[ -f "${cfg_file}" ]]; then
+    if grep -qE "config\.json|json\.load" "${cfg_file}"; then
+      echo "verify-standards: ${cfg_file} references 'config.json' or uses json.load." >&2
+      echo "  Config must be loaded from config.yaml via yaml.safe_load." >&2
+      config_json_bad=1
+    fi
+  fi
+done
+if [[ ${config_json_bad} -ne 0 ]]; then
+  exit 1
+fi
+
+echo "verify-standards: config files use YAML (no config.json or json.load in config.py)."
+
+# API versioning: every registered HTTP route (outside /health) must match
+# ^/(agent-auth|things-bridge)/v[0-9]+/
+# (.claude/instructions/service-design.md — URL-versioned APIs).
+unversioned_routes=$(grep -rn 'self\.path ==' src/agent_auth/server.py src/things_bridge/server.py 2>/dev/null \
+  | grep -v '/health' \
+  | grep -v '/v[0-9]\+/' \
+  | grep -v '# unversioned' || true)
+if [[ -n "${unversioned_routes}" ]]; then
+  echo "verify-standards: unversioned HTTP routes found in server files:" >&2
+  echo "${unversioned_routes}" >&2
+  echo "  All endpoints (except /health) must use the /v1/ namespace." >&2
+  exit 1
+fi
+
+echo "verify-standards: all non-health HTTP routes are versioned (/v1/)."
+
+# Audit schema contract tests: tests/test_audit_schema.py must exist and
+# reference each documented event kind
+# (.claude/instructions/release-and-hygiene.md — structured output schemas).
+audit_schema_file="tests/test_audit_schema.py"
+if [[ ! -f "${audit_schema_file}" ]]; then
+  echo "verify-standards: ${audit_schema_file} does not exist." >&2
+  echo "  Create schema-contract tests for every documented audit event kind." >&2
+  exit 1
+fi
+
+audit_events=(
+  token_created token_refreshed token_reissued token_revoked token_rotated
+  scopes_modified reissue_denied validation_allowed validation_denied
+  approval_granted approval_denied
+)
+audit_missing=0
+for event in "${audit_events[@]}"; do
+  if ! grep -q "\"${event}\"" "${audit_schema_file}"; then
+    echo "verify-standards: audit event '${event}' not referenced in ${audit_schema_file}." >&2
+    audit_missing=1
+  fi
+done
+if [[ ${audit_missing} -ne 0 ]]; then
+  exit 1
+fi
+
+echo "verify-standards: ${audit_schema_file} exists and references all documented audit event kinds."
+
+# Error taxonomy contract tests: tests/test_error_taxonomy.py must exist and
+# reference each documented error code
+# (.claude/instructions/service-design.md — stable error taxonomy).
+error_taxonomy_file="tests/test_error_taxonomy.py"
+if [[ ! -f "${error_taxonomy_file}" ]]; then
+  echo "verify-standards: ${error_taxonomy_file} does not exist." >&2
+  echo "  Create contract tests for every documented error code in design/error-codes.md." >&2
+  exit 1
+fi
+
+error_codes=(
+  malformed_request invalid_token token_expired token_revoked scope_denied
+  family_revoked refresh_token_expired refresh_token_reuse_detected
+  refresh_token_still_valid reissue_denied missing_token not_found
+  unauthorized authz_unavailable things_permission_denied things_unavailable
+  method_not_allowed
+)
+error_missing=0
+for code in "${error_codes[@]}"; do
+  if ! grep -q "\"${code}\"" "${error_taxonomy_file}"; then
+    echo "verify-standards: error code '${code}' not referenced in ${error_taxonomy_file}." >&2
+    error_missing=1
+  fi
+done
+if [[ ${error_missing} -ne 0 ]]; then
+  exit 1
+fi
+
+echo "verify-standards: ${error_taxonomy_file} exists and references all documented error codes."

--- a/src/agent_auth/cli.py
+++ b/src/agent_auth/cli.py
@@ -234,7 +234,7 @@ def build_parser() -> argparse.ArgumentParser:
     rotate_parser = token_sub.add_parser("rotate", help="Rotate a token family")
     rotate_parser.add_argument("family_id", help="Token family ID")
 
-    # serve subcommand — bind address/port are configured in config.json;
+    # serve subcommand — bind address/port are configured in config.yaml;
     # the CLI has no override flags to keep exactly one source of truth.
     subparsers.add_parser("serve", help="Start the HTTP server")
 

--- a/src/agent_auth/config.py
+++ b/src/agent_auth/config.py
@@ -6,9 +6,10 @@ Paths follow the XDG Base Directory Specification:
 - State:  ``$XDG_STATE_HOME/agent-auth``  (default ``~/.local/state/agent-auth``)
 """
 
-import json
 import os
 from dataclasses import dataclass, field
+
+import yaml
 
 
 def _xdg_dir(env_var: str, fallback_segments: tuple[str, ...]) -> str:
@@ -58,12 +59,12 @@ def load_config(config_dir: str | None = None) -> Config:
     config, database, and logs. Otherwise XDG defaults apply.
     """
     base_dir = config_dir or _default_config_dir()
-    config_path = os.path.join(base_dir, "config.json")
+    config_path = os.path.join(base_dir, "config.yaml")
     valid_fields = set(Config.__dataclass_fields__)
 
     if os.path.exists(config_path):
         with open(config_path) as f:
-            data = json.load(f)
+            data = yaml.safe_load(f) or {}
         return Config(**{k: v for k, v in data.items() if k in valid_fields})
 
     if config_dir:

--- a/src/agent_auth/server.py
+++ b/src/agent_auth/server.py
@@ -53,17 +53,17 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         pass
 
     def do_POST(self):
-        if self.path == "/agent-auth/validate":
+        if self.path == "/agent-auth/v1/validate":
             self._handle_validate()
-        elif self.path == "/agent-auth/token/refresh":
+        elif self.path == "/agent-auth/v1/token/refresh":
             self._handle_refresh()
-        elif self.path == "/agent-auth/token/reissue":
+        elif self.path == "/agent-auth/v1/token/reissue":
             self._handle_reissue()
         else:
             self._send_json(404, {"error": "not_found"})
 
     def do_GET(self):
-        if self.path == "/agent-auth/token/status":
+        if self.path == "/agent-auth/v1/token/status":
             self._handle_status()
         elif self.path == "/agent-auth/health":
             self._handle_health()

--- a/src/tests_support/always_approve.py
+++ b/src/tests_support/always_approve.py
@@ -2,7 +2,7 @@
 
 Integration-test use only. The production ``terminal`` plugin prompts
 the user; the tests swap this in via ``notification_plugin`` in the
-bind-mounted ``config.json`` when they need approvals to succeed.
+bind-mounted ``config.yaml`` when they need approvals to succeed.
 """
 
 from agent_auth.plugins import ApprovalResult, NotificationPlugin

--- a/src/tests_support/always_deny.py
+++ b/src/tests_support/always_deny.py
@@ -1,7 +1,7 @@
 """Notification plugin that denies every request.
 
 Integration-test use only. Paired with ``always_approve`` so tests can
-pick a deterministic plugin in ``config.json`` rather than threading an
+pick a deterministic plugin in ``config.yaml`` rather than threading an
 env-var through the container.
 """
 

--- a/src/things_bridge/authz.py
+++ b/src/things_bridge/authz.py
@@ -13,7 +13,7 @@ from things_bridge.errors import (
 
 
 class AgentAuthClient:
-    """Validates bearer tokens against agent-auth's ``/agent-auth/validate`` endpoint."""
+    """Validates bearer tokens against agent-auth's ``/agent-auth/v1/validate`` endpoint."""
 
     def __init__(self, auth_url: str, *, timeout_seconds: float = 30.0):
         parsed = urlparse(auth_url)
@@ -39,7 +39,7 @@ class AgentAuthClient:
             try:
                 conn.request(
                     "POST",
-                    "/agent-auth/validate",
+                    "/agent-auth/v1/validate",
                     body=body,
                     headers={
                         "Content-Type": "application/json",

--- a/src/things_bridge/server.py
+++ b/src/things_bridge/server.py
@@ -120,7 +120,7 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
         # Health is authenticated under ``things-bridge:health`` to mirror
         # ``agent-auth/health``. Readiness probes that need to keep working
         # without a token can probe the 401 (server-is-up signal); the
-        # 200 path requires the scope.
+        # 200 path requires the scope. Health remains unversioned by convention.
         if path == "/things-bridge/health":
             if not self._validate(token, HEALTH_SCOPE, "things-bridge health check"):
                 return
@@ -130,7 +130,7 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
         things: ThingsClient = self._bridge.things
 
         # Routing: longest-prefix specific paths first.
-        if path == "/things-bridge/todos":
+        if path == "/things-bridge/v1/todos":
             if not self._validate(token, READ_SCOPE, "List Things todos"):
                 return
             try:
@@ -147,8 +147,8 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
             self._send_json(200, {"todos": [t.to_json() for t in todos]})
             return
 
-        if path.startswith("/things-bridge/todos/"):
-            todo_id = _safe_id(path[len("/things-bridge/todos/") :])
+        if path.startswith("/things-bridge/v1/todos/"):
+            todo_id = _safe_id(path[len("/things-bridge/v1/todos/") :])
             if todo_id is None:
                 self._send_json(404, {"error": "not_found"})
                 return
@@ -162,7 +162,7 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
             self._send_json(200, {"todo": todo.to_json()})
             return
 
-        if path == "/things-bridge/projects":
+        if path == "/things-bridge/v1/projects":
             if not self._validate(token, READ_SCOPE, "List Things projects"):
                 return
             try:
@@ -173,8 +173,8 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
             self._send_json(200, {"projects": [p.to_json() for p in projects]})
             return
 
-        if path.startswith("/things-bridge/projects/"):
-            project_id = _safe_id(path[len("/things-bridge/projects/") :])
+        if path.startswith("/things-bridge/v1/projects/"):
+            project_id = _safe_id(path[len("/things-bridge/v1/projects/") :])
             if project_id is None:
                 self._send_json(404, {"error": "not_found"})
                 return
@@ -188,7 +188,7 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
             self._send_json(200, {"project": project.to_json()})
             return
 
-        if path == "/things-bridge/areas":
+        if path == "/things-bridge/v1/areas":
             if not self._validate(token, READ_SCOPE, "List Things areas"):
                 return
             try:
@@ -199,8 +199,8 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
             self._send_json(200, {"areas": [a.to_json() for a in areas]})
             return
 
-        if path.startswith("/things-bridge/areas/"):
-            area_id = _safe_id(path[len("/things-bridge/areas/") :])
+        if path.startswith("/things-bridge/v1/areas/"):
+            area_id = _safe_id(path[len("/things-bridge/v1/areas/") :])
             if area_id is None:
                 self._send_json(404, {"error": "not_found"})
                 return

--- a/src/things_cli/client.py
+++ b/src/things_cli/client.py
@@ -46,27 +46,27 @@ class BridgeClient:
 
     def list_todos(self, params: dict[str, str] | None = None) -> dict:
         """List todos from the bridge, optionally filtered by query params."""
-        return self._request("GET", "/things-bridge/todos", params=params)
+        return self._request("GET", "/things-bridge/v1/todos", params=params)
 
     def get_todo(self, todo_id: str) -> dict:
         """Get a single todo by id."""
-        return self._request("GET", f"/things-bridge/todos/{quote(todo_id, safe='')}")
+        return self._request("GET", f"/things-bridge/v1/todos/{quote(todo_id, safe='')}")
 
     def list_projects(self, params: dict[str, str] | None = None) -> dict:
         """List projects from the bridge, optionally filtered by query params."""
-        return self._request("GET", "/things-bridge/projects", params=params)
+        return self._request("GET", "/things-bridge/v1/projects", params=params)
 
     def get_project(self, project_id: str) -> dict:
         """Get a single project by id."""
-        return self._request("GET", f"/things-bridge/projects/{quote(project_id, safe='')}")
+        return self._request("GET", f"/things-bridge/v1/projects/{quote(project_id, safe='')}")
 
     def list_areas(self) -> dict:
         """List areas from the bridge."""
-        return self._request("GET", "/things-bridge/areas")
+        return self._request("GET", "/things-bridge/v1/areas")
 
     def get_area(self, area_id: str) -> dict:
         """Get a single area by id."""
-        return self._request("GET", f"/things-bridge/areas/{quote(area_id, safe='')}")
+        return self._request("GET", f"/things-bridge/v1/areas/{quote(area_id, safe='')}")
 
     # -- internal --
 
@@ -119,7 +119,7 @@ class BridgeClient:
         status, data = self._do_http(
             self._credentials.auth_url,
             "POST",
-            "/agent-auth/token/refresh",
+            "/agent-auth/v1/token/refresh",
             body={"refresh_token": self._credentials.refresh_token},
         )
         if status == 200 and data:
@@ -145,7 +145,7 @@ class BridgeClient:
         status, data = self._do_http(
             self._credentials.auth_url,
             "POST",
-            "/agent-auth/token/reissue",
+            "/agent-auth/v1/token/reissue",
             body={"family_id": self._credentials.family_id},
         )
         if status == 200 and data:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
+import yaml
 from testcontainers.compose import DockerCompose
 
 from tests.integration._support import (
@@ -33,12 +34,12 @@ from tests.integration._support import (
     wait_until_server_ready,
 )
 
-BASELINE_CONFIG = DOCKER_DIR / "config.test.json"
+BASELINE_CONFIG = DOCKER_DIR / "config.test.yaml"
 
 # Maps the integration-test factory's human-readable ``approval`` knob
 # onto the fully-qualified notification-plugin module the container
 # should load. Tests pass ``approve`` / ``deny``; the plugin name is
-# written into the per-test config.json.
+# written into the per-test config.yaml.
 APPROVAL_PLUGINS = {
     "approve": "tests_support.always_approve",
     "deny": "tests_support.always_deny",
@@ -60,8 +61,12 @@ class AgentAuthContainer:
     service: str = "agent-auth"
 
     def url(self, path: str) -> str:
-        """Return ``{base_url}/agent-auth/{path}``."""
-        return f"{self.base_url}/agent-auth/{path.lstrip('/')}"
+        """Return ``{base_url}/agent-auth/v1/{path}``."""
+        return f"{self.base_url}/agent-auth/v1/{path.lstrip('/')}"
+
+    def health_url(self) -> str:
+        """Return the unversioned health endpoint URL."""
+        return f"{self.base_url}/agent-auth/health"
 
     def exec_cli(self, *args: str) -> str:
         """Run ``agent-auth <args>`` inside the container and return stdout.
@@ -135,7 +140,7 @@ def _test_image_tag(_docker_required):
 
 
 def _write_test_config(config_dir: Path, **overrides: object) -> None:
-    """Copy the baseline ``config.test.json`` into ``config_dir/config.json``
+    """Copy the baseline ``config.test.yaml`` into ``config_dir/config.yaml``
     with ``overrides`` applied on top.
 
     The directory and file are chmod'd world-readable because the config
@@ -143,14 +148,14 @@ def _write_test_config(config_dir: Path, **overrides: object) -> None:
     ``docker/Dockerfile.test``), while ``tmp_path_factory.mktemp`` on
     Linux defaults to mode 0700 owned by the host test runner's UID. If
     those UIDs disagree (common in devcontainers and some CI configs)
-    the container user cannot read ``config.json`` and ``agent-auth
+    the container user cannot read ``config.yaml`` and ``agent-auth
     serve`` fails on startup. No secrets live in the test config.
     """
     with BASELINE_CONFIG.open() as f:
-        config = json.load(f)
+        config = yaml.safe_load(f) or {}
     config.update(overrides)
-    config_path = config_dir / "config.json"
-    config_path.write_text(json.dumps(config, indent=2))
+    config_path = config_dir / "config.yaml"
+    config_path.write_text(yaml.dump(config, default_flow_style=False))
     os.chmod(config_dir, 0o755)
     os.chmod(config_path, 0o644)
 

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -9,7 +9,7 @@ from tests._http import get
 def test_health_endpoint_reports_ok_when_called_with_the_health_scope(agent_auth_container):
     tokens = agent_auth_container.create_token("agent-auth:health=allow")
     status, body = get(
-        agent_auth_container.url("health"),
+        agent_auth_container.health_url(),
         {"Authorization": f"Bearer {tokens['access_token']}"},
     )
     assert status == 200
@@ -18,7 +18,7 @@ def test_health_endpoint_reports_ok_when_called_with_the_health_scope(agent_auth
 
 @pytest.mark.covers_function("Serve Health Endpoint")
 def test_health_endpoint_rejects_unauthenticated_callers(agent_auth_container):
-    status, body = get(agent_auth_container.url("health"))
+    status, body = get(agent_auth_container.health_url())
     assert status == 401
     assert body["error"] == "missing_token"
 
@@ -27,7 +27,7 @@ def test_health_endpoint_rejects_unauthenticated_callers(agent_auth_container):
 def test_health_endpoint_rejects_tokens_missing_the_health_scope(agent_auth_container):
     tokens = agent_auth_container.create_token("things:read=allow")
     status, body = get(
-        agent_auth_container.url("health"),
+        agent_auth_container.health_url(),
         {"Authorization": f"Bearer {tokens['access_token']}"},
     )
     assert status == 403

--- a/tests/integration/test_refresh.py
+++ b/tests/integration/test_refresh.py
@@ -1,4 +1,4 @@
-"""Integration tests for the /agent-auth/token/refresh endpoint."""
+"""Integration tests for the /agent-auth/v1/token/refresh endpoint."""
 
 import pytest
 

--- a/tests/integration/test_reissue.py
+++ b/tests/integration/test_reissue.py
@@ -1,4 +1,4 @@
-"""Integration tests for the /agent-auth/token/reissue endpoint.
+"""Integration tests for the /agent-auth/v1/token/reissue endpoint.
 
 These tests exercise the expired-refresh-token branch by running the
 container with a very short ``refresh_token_ttl_seconds`` and sleeping

--- a/tests/integration/test_status.py
+++ b/tests/integration/test_status.py
@@ -1,4 +1,4 @@
-"""Integration tests for the /agent-auth/token/status endpoint."""
+"""Integration tests for the /agent-auth/v1/token/status endpoint."""
 
 import pytest
 

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -1,4 +1,4 @@
-"""Integration tests for the /agent-auth/validate endpoint."""
+"""Integration tests for the /agent-auth/v1/validate endpoint."""
 
 import pytest
 

--- a/tests/integration/things_bridge/conftest.py
+++ b/tests/integration/things_bridge/conftest.py
@@ -16,7 +16,6 @@ shared compose file used by every per-service fixture in this tree).
 
 from __future__ import annotations
 
-import json
 import os
 import uuid
 from collections.abc import Callable
@@ -63,8 +62,12 @@ class ThingsBridgeStack:
     compose_file: str
 
     def url(self, path: str) -> str:
-        """Return ``{base_url}/things-bridge/{path}``."""
-        return f"{self.base_url}/things-bridge/{path.lstrip('/')}"
+        """Return ``{base_url}/things-bridge/v1/{path}``."""
+        return f"{self.base_url}/things-bridge/v1/{path.lstrip('/')}"
+
+    def health_url(self) -> str:
+        """Return the unversioned health endpoint URL."""
+        return f"{self.base_url}/things-bridge/health"
 
     def write_fixture(self, fixture: dict) -> None:
         """Write/replace ``things.yaml`` in the bind-mounted fixtures dir."""
@@ -89,12 +92,12 @@ def _write_agent_auth_config(
     default without touching the agent-auth-only fixture.
     """
     with BASELINE_CONFIG.open() as f:
-        config = json.load(f)
+        config = yaml.safe_load(f) or {}
     config["notification_plugin"] = APPROVAL_PLUGINS[approval]
     config["access_token_ttl_seconds"] = access_token_ttl_seconds
     config["refresh_token_ttl_seconds"] = refresh_token_ttl_seconds
-    config_path = config_dir / "config.json"
-    config_path.write_text(json.dumps(config, indent=2))
+    config_path = config_dir / "config.yaml"
+    config_path.write_text(yaml.dump(config, default_flow_style=False))
     os.chmod(config_dir, 0o755)
     os.chmod(config_path, 0o644)
 

--- a/tests/integration/things_bridge/test_bridge.py
+++ b/tests/integration/things_bridge/test_bridge.py
@@ -214,7 +214,7 @@ def test_expired_access_token_returns_401_token_expired(
 def test_health_endpoint_requires_token(things_bridge_stack):
     # Regression guard: dropping the bearer check would let any caller
     # probe service-internal state without authorization.
-    status, data = _get(things_bridge_stack.url("health"), token=None)
+    status, data = _get(things_bridge_stack.health_url(), token=None)
     assert status == 401
     assert data == {"error": "unauthorized"}
 
@@ -225,7 +225,7 @@ def test_health_endpoint_requires_health_scope(things_bridge_stack):
     # health endpoint — it pins the scope-check path on /health, mirroring
     # the agent-auth/health behaviour.
     payload = things_bridge_stack.agent_auth.create_token("things:read=allow")
-    status, data = _get(things_bridge_stack.url("health"), payload["access_token"])
+    status, data = _get(things_bridge_stack.health_url(), payload["access_token"])
     assert status == 403
     assert data == {"error": "scope_denied"}
 
@@ -233,6 +233,6 @@ def test_health_endpoint_requires_health_scope(things_bridge_stack):
 @pytest.mark.covers_function("Delegate Token Validation", "Serve Bridge HTTP API")
 def test_health_endpoint_returns_ok_with_health_scope(things_bridge_stack):
     payload = things_bridge_stack.agent_auth.create_token("things-bridge:health=allow")
-    status, data = _get(things_bridge_stack.url("health"), payload["access_token"])
+    status, data = _get(things_bridge_stack.health_url(), payload["access_token"])
     assert status == 200
     assert data == {"status": "ok"}

--- a/tests/test_audit_schema.py
+++ b/tests/test_audit_schema.py
@@ -1,0 +1,217 @@
+"""Contract tests for the audit-log schema.
+
+Every documented audit event kind is exercised here. Each test writes one
+event to a temp log, reads it back, and asserts the required fields are
+present with the correct names and types.
+
+Breaking schema changes (renaming a field, removing a field) will fail
+these tests, which is the intent: the on-disk format is public API.
+
+Documented events
+-----------------
+Token operations: token_created, token_refreshed, token_reissued,
+  token_revoked, token_rotated, scopes_modified, reissue_denied.
+Authorization decisions: validation_allowed, validation_denied,
+  approval_granted, approval_denied.
+"""
+
+import json
+from datetime import datetime
+
+from agent_auth.audit import AuditLogger
+
+# -- helpers --
+
+
+def _log_path(tmp_path):
+    return str(tmp_path / "audit.log")
+
+
+def _read_last_entry(path: str) -> dict:
+    with open(path) as f:
+        lines = [line.strip() for line in f if line.strip()]
+    assert lines, "audit log is empty"
+    return json.loads(lines[-1])
+
+
+def _assert_base_fields(entry: dict) -> None:
+    assert "timestamp" in entry
+    assert "event" in entry
+    ts = entry["timestamp"]
+    # Must be ISO 8601 UTC (ends with +00:00 or Z)
+    assert ts.endswith("+00:00") or ts.endswith("Z"), f"timestamp not UTC: {ts!r}"
+    # Must parse as a datetime
+    datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+# -- token operation events --
+
+
+def test_token_created_schema(tmp_path):
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log_token_operation("token_created", family_id="fam-1", scopes=["things:read=allow"])
+    entry = _read_last_entry(_log_path(tmp_path))
+    _assert_base_fields(entry)
+    assert entry["event"] == "token_created"
+    assert isinstance(entry["family_id"], str)
+    assert "scopes" in entry
+
+
+def test_token_refreshed_schema(tmp_path):
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log_token_operation("token_refreshed", family_id="fam-1")
+    entry = _read_last_entry(_log_path(tmp_path))
+    _assert_base_fields(entry)
+    assert entry["event"] == "token_refreshed"
+    assert isinstance(entry["family_id"], str)
+
+
+def test_token_reissued_schema(tmp_path):
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log_token_operation("token_reissued", family_id="fam-1")
+    entry = _read_last_entry(_log_path(tmp_path))
+    _assert_base_fields(entry)
+    assert entry["event"] == "token_reissued"
+    assert isinstance(entry["family_id"], str)
+
+
+def test_token_revoked_schema(tmp_path):
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log_token_operation("token_revoked", family_id="fam-1")
+    entry = _read_last_entry(_log_path(tmp_path))
+    _assert_base_fields(entry)
+    assert entry["event"] == "token_revoked"
+    assert isinstance(entry["family_id"], str)
+
+
+def test_token_revoked_with_reason_schema(tmp_path):
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log_token_operation(
+        "token_revoked", family_id="fam-1", reason="refresh_token_reuse_detected"
+    )
+    entry = _read_last_entry(_log_path(tmp_path))
+    _assert_base_fields(entry)
+    assert entry["event"] == "token_revoked"
+    assert isinstance(entry["family_id"], str)
+    assert isinstance(entry["reason"], str)
+
+
+def test_token_rotated_schema(tmp_path):
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log_token_operation(
+        "token_rotated",
+        old_family_id="fam-old",
+        new_family_id="fam-new",
+        scopes=["things:read=allow"],
+    )
+    entry = _read_last_entry(_log_path(tmp_path))
+    _assert_base_fields(entry)
+    assert entry["event"] == "token_rotated"
+    assert isinstance(entry["old_family_id"], str)
+    assert isinstance(entry["new_family_id"], str)
+    assert "scopes" in entry
+
+
+def test_scopes_modified_schema(tmp_path):
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log_token_operation("scopes_modified", family_id="fam-1", scopes=["things:read=allow"])
+    entry = _read_last_entry(_log_path(tmp_path))
+    _assert_base_fields(entry)
+    assert entry["event"] == "scopes_modified"
+    assert isinstance(entry["family_id"], str)
+    assert "scopes" in entry
+
+
+def test_reissue_denied_schema(tmp_path):
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log_token_operation("reissue_denied", family_id="fam-1")
+    entry = _read_last_entry(_log_path(tmp_path))
+    _assert_base_fields(entry)
+    assert entry["event"] == "reissue_denied"
+    assert isinstance(entry["family_id"], str)
+
+
+# -- authorization decision events --
+
+
+def test_validation_allowed_allow_tier_schema(tmp_path):
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log_authorization_decision(
+        "validation_allowed", token_id="tok-1", scope="things:read", tier="allow"
+    )
+    entry = _read_last_entry(_log_path(tmp_path))
+    _assert_base_fields(entry)
+    assert entry["event"] == "validation_allowed"
+    assert isinstance(entry["token_id"], str)
+    assert isinstance(entry["scope"], str)
+    assert isinstance(entry["tier"], str)
+
+
+def test_validation_allowed_prompt_tier_schema(tmp_path):
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log_authorization_decision(
+        "validation_allowed",
+        token_id="tok-1",
+        scope="things:read",
+        tier="prompt",
+        grant_type="once",
+    )
+    entry = _read_last_entry(_log_path(tmp_path))
+    _assert_base_fields(entry)
+    assert entry["event"] == "validation_allowed"
+    assert isinstance(entry["token_id"], str)
+    assert isinstance(entry["scope"], str)
+    assert entry["tier"] == "prompt"
+    assert isinstance(entry["grant_type"], str)
+
+
+def test_validation_denied_schema(tmp_path):
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log_authorization_decision(
+        "validation_denied", reason="token_expired", token_id="tok-1", scope="things:read"
+    )
+    entry = _read_last_entry(_log_path(tmp_path))
+    _assert_base_fields(entry)
+    assert entry["event"] == "validation_denied"
+    assert isinstance(entry["reason"], str)
+    assert isinstance(entry["scope"], str)
+
+
+def test_validation_denied_without_token_id_schema(tmp_path):
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log_authorization_decision(
+        "validation_denied", reason="invalid_token", scope="things:read"
+    )
+    entry = _read_last_entry(_log_path(tmp_path))
+    _assert_base_fields(entry)
+    assert entry["event"] == "validation_denied"
+    assert isinstance(entry["reason"], str)
+    assert isinstance(entry["scope"], str)
+
+
+def test_approval_granted_schema(tmp_path):
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log_authorization_decision(
+        "approval_granted",
+        family_id="fam-1",
+        scope="things:read",
+        grant_type="once",
+        duration_minutes=None,
+    )
+    entry = _read_last_entry(_log_path(tmp_path))
+    _assert_base_fields(entry)
+    assert entry["event"] == "approval_granted"
+    assert isinstance(entry["family_id"], str)
+    assert isinstance(entry["scope"], str)
+    assert "grant_type" in entry
+    assert "duration_minutes" in entry
+
+
+def test_approval_denied_schema(tmp_path):
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log_authorization_decision("approval_denied", family_id="fam-1", scope="things:read")
+    entry = _read_last_entry(_log_path(tmp_path))
+    _assert_base_fields(entry)
+    assert entry["event"] == "approval_denied"
+    assert isinstance(entry["family_id"], str)
+    assert isinstance(entry["scope"], str)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,8 @@
 """Tests for configuration loading."""
 
-import json
 import os
+
+import yaml
 
 from agent_auth.config import Config, load_config
 
@@ -15,7 +16,7 @@ def test_default_config_when_file_absent(tmp_dir):
     assert config.refresh_token_ttl_seconds == 28800
     assert config.notification_plugin == "terminal"
     # Defaults must not be persisted — the config file is optional.
-    assert not os.path.exists(os.path.join(tmp_dir, "config.json"))
+    assert not os.path.exists(os.path.join(tmp_dir, "config.yaml"))
 
 
 def test_default_config_dir_roots_paths_when_no_file(tmp_dir):
@@ -26,9 +27,9 @@ def test_default_config_dir_roots_paths_when_no_file(tmp_dir):
 
 
 def test_loads_existing_config(tmp_dir):
-    config_path = os.path.join(tmp_dir, "config.json")
+    config_path = os.path.join(tmp_dir, "config.yaml")
     with open(config_path, "w") as f:
-        json.dump({"port": 9999, "notification_plugin": "desktop"}, f)
+        yaml.dump({"port": 9999, "notification_plugin": "desktop"}, f)
 
     config = load_config(tmp_dir)
     assert config.port == 9999

--- a/tests/test_error_taxonomy.py
+++ b/tests/test_error_taxonomy.py
@@ -1,0 +1,484 @@
+"""Contract tests for the error-code taxonomy.
+
+Every error code documented in ``design/error-codes.md`` is exercised here.
+Each test triggers the precise condition that should produce a given code and
+asserts the response body. Changes to error strings or HTTP statuses will
+fail these tests, which is the intent: the error taxonomy is public API.
+
+Documented codes
+----------------
+agent-auth /v1/validate:
+  malformed_request (400), invalid_token (401), token_expired (401),
+  token_revoked (401), scope_denied (403).
+agent-auth /v1/token/refresh:
+  malformed_request (400), invalid_token (401), family_revoked (401),
+  refresh_token_expired (401), refresh_token_reuse_detected (401).
+agent-auth /v1/token/reissue:
+  malformed_request (400), refresh_token_still_valid (400),
+  family_revoked (401), reissue_denied (403).
+agent-auth /health (unversioned):
+  missing_token (401), invalid_token (401), token_expired (401),
+  scope_denied (403).
+agent-auth server-wide:
+  not_found (404).
+things-bridge /v1/* data endpoints:
+  unauthorized (401), token_expired (401), scope_denied (403),
+  authz_unavailable (502), not_found (404),
+  things_permission_denied (503), things_unavailable (502).
+things-bridge /health (unversioned):
+  unauthorized (401), token_expired (401), scope_denied (403),
+  authz_unavailable (502).
+things-bridge server-wide:
+  not_found (404), method_not_allowed (405).
+"""
+
+import os
+import sqlite3
+import threading
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agent_auth.approval import ApprovalManager
+from agent_auth.audit import AuditLogger
+from agent_auth.config import Config
+from agent_auth.plugins import ApprovalResult, NotificationPlugin
+from agent_auth.server import AgentAuthServer
+from agent_auth.store import TokenStore
+from agent_auth.tokens import create_token_pair
+from tests._http import get, post
+from tests.things_client_fake.store import FakeThingsClient, FakeThingsStore
+from things_bridge.config import Config as BridgeConfig
+from things_bridge.errors import (
+    AuthzScopeDeniedError,
+    AuthzTokenExpiredError,
+    AuthzUnavailableError,
+    ThingsError,
+    ThingsPermissionError,
+)
+from things_bridge.server import ThingsBridgeServer
+
+# -- test infrastructure --
+
+
+class _DenyPlugin(NotificationPlugin):
+    def request_approval(self, scope, description, family_id):
+        return ApprovalResult(approved=False)
+
+
+@pytest.fixture
+def auth_server(tmp_dir, signing_key, encryption_key):
+    config = Config(
+        db_path=os.path.join(tmp_dir, "tokens.db"),
+        log_path=os.path.join(tmp_dir, "audit.log"),
+        host="127.0.0.1",
+        port=0,
+    )
+    store = TokenStore(config.db_path, encryption_key)
+    audit = AuditLogger(config.log_path)
+    approval_manager = ApprovalManager(_DenyPlugin(), store, audit)
+    server = AgentAuthServer(config, signing_key, store, audit, approval_manager)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield config, signing_key, store, f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+
+
+def _expire_token(db_path: str, token_id: str) -> None:
+    """Directly back-date a token's expiry to the past so the server treats it as expired."""
+    past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE tokens SET expires_at = ? WHERE id = ?", (past, token_id))
+
+
+def _extract_token_id(raw_token: str) -> str:
+    """Extract the token_id segment from a raw token string."""
+    return raw_token.split("_")[1]
+
+
+def _bearer(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+class _FakeAuthz:
+    exc: Exception | None = None
+
+    def validate(self, token, required_scope, *, description=None):
+        if self.exc is not None:
+            raise self.exc
+
+
+class _InjectableThings:
+    """Wraps FakeThingsClient with error-injection for taxonomy tests."""
+
+    exc: Exception | None = None
+
+    def __init__(self, store: FakeThingsStore):
+        self._client = FakeThingsClient(store)
+
+    def list_todos(self, **kwargs):
+        if self.exc is not None:
+            raise self.exc
+        return self._client.list_todos(**kwargs)
+
+    def get_todo(self, todo_id):
+        if self.exc is not None:
+            raise self.exc
+        return self._client.get_todo(todo_id)
+
+    def list_projects(self, **kwargs):
+        if self.exc is not None:
+            raise self.exc
+        return self._client.list_projects(**kwargs)
+
+    def get_project(self, project_id):
+        if self.exc is not None:
+            raise self.exc
+        return self._client.get_project(project_id)
+
+    def list_areas(self):
+        if self.exc is not None:
+            raise self.exc
+        return self._client.list_areas()
+
+    def get_area(self, area_id):
+        if self.exc is not None:
+            raise self.exc
+        return self._client.get_area(area_id)
+
+
+@pytest.fixture
+def bridge_server():
+    config = BridgeConfig(host="127.0.0.1", port=0)
+    authz = _FakeAuthz()
+    store = FakeThingsStore()
+    things = _InjectableThings(store)
+    server = ThingsBridgeServer(config, things, authz)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield authz, things, f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+# == agent-auth: POST /agent-auth/v1/validate ==
+
+
+def test_validate_malformed_request(auth_server):
+    _, _, _, base = auth_server
+    status, body = post(f"{base}/agent-auth/v1/validate", raw=b"{not json")
+    assert status == 400
+    assert body["error"] == "malformed_request"
+
+
+def test_validate_invalid_token(auth_server):
+    _, _, _, base = auth_server
+    status, body = post(
+        f"{base}/agent-auth/v1/validate",
+        {"token": "aa_fake_badsig", "required_scope": "things:read"},
+    )
+    assert status == 401
+    assert body["error"] == "invalid_token"
+    assert body["valid"] is False
+
+
+def test_validate_token_expired(auth_server):
+    config, signing_key, store, base = auth_server
+    family_id = "fam-exp"
+    store.create_family(family_id, {"things:read": "allow"})
+    access_token, _ = create_token_pair(signing_key, store, family_id, config)
+    token_id = _extract_token_id(access_token)
+    _expire_token(config.db_path, token_id)
+    status, body = post(
+        f"{base}/agent-auth/v1/validate",
+        {"token": access_token, "required_scope": "things:read"},
+    )
+    assert status == 401
+    assert body["error"] == "token_expired"
+    assert body["valid"] is False
+
+
+def test_validate_token_revoked(auth_server):
+    config, signing_key, store, base = auth_server
+    family_id = "fam-rev"
+    store.create_family(family_id, {"things:read": "allow"})
+    access_token, _ = create_token_pair(signing_key, store, family_id, config)
+    store.mark_family_revoked(family_id)
+    status, body = post(
+        f"{base}/agent-auth/v1/validate",
+        {"token": access_token, "required_scope": "things:read"},
+    )
+    assert status == 401
+    assert body["error"] == "token_revoked"
+    assert body["valid"] is False
+
+
+def test_validate_scope_denied(auth_server):
+    config, signing_key, store, base = auth_server
+    family_id = "fam-scope"
+    store.create_family(family_id, {"things:read": "allow"})
+    access_token, _ = create_token_pair(signing_key, store, family_id, config)
+    status, body = post(
+        f"{base}/agent-auth/v1/validate",
+        {"token": access_token, "required_scope": "agent-auth:admin"},
+    )
+    assert status == 403
+    assert body["error"] == "scope_denied"
+    assert body["valid"] is False
+
+
+# == agent-auth: POST /agent-auth/v1/token/refresh ==
+
+
+def test_refresh_malformed_request(auth_server):
+    _, _, _, base = auth_server
+    status, body = post(f"{base}/agent-auth/v1/token/refresh", raw=b"{not json")
+    assert status == 400
+    assert body["error"] == "malformed_request"
+
+
+def test_refresh_invalid_token(auth_server):
+    _, _, _, base = auth_server
+    status, body = post(f"{base}/agent-auth/v1/token/refresh", {"refresh_token": "rt_fake_badsig"})
+    assert status == 401
+    assert body["error"] == "invalid_token"
+
+
+def test_refresh_family_revoked(auth_server):
+    config, signing_key, store, base = auth_server
+    family_id = "fam-ref-rev"
+    store.create_family(family_id, {"things:read": "allow"})
+    _, refresh_token = create_token_pair(signing_key, store, family_id, config)
+    store.mark_family_revoked(family_id)
+    status, body = post(f"{base}/agent-auth/v1/token/refresh", {"refresh_token": refresh_token})
+    assert status == 401
+    assert body["error"] == "family_revoked"
+
+
+def test_refresh_token_expired(auth_server):
+    config, signing_key, store, base = auth_server
+    family_id = "fam-ref-exp"
+    store.create_family(family_id, {"things:read": "allow"})
+    _, refresh_token = create_token_pair(signing_key, store, family_id, config)
+    token_id = _extract_token_id(refresh_token)
+    _expire_token(config.db_path, token_id)
+    status, body = post(f"{base}/agent-auth/v1/token/refresh", {"refresh_token": refresh_token})
+    assert status == 401
+    assert body["error"] == "refresh_token_expired"
+
+
+def test_refresh_token_reuse_detected(auth_server):
+    config, signing_key, store, base = auth_server
+    family_id = "fam-reuse"
+    store.create_family(family_id, {"things:read": "allow"})
+    _, refresh_token = create_token_pair(signing_key, store, family_id, config)
+    post(f"{base}/agent-auth/v1/token/refresh", {"refresh_token": refresh_token})
+    status, body = post(f"{base}/agent-auth/v1/token/refresh", {"refresh_token": refresh_token})
+    assert status == 401
+    assert body["error"] == "refresh_token_reuse_detected"
+
+
+# == agent-auth: POST /agent-auth/v1/token/reissue ==
+
+
+def test_reissue_malformed_request(auth_server):
+    _, _, _, base = auth_server
+    status, body = post(f"{base}/agent-auth/v1/token/reissue", raw=b"{not json")
+    assert status == 400
+    assert body["error"] == "malformed_request"
+
+
+def test_reissue_refresh_token_still_valid(auth_server):
+    config, signing_key, store, base = auth_server
+    family_id = "fam-reissue-valid"
+    store.create_family(family_id, {"things:read": "allow"})
+    create_token_pair(signing_key, store, family_id, config)
+    status, body = post(f"{base}/agent-auth/v1/token/reissue", {"family_id": family_id})
+    assert status == 400
+    assert body["error"] == "refresh_token_still_valid"
+
+
+def test_reissue_family_revoked(auth_server):
+    _, _, store, base = auth_server
+    family_id = "fam-reissue-rev"
+    store.create_family(family_id, {"things:read": "allow"})
+    store.mark_family_revoked(family_id)
+    status, body = post(f"{base}/agent-auth/v1/token/reissue", {"family_id": family_id})
+    assert status == 401
+    assert body["error"] == "family_revoked"
+
+
+def test_reissue_denied(auth_server):
+    config, signing_key, store, base = auth_server
+    family_id = "fam-reissue-deny"
+    store.create_family(family_id, {"things:read": "allow"})
+    _, refresh_token = create_token_pair(signing_key, store, family_id, config)
+    token_id = _extract_token_id(refresh_token)
+    _expire_token(config.db_path, token_id)
+    status, body = post(f"{base}/agent-auth/v1/token/reissue", {"family_id": family_id})
+    assert status == 403
+    assert body["error"] == "reissue_denied"
+
+
+# == agent-auth: GET /agent-auth/health (unversioned) ==
+
+
+def test_health_missing_token(auth_server):
+    _, _, _, base = auth_server
+    status, body = get(f"{base}/agent-auth/health")
+    assert status == 401
+    assert body["error"] == "missing_token"
+
+
+def test_health_invalid_token(auth_server):
+    _, _, _, base = auth_server
+    status, body = get(f"{base}/agent-auth/health", _bearer("aa_fake_badsig"))
+    assert status == 401
+    assert body["error"] == "invalid_token"
+
+
+def test_health_token_expired(auth_server):
+    config, signing_key, store, base = auth_server
+    family_id = "fam-health-exp"
+    store.create_family(family_id, {"agent-auth:health": "allow"})
+    access_token, _ = create_token_pair(signing_key, store, family_id, config)
+    token_id = _extract_token_id(access_token)
+    _expire_token(config.db_path, token_id)
+    status, body = get(f"{base}/agent-auth/health", _bearer(access_token))
+    assert status == 401
+    assert body["error"] == "token_expired"
+
+
+def test_health_scope_denied(auth_server):
+    config, signing_key, store, base = auth_server
+    family_id = "fam-health-scope"
+    store.create_family(family_id, {"things:read": "allow"})
+    access_token, _ = create_token_pair(signing_key, store, family_id, config)
+    status, body = get(f"{base}/agent-auth/health", _bearer(access_token))
+    assert status == 403
+    assert body["error"] == "scope_denied"
+
+
+# == agent-auth: server-wide ==
+
+
+def test_agent_auth_not_found(auth_server):
+    _, _, _, base = auth_server
+    status, body = get(f"{base}/agent-auth/v1/does-not-exist")
+    assert status == 404
+    assert body["error"] == "not_found"
+
+
+# == things-bridge: GET /things-bridge/v1/todos (authorization errors) ==
+
+
+def test_bridge_unauthorized_no_token(bridge_server):
+    _, _, base = bridge_server
+    status, body = get(f"{base}/things-bridge/v1/todos")
+    assert status == 401
+    assert body["error"] == "unauthorized"
+
+
+def test_bridge_token_expired(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzTokenExpiredError("expired")
+    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
+    assert status == 401
+    assert body["error"] == "token_expired"
+
+
+def test_bridge_scope_denied(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzScopeDeniedError("denied")
+    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
+    assert status == 403
+    assert body["error"] == "scope_denied"
+
+
+def test_bridge_authz_unavailable(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzUnavailableError("down")
+    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
+    assert status == 502
+    assert body["error"] == "authz_unavailable"
+
+
+def test_bridge_not_found_unknown_id(bridge_server):
+    _, _, base = bridge_server
+    status, body = get(f"{base}/things-bridge/v1/todos/nonexistent-id", _bearer("tok"))
+    assert status == 404
+    assert body["error"] == "not_found"
+
+
+def test_bridge_things_permission_denied(bridge_server):
+    _, things, base = bridge_server
+    things.exc = ThingsPermissionError("denied")
+    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
+    assert status == 503
+    assert body["error"] == "things_permission_denied"
+
+
+def test_bridge_things_unavailable(bridge_server):
+    _, things, base = bridge_server
+    things.exc = ThingsError("subprocess failed")
+    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
+    assert status == 502
+    assert body["error"] == "things_unavailable"
+
+
+# == things-bridge: GET /things-bridge/health (unversioned) ==
+
+
+def test_bridge_health_unauthorized_no_token(bridge_server):
+    _, _, base = bridge_server
+    status, body = get(f"{base}/things-bridge/health")
+    assert status == 401
+    assert body["error"] == "unauthorized"
+
+
+def test_bridge_health_token_expired(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzTokenExpiredError("expired")
+    status, body = get(f"{base}/things-bridge/health", _bearer("tok"))
+    assert status == 401
+    assert body["error"] == "token_expired"
+
+
+def test_bridge_health_scope_denied(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzScopeDeniedError("denied")
+    status, body = get(f"{base}/things-bridge/health", _bearer("tok"))
+    assert status == 403
+    assert body["error"] == "scope_denied"
+
+
+def test_bridge_health_authz_unavailable(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzUnavailableError("down")
+    status, body = get(f"{base}/things-bridge/health", _bearer("tok"))
+    assert status == 502
+    assert body["error"] == "authz_unavailable"
+
+
+# == things-bridge: server-wide ==
+
+
+def test_bridge_not_found_unknown_path(bridge_server):
+    _, _, base = bridge_server
+    status, body = get(f"{base}/things-bridge/v1/does-not-exist", _bearer("tok"))
+    assert status == 404
+    assert body["error"] == "not_found"
+
+
+def test_bridge_method_not_allowed(bridge_server):
+    _, _, base = bridge_server
+    status, body = post(f"{base}/things-bridge/v1/todos", {})
+    assert status == 405
+    assert body["error"] == "method_not_allowed"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -108,7 +108,7 @@ def test_unknown_post_route_returns_404(in_process_server):
 
 def test_malformed_json_returns_400(in_process_server):
     _, base, _ = in_process_server
-    status, body = post(f"{base}/agent-auth/validate", raw=b"{not json")
+    status, body = post(f"{base}/agent-auth/v1/validate", raw=b"{not json")
     assert status == 400
     assert body["error"] == "malformed_request"
 
@@ -116,6 +116,6 @@ def test_malformed_json_returns_400(in_process_server):
 def test_oversize_body_returns_400(in_process_server):
     _, base, _ = in_process_server
     payload = b'{"token":"' + b"x" * (AgentAuthHandler.MAX_BODY_SIZE + 1) + b'"}'
-    status, body = post(f"{base}/agent-auth/validate", raw=payload)
+    status, body = post(f"{base}/agent-auth/v1/validate", raw=payload)
     assert status == 400
     assert body["error"] == "malformed_request"

--- a/tests/test_tests_support_plugins.py
+++ b/tests/test_tests_support_plugins.py
@@ -1,7 +1,7 @@
 """Unit tests for the always-approve / always-deny integration-test plugins.
 
 Verifies the loader honours the module names the integration fixture
-writes into ``config.json`` and that each plugin hard-codes the
+writes into ``config.yaml`` and that each plugin hard-codes the
 advertised decision regardless of the (scope, description, family_id)
 triple.
 """

--- a/tests/test_things_bridge_authz.py
+++ b/tests/test_things_bridge_authz.py
@@ -20,6 +20,7 @@ class _Responder(BaseHTTPRequestHandler):
     status = 200
     body: ClassVar[dict] = {"valid": True}
     last_request_body: bytes | None = None
+    last_request_path: str | None = None
 
     def log_message(self, *args, **kwargs):
         pass
@@ -27,6 +28,7 @@ class _Responder(BaseHTTPRequestHandler):
     def do_POST(self):
         length = int(self.headers.get("Content-Length", 0))
         _Responder.last_request_body = self.rfile.read(length)
+        _Responder.last_request_path = self.path
         body = json.dumps(_Responder.body).encode("utf-8")
         self.send_response(_Responder.status)
         self.send_header("Content-Type", "application/json")
@@ -50,6 +52,7 @@ def test_validate_allows_on_success(auth_server):
     _Responder.body = {"valid": True}
     client = AgentAuthClient(url, timeout_seconds=2.0)
     client.validate("aa_xxx_yyy", "things:read", description="list todos")
+    assert _Responder.last_request_path == "/agent-auth/v1/validate"
     assert _Responder.last_request_body is not None
     sent = json.loads(_Responder.last_request_body)
     assert sent["token"] == "aa_xxx_yyy"

--- a/tests/test_things_bridge_server.py
+++ b/tests/test_things_bridge_server.py
@@ -127,14 +127,14 @@ def _get(url: str, token: str | None = "aa_test_token"):
 
 
 def test_get_todos_requires_bearer_token(bridge):
-    status, data = _get(f"{bridge['url']}/things-bridge/todos", token=None)
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/todos", token=None)
     assert status == 401
     assert data == {"error": "unauthorized"}
 
 
 def test_get_todos_delegates_to_authz_and_returns_list(bridge):
     bridge["store"].todos = [_todo(id="t1", name="A"), _todo(id="t2", name="B")]
-    status, data = _get(f"{bridge['url']}/things-bridge/todos")
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/todos")
     assert status == 200
     assert bridge["authz"].last_token == "aa_test_token"
     assert bridge["authz"].last_scope == "things:read"
@@ -144,7 +144,7 @@ def test_get_todos_delegates_to_authz_and_returns_list(bridge):
 
 def test_get_todos_forwards_filters(bridge):
     _get(
-        f"{bridge['url']}/things-bridge/todos?list=TMTodayListSource&project=p1&area=a1&tag=Urgent&status=open"
+        f"{bridge['url']}/things-bridge/v1/todos?list=TMTodayListSource&project=p1&area=a1&tag=Urgent&status=open"
     )
     kwargs = bridge["things"].last_list_todos_kwargs
     assert kwargs == {
@@ -158,84 +158,84 @@ def test_get_todos_forwards_filters(bridge):
 
 def test_get_todos_token_expired_maps_to_401(bridge):
     bridge["authz"].raise_on_validate = AuthzTokenExpiredError("token_expired")
-    status, data = _get(f"{bridge['url']}/things-bridge/todos")
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/todos")
     assert status == 401
     assert data == {"error": "token_expired"}
 
 
 def test_get_todos_invalid_token_maps_to_401_unauthorized(bridge):
     bridge["authz"].raise_on_validate = AuthzTokenInvalidError("invalid_token")
-    status, data = _get(f"{bridge['url']}/things-bridge/todos")
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/todos")
     assert status == 401
     assert data == {"error": "unauthorized"}
 
 
 def test_get_todos_scope_denied_maps_to_403(bridge):
     bridge["authz"].raise_on_validate = AuthzScopeDeniedError("scope_denied")
-    status, data = _get(f"{bridge['url']}/things-bridge/todos")
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/todos")
     assert status == 403
     assert data == {"error": "scope_denied"}
 
 
 def test_get_todos_authz_unavailable_maps_to_502(bridge):
     bridge["authz"].raise_on_validate = AuthzUnavailableError("unreachable")
-    status, data = _get(f"{bridge['url']}/things-bridge/todos")
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/todos")
     assert status == 502
     assert data["error"] == "authz_unavailable"
 
 
 def test_get_todos_things_error_maps_to_502(bridge):
     bridge["things"].raise_on_call = ThingsError("osascript blew up")
-    status, data = _get(f"{bridge['url']}/things-bridge/todos")
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/todos")
     assert status == 502
     assert data["error"] == "things_unavailable"
 
 
 def test_get_todos_things_permission_error_maps_to_503(bridge):
     bridge["things"].raise_on_call = ThingsPermissionError("grant automation")
-    status, data = _get(f"{bridge['url']}/things-bridge/todos")
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/todos")
     assert status == 503
     assert data["error"] == "things_permission_denied"
 
 
 def test_get_todo_by_id_returns_single(bridge):
     bridge["store"].todos = [_todo(id="t1", name="X")]
-    status, data = _get(f"{bridge['url']}/things-bridge/todos/t1")
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/todos/t1")
     assert status == 200
     assert data["todo"]["id"] == "t1"
     assert bridge["authz"].last_description == "Read Things todo t1"
 
 
 def test_get_todo_not_found_returns_404(bridge):
-    status, data = _get(f"{bridge['url']}/things-bridge/todos/nope")
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/todos/nope")
     assert status == 404
     assert data["error"] == "not_found"
 
 
 def test_get_projects_list(bridge):
     bridge["store"].projects = [_project(id="p1"), _project(id="p2")]
-    status, data = _get(f"{bridge['url']}/things-bridge/projects")
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/projects")
     assert status == 200
     assert [p["id"] for p in data["projects"]] == ["p1", "p2"]
 
 
 def test_get_project_by_id(bridge):
     bridge["store"].projects = [_project(id="p1")]
-    status, data = _get(f"{bridge['url']}/things-bridge/projects/p1")
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/projects/p1")
     assert status == 200
     assert data["project"]["id"] == "p1"
 
 
 def test_get_areas_list(bridge):
     bridge["store"].areas = [Area(id="a1", name="Personal", tag_names=[])]
-    status, data = _get(f"{bridge['url']}/things-bridge/areas")
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/areas")
     assert status == 200
     assert data["areas"][0]["id"] == "a1"
 
 
 def test_get_area_by_id(bridge):
     bridge["store"].areas = [Area(id="a1", name="Personal", tag_names=["home"])]
-    status, data = _get(f"{bridge['url']}/things-bridge/areas/a1")
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/areas/a1")
     assert status == 200
     assert data["area"]["tag_names"] == ["home"]
 
@@ -249,7 +249,7 @@ def test_todo_id_over_length_returns_404(bridge):
     # Overly long ids are rejected before authz or AppleScript are involved,
     # so a caller cannot DoS or spam the JIT approval prompt with giant strings.
     long_id = "a" * 300
-    status, data = _get(f"{bridge['url']}/things-bridge/todos/{long_id}")
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/todos/{long_id}")
     assert status == 404
     assert data == {"error": "not_found"}
     assert bridge["authz"].last_token is None
@@ -272,7 +272,7 @@ def test_safe_id_rejects_control_and_path_chars():
 
 def test_post_to_readonly_endpoint_returns_405(bridge):
     req = urllib.request.Request(
-        f"{bridge['url']}/things-bridge/todos",
+        f"{bridge['url']}/things-bridge/v1/todos",
         data=b"{}",
         headers={"Authorization": "Bearer aa_test", "Content-Type": "application/json"},
         method="POST",
@@ -293,7 +293,7 @@ def test_non_get_methods_return_405(bridge, method):
     # distinguish whether a method is merely unimplemented (501) from
     # the stdlib default vs. explicitly disallowed on a read-only bridge.
     req = urllib.request.Request(
-        f"{bridge['url']}/things-bridge/todos",
+        f"{bridge['url']}/things-bridge/v1/todos",
         headers={"Authorization": "Bearer aa_test"},
         method=method,
     )
@@ -309,7 +309,7 @@ def test_things_error_detail_not_leaked_in_response(bridge):
     # AppleScript stderr can contain filesystem paths and user names; the
     # bridge must not forward it to the HTTP client.
     bridge["things"].raise_on_call = ThingsError("/Users/secret/path leaked in stderr")
-    status, data = _get(f"{bridge['url']}/things-bridge/todos")
+    status, data = _get(f"{bridge['url']}/things-bridge/v1/todos")
     assert status == 502
     assert data == {"error": "things_unavailable"}
     assert "secret" not in json.dumps(data)

--- a/tests/test_things_cli_client.py
+++ b/tests/test_things_cli_client.py
@@ -74,9 +74,9 @@ class _AuthHandler(BaseHTTPRequestHandler):
         raw = self.rfile.read(length) if length else b""
         body = json.loads(raw) if raw else {}
         _AuthHandler.requests.append((self.path, body))
-        if self.path == "/agent-auth/token/refresh":
+        if self.path == "/agent-auth/v1/token/refresh":
             status, resp = _AuthHandler.refresh_responses.pop(0)
-        elif self.path == "/agent-auth/token/reissue":
+        elif self.path == "/agent-auth/v1/token/reissue":
             status, resp = _AuthHandler.reissue_responses.pop(0)
         else:
             status, resp = 404, {"error": "not_found"}


### PR DESCRIPTION
## Summary

Addresses four \`1.0/api-stability\` issues together:

- **#24 — Config YAML migration**: \`config.json\` → \`config.yaml\`; loading switched from \`json.load\` to \`yaml.safe_load\`. Integration test fixtures updated to write YAML. Old \`docker/config.test.json\` deleted in favour of \`docker/config.test.yaml\`.
- **#27 — URL-versioned APIs**: All HTTP endpoints on both servers moved to \`/v1/\` namespace (e.g. \`/agent-auth/v1/validate\`, \`/things-bridge/v1/todos\`). Health endpoints (\`/agent-auth/health\`, \`/things-bridge/health\`) stay unversioned per convention. API Versioning Policy added to \`design/DESIGN.md\`. \`src/things_bridge/authz.py\` (the production validation client) also updated.
- **#28 — Stable error taxonomy**: All 17 error codes documented in \`design/error-codes.md\`. Contract tests in \`tests/test_error_taxonomy.py\` exercise every code end-to-end using in-process server fixtures. \`verify-standards.sh\` now fails if any code is missing coverage.
- **#20 — Audit log schema**: Contract tests in \`tests/test_audit_schema.py\` pin the schema for all 11 audit event kinds. \`verify-standards.sh\` now fails if any event kind is missing coverage.

## Test plan

- [x] \`uv run pytest tests/ --ignore=tests/integration\` passes (283 passed, 3 skipped)
- [x] \`uv run pytest tests/test_error_taxonomy.py\` passes (32 tests)
- [x] \`uv run pytest tests/test_audit_schema.py\` passes (14 tests)
- [x] \`uv run pytest tests/test_things_bridge_authz.py\` passes including path assertion
- [x] Pre-commit hooks pass (ruff, shfmt, shellcheck, mdformat, keep-sorted)
- [x] Docker integration tests pass (CI run 24665149982)
- [x] \`scripts/verify-standards.sh\` passes (CI: all non-Test workflows green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)