### PR TITLE
fix: move token management routes under /v1/ namespace (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   security redirect), pull-request template, and SUPPORT.md. CoC and SUPPORT
   are referenced from `README.md` and `CONTRIBUTING.md`.
 
+### Changed
+
+- **Token management HTTP routes moved under `/v1/`.**
+  `POST /agent-auth/token/{create,modify,revoke,rotate}` and
+  `GET /agent-auth/token/list` are now served at `/agent-auth/v1/token/...`.
+  Completes the `/v1/` API namespace migration so every non-health route is
+  versioned (enforced by `scripts/verify-standards.sh`).
+
 ## [0.1.0] - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -105,18 +105,18 @@ agent-auth serve --host 127.0.0.1 --port 8080
 
 ```bash
 # Validate a token against a required scope
-curl -X POST http://127.0.0.1:9100/agent-auth/validate \
+curl -X POST http://127.0.0.1:9100/agent-auth/v1/validate \
   -H "Content-Type: application/json" \
   -d '{"token": "aa_<id>_<sig>", "required_scope": "things:read"}'
 
 # Refresh a token pair
-curl -X POST http://127.0.0.1:9100/agent-auth/token/refresh \
+curl -X POST http://127.0.0.1:9100/agent-auth/v1/token/refresh \
   -H "Content-Type: application/json" \
   -d '{"refresh_token": "rt_<id>_<sig>"}'
 
 # Check token status
 curl -H "Authorization: Bearer aa_<id>_<sig>" \
-  http://127.0.0.1:9100/agent-auth/token/status
+  http://127.0.0.1:9100/agent-auth/v1/token/status
 ```
 
 ### things-bridge (macOS host)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,20 +42,20 @@ Trust boundary decisions:
 
 ## Token management endpoints
 
-The management endpoints (`POST /agent-auth/token/create`,
-`GET /agent-auth/token/list`, `POST /agent-auth/token/modify`,
-`POST /agent-auth/token/revoke`, `POST /agent-auth/token/rotate`) require
+The management endpoints (`POST /agent-auth/v1/token/create`,
+`GET /agent-auth/v1/token/list`, `POST /agent-auth/v1/token/modify`,
+`POST /agent-auth/v1/token/revoke`, `POST /agent-auth/v1/token/rotate`) require
 `Authorization: Bearer <token>` where the token's family carries
 `agent-auth:manage=allow` in its scopes.
 
 On first startup the server creates this management token family directly via
 the store and stores the refresh token in the OS keyring. Operators retrieve
 it with `agent-auth management-token show` and exchange it for an access
-token via `POST /agent-auth/token/refresh`. External clients must refresh
+token via `POST /agent-auth/v1/token/refresh`. External clients must refresh
 before each management session (access tokens expire after 900 s by default).
 
 The `agent-auth:manage` scope is reserved. The management token family is
-excluded from `GET /token/list` responses. If the management family is rotated
+excluded from `GET /agent-auth/v1/token/list` responses. If the management family is rotated
 or revoked, the server recreates it automatically on the next restart. See
 [ADR 0014](design/decisions/0014-management-endpoint-auth.md) for the full
 rationale.

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -604,13 +604,13 @@ where the access token's family has `agent-auth:manage=allow` in its scopes.
 On first startup, the server creates this management token family automatically
 and stores the refresh token in the OS keyring. Retrieve the refresh token via
 `agent-auth management-token show`, then exchange it for an access token via
-`POST /agent-auth/token/refresh` before calling management endpoints. See
+`POST /agent-auth/v1/token/refresh` before calling management endpoints. See
 [ADR 0014](decisions/0014-management-endpoint-auth.md) for the rationale.
 
 Errors returned when auth is missing or invalid: `401 missing_token`,
 `401 invalid_token`, `401 token_expired`, `403 scope_denied`.
 
-### POST /agent-auth/token/create
+### POST /agent-auth/v1/token/create
 
 Create a new token family and return an access/refresh token pair.
 
@@ -636,7 +636,7 @@ Errors: `400 no_scopes` (empty or missing scopes), `400 invalid_tier` (tier not 
 
 No authentication required. Trust boundary is the server's bind address (127.0.0.1 by default — see ADR 0006).
 
-### GET /agent-auth/token/list
+### GET /agent-auth/v1/token/list
 
 Return all token families, including revoked ones.
 
@@ -650,7 +650,7 @@ Response (200): JSON array of family objects.
 
 No authentication required.
 
-### POST /agent-auth/token/modify
+### POST /agent-auth/v1/token/modify
 
 Modify the scopes on an existing token family. Takes effect on the next `/validate` call — no new tokens are issued.
 
@@ -675,7 +675,7 @@ Response (200):
 
 Errors: `400 no_modifications`, `400 invalid_tier`, `400 malformed_request`, `404 family_not_found`, `409 family_revoked`. No authentication required.
 
-### POST /agent-auth/token/revoke
+### POST /agent-auth/v1/token/revoke
 
 Revoke a token family, invalidating all its tokens. Idempotent: revoking an already-revoked family returns 200.
 
@@ -693,7 +693,7 @@ Response (200):
 
 Errors: `400 malformed_request`, `404 family_not_found`. No authentication required.
 
-### POST /agent-auth/token/rotate
+### POST /agent-auth/v1/token/rotate
 
 Revoke an existing token family and create a new one with the same scopes.
 

--- a/design/functional_decomposition.yaml
+++ b/design/functional_decomposition.yaml
@@ -74,25 +74,25 @@ functions:
     description: Expose agent-auth functionality over HTTP for use by app bridges and CLIs. All endpoints are prefixed with /agent-auth/.
     functions:
       - name: Serve Validate Endpoint
-        description: Handle POST /agent-auth/validate requests from app bridges, including blocking for JIT approval on prompt-tier scopes.
+        description: Handle POST /agent-auth/v1/validate requests from app bridges, including blocking for JIT approval on prompt-tier scopes.
       - name: Serve Refresh Endpoint
-        description: Handle POST /agent-auth/token/refresh requests from CLIs.
+        description: Handle POST /agent-auth/v1/token/refresh requests from CLIs.
       - name: Serve Reissue Endpoint
-        description: Handle POST /agent-auth/token/reissue requests from CLIs when the refresh token has expired. Triggers JIT approval via the configured notification plugin.
+        description: Handle POST /agent-auth/v1/token/reissue requests from CLIs when the refresh token has expired. Triggers JIT approval via the configured notification plugin.
       - name: Serve Status Endpoint
-        description: Handle GET /agent-auth/token/status requests for token introspection.
+        description: Handle GET /agent-auth/v1/token/status requests for token introspection.
       - name: Serve Health Endpoint
         description: Handle GET /agent-auth/health liveness / readiness probes; require an access token carrying the agent-auth:health scope, return 200 when the token store is reachable, 401 / 403 on missing / unscoped tokens, and 503 when the store is unreachable.
       - name: Serve Token Create Endpoint
-        description: Handle POST /agent-auth/token/create requests to create a new token family and return an access/refresh token pair.
+        description: Handle POST /agent-auth/v1/token/create requests to create a new token family and return an access/refresh token pair.
       - name: Serve Token List Endpoint
-        description: Handle GET /agent-auth/token/list requests to return all token families and their scopes.
+        description: Handle GET /agent-auth/v1/token/list requests to return all token families and their scopes.
       - name: Serve Token Modify Endpoint
-        description: Handle POST /agent-auth/token/modify requests to add, remove, or change tiers on scopes of an existing token family.
+        description: Handle POST /agent-auth/v1/token/modify requests to add, remove, or change tiers on scopes of an existing token family.
       - name: Serve Token Revoke Endpoint
-        description: Handle POST /agent-auth/token/revoke requests to revoke a token family, invalidating all its tokens.
+        description: Handle POST /agent-auth/v1/token/revoke requests to revoke a token family, invalidating all its tokens.
       - name: Serve Token Rotate Endpoint
-        description: Handle POST /agent-auth/token/rotate requests to revoke an existing token family and create a new one with the same scopes.
+        description: Handle POST /agent-auth/v1/token/rotate requests to revoke an existing token family and create a new one with the same scopes.
       - name: Bootstrap Management Token
         description: On server startup, check the OS keyring for a management refresh token; if absent or revoked, create a new agent-auth:manage=allow token family directly via the store and persist the refresh token to the keyring.
   - name: Audit Logging

--- a/scripts/verify-token-cli-http-parity.sh
+++ b/scripts/verify-token-cli-http-parity.sh
@@ -40,7 +40,7 @@ routing_source = (
 missing = []
 for cmd in sorted(COMMAND_HANDLERS):
     method = f"_handle_token_{cmd}"
-    route = f"/agent-auth/token/{cmd}"
+    route = f"/agent-auth/v1/token/{cmd}"
     if not hasattr(AgentAuthHandler, method):
         missing.append(f"  token {cmd!r}: no handler method {method!r}")
     elif route not in routing_source:

--- a/src/agent_auth/server.py
+++ b/src/agent_auth/server.py
@@ -62,13 +62,13 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             self._handle_refresh()
         elif self.path == "/agent-auth/v1/token/reissue":
             self._handle_reissue()
-        elif self.path == "/agent-auth/token/create":
+        elif self.path == "/agent-auth/v1/token/create":
             self._handle_token_create()
-        elif self.path == "/agent-auth/token/modify":
+        elif self.path == "/agent-auth/v1/token/modify":
             self._handle_token_modify()
-        elif self.path == "/agent-auth/token/revoke":
+        elif self.path == "/agent-auth/v1/token/revoke":
             self._handle_token_revoke()
-        elif self.path == "/agent-auth/token/rotate":
+        elif self.path == "/agent-auth/v1/token/rotate":
             self._handle_token_rotate()
         else:
             self._send_json(404, {"error": "not_found"})
@@ -78,7 +78,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             self._handle_status()
         elif self.path == "/agent-auth/health":
             self._handle_health()
-        elif self.path == "/agent-auth/token/list":
+        elif self.path == "/agent-auth/v1/token/list":
             self._handle_token_list()
         else:
             self._send_json(404, {"error": "not_found"})

--- a/src/things_cli/client.py
+++ b/src/things_cli/client.py
@@ -19,10 +19,10 @@ class BridgeClient:
     Handles the token lifecycle automatically:
 
     1. Attaches ``Authorization: Bearer <access_token>`` from the credential store.
-    2. On ``401 {"error": "token_expired"}`` calls ``/agent-auth/token/refresh``,
+    2. On ``401 {"error": "token_expired"}`` calls ``/agent-auth/v1/token/refresh``,
        persists the new tokens, and retries the original request once.
     3. If the refresh token has itself expired (``401 refresh_token_expired``),
-       calls ``/agent-auth/token/reissue`` (which blocks on host-side JIT approval)
+       calls ``/agent-auth/v1/token/reissue`` (which blocks on host-side JIT approval)
        and retries once.
     4. Any further 401 surfaces as :class:`BridgeUnauthorizedError`.
     """

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -188,7 +188,7 @@ def management_session(in_process_server):
 @pytest.mark.covers_function("Serve Token Create Endpoint")
 def test_token_create_requires_management_auth(in_process_server):
     _, base, _ = in_process_server
-    status, body = post(f"{base}/agent-auth/token/create", data={"scopes": {"x": "allow"}})
+    status, body = post(f"{base}/agent-auth/v1/token/create", data={"scopes": {"x": "allow"}})
     assert status == 401
     assert body["error"] == "missing_token"
 
@@ -198,7 +198,7 @@ def test_token_create_returns_tokens_and_family(management_session):
     base, _, mgmt_token = management_session
     auth = {"Authorization": f"Bearer {mgmt_token}"}
     status, body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {"things:read": "allow"}},
         headers=auth,
     )
@@ -214,7 +214,7 @@ def test_token_create_returns_tokens_and_family(management_session):
 def test_token_create_rejects_empty_scopes(management_session):
     base, _, mgmt_token = management_session
     status, body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {}},
         headers={"Authorization": f"Bearer {mgmt_token}"},
     )
@@ -226,7 +226,7 @@ def test_token_create_rejects_empty_scopes(management_session):
 def test_token_create_rejects_missing_scopes_field(management_session):
     base, _, mgmt_token = management_session
     status, body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={},
         headers={"Authorization": f"Bearer {mgmt_token}"},
     )
@@ -238,7 +238,7 @@ def test_token_create_rejects_missing_scopes_field(management_session):
 def test_token_create_rejects_malformed_json(management_session):
     base, _, mgmt_token = management_session
     status, body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         raw=b"{bad",
         headers={"Authorization": f"Bearer {mgmt_token}"},
     )
@@ -250,7 +250,7 @@ def test_token_create_rejects_malformed_json(management_session):
 def test_token_create_rejects_invalid_tier(management_session):
     base, _, mgmt_token = management_session
     status, body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {"things:read": "banana"}},
         headers={"Authorization": f"Bearer {mgmt_token}"},
     )
@@ -264,7 +264,7 @@ def test_token_create_rejects_invalid_tier(management_session):
 @pytest.mark.covers_function("Serve Token List Endpoint")
 def test_token_list_requires_management_auth(in_process_server):
     _, base, _ = in_process_server
-    status, body = get(f"{base}/agent-auth/token/list")
+    status, body = get(f"{base}/agent-auth/v1/token/list")
     assert status == 401
     assert body["error"] == "missing_token"
 
@@ -272,7 +272,9 @@ def test_token_list_requires_management_auth(in_process_server):
 @pytest.mark.covers_function("Serve Token List Endpoint")
 def test_token_list_returns_empty_array_when_no_families(management_session):
     base, _, mgmt_token = management_session
-    status, body = get(f"{base}/agent-auth/token/list", {"Authorization": f"Bearer {mgmt_token}"})
+    status, body = get(
+        f"{base}/agent-auth/v1/token/list", {"Authorization": f"Bearer {mgmt_token}"}
+    )
     assert status == 200
     assert body == []
 
@@ -282,11 +284,11 @@ def test_token_list_returns_created_family(management_session):
     base, _, mgmt_token = management_session
     auth = {"Authorization": f"Bearer {mgmt_token}"}
     post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {"things:read": "allow"}},
         headers=auth,
     )
-    status, body = get(f"{base}/agent-auth/token/list", auth)
+    status, body = get(f"{base}/agent-auth/v1/token/list", auth)
     assert status == 200
     assert len(body) == 1
     assert body[0]["scopes"] == {"things:read": "allow"}
@@ -297,14 +299,14 @@ def test_token_list_includes_revoked_families(management_session):
     base, _, mgmt_token = management_session
     auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {"things:read": "allow"}},
         headers=auth,
     )
     family_id = create_body["family_id"]
-    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id}, headers=auth)
+    post(f"{base}/agent-auth/v1/token/revoke", data={"family_id": family_id}, headers=auth)
 
-    status, body = get(f"{base}/agent-auth/token/list", auth)
+    status, body = get(f"{base}/agent-auth/v1/token/list", auth)
     assert status == 200
     assert any(f["id"] == family_id and f["revoked"] for f in body)
 
@@ -312,7 +314,9 @@ def test_token_list_includes_revoked_families(management_session):
 @pytest.mark.covers_function("Serve Token List Endpoint")
 def test_token_list_excludes_management_token_family(management_session):
     base, _, mgmt_token = management_session
-    status, body = get(f"{base}/agent-auth/token/list", {"Authorization": f"Bearer {mgmt_token}"})
+    status, body = get(
+        f"{base}/agent-auth/v1/token/list", {"Authorization": f"Bearer {mgmt_token}"}
+    )
     assert status == 200
     assert not any(MANAGEMENT_SCOPE in f.get("scopes", {}) for f in body)
 
@@ -324,7 +328,7 @@ def test_token_list_excludes_management_token_family(management_session):
 def test_token_modify_requires_management_auth(in_process_server):
     _, base, _ = in_process_server
     status, body = post(
-        f"{base}/agent-auth/token/modify",
+        f"{base}/agent-auth/v1/token/modify",
         data={"family_id": "x", "add_scopes": {"y": "allow"}},
     )
     assert status == 401
@@ -336,14 +340,14 @@ def test_token_modify_adds_scope(management_session):
     base, _, mgmt_token = management_session
     auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {"things:read": "allow"}},
         headers=auth,
     )
     family_id = create_body["family_id"]
 
     status, body = post(
-        f"{base}/agent-auth/token/modify",
+        f"{base}/agent-auth/v1/token/modify",
         data={"family_id": family_id, "add_scopes": {"things:write": "prompt"}},
         headers=auth,
     )
@@ -356,14 +360,14 @@ def test_token_modify_removes_scope(management_session):
     base, _, mgmt_token = management_session
     auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {"things:read": "allow", "things:write": "prompt"}},
         headers=auth,
     )
     family_id = create_body["family_id"]
 
     status, body = post(
-        f"{base}/agent-auth/token/modify",
+        f"{base}/agent-auth/v1/token/modify",
         data={"family_id": family_id, "remove_scopes": ["things:write"]},
         headers=auth,
     )
@@ -375,7 +379,7 @@ def test_token_modify_removes_scope(management_session):
 def test_token_modify_returns_404_for_unknown_family(management_session):
     base, _, mgmt_token = management_session
     status, body = post(
-        f"{base}/agent-auth/token/modify",
+        f"{base}/agent-auth/v1/token/modify",
         data={"family_id": "no-such-family", "add_scopes": {"x": "allow"}},
         headers={"Authorization": f"Bearer {mgmt_token}"},
     )
@@ -388,15 +392,15 @@ def test_token_modify_returns_409_for_revoked_family(management_session):
     base, _, mgmt_token = management_session
     auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {"things:read": "allow"}},
         headers=auth,
     )
     family_id = create_body["family_id"]
-    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id}, headers=auth)
+    post(f"{base}/agent-auth/v1/token/revoke", data={"family_id": family_id}, headers=auth)
 
     status, body = post(
-        f"{base}/agent-auth/token/modify",
+        f"{base}/agent-auth/v1/token/modify",
         data={"family_id": family_id, "add_scopes": {"x": "allow"}},
         headers=auth,
     )
@@ -409,12 +413,12 @@ def test_token_modify_returns_400_when_no_modifications_provided(management_sess
     base, _, mgmt_token = management_session
     auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {"things:read": "allow"}},
         headers=auth,
     )
     status, body = post(
-        f"{base}/agent-auth/token/modify",
+        f"{base}/agent-auth/v1/token/modify",
         data={"family_id": create_body["family_id"]},
         headers=auth,
     )
@@ -427,12 +431,12 @@ def test_token_modify_rejects_invalid_tier_in_add_scopes(management_session):
     base, _, mgmt_token = management_session
     auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {"things:read": "allow"}},
         headers=auth,
     )
     status, body = post(
-        f"{base}/agent-auth/token/modify",
+        f"{base}/agent-auth/v1/token/modify",
         data={"family_id": create_body["family_id"], "add_scopes": {"things:write": "banana"}},
         headers=auth,
     )
@@ -445,14 +449,14 @@ def test_token_modify_set_tiers_silently_skips_unknown_scope(management_session)
     base, _, mgmt_token = management_session
     auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {"things:read": "allow"}},
         headers=auth,
     )
     family_id = create_body["family_id"]
 
     status, body = post(
-        f"{base}/agent-auth/token/modify",
+        f"{base}/agent-auth/v1/token/modify",
         data={"family_id": family_id, "set_tiers": {"no-such-scope": "prompt"}},
         headers=auth,
     )
@@ -464,7 +468,7 @@ def test_token_modify_set_tiers_silently_skips_unknown_scope(management_session)
 def test_token_modify_rejects_malformed_json(management_session):
     base, _, mgmt_token = management_session
     status, body = post(
-        f"{base}/agent-auth/token/modify",
+        f"{base}/agent-auth/v1/token/modify",
         raw=b"{bad",
         headers={"Authorization": f"Bearer {mgmt_token}"},
     )
@@ -476,7 +480,7 @@ def test_token_modify_rejects_malformed_json(management_session):
 def test_token_modify_rejects_missing_family_id(management_session):
     base, _, mgmt_token = management_session
     status, body = post(
-        f"{base}/agent-auth/token/modify",
+        f"{base}/agent-auth/v1/token/modify",
         data={"add_scopes": {"x": "allow"}},
         headers={"Authorization": f"Bearer {mgmt_token}"},
     )
@@ -489,12 +493,12 @@ def test_token_modify_rejects_wrong_type_for_add_scopes(management_session):
     base, _, mgmt_token = management_session
     auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {"things:read": "allow"}},
         headers=auth,
     )
     status, body = post(
-        f"{base}/agent-auth/token/modify",
+        f"{base}/agent-auth/v1/token/modify",
         data={"family_id": create_body["family_id"], "add_scopes": "not-a-dict"},
         headers=auth,
     )
@@ -508,7 +512,7 @@ def test_token_modify_rejects_wrong_type_for_add_scopes(management_session):
 @pytest.mark.covers_function("Serve Token Revoke Endpoint")
 def test_token_revoke_requires_management_auth(in_process_server):
     _, base, _ = in_process_server
-    status, body = post(f"{base}/agent-auth/token/revoke", data={"family_id": "x"})
+    status, body = post(f"{base}/agent-auth/v1/token/revoke", data={"family_id": "x"})
     assert status == 401
     assert body["error"] == "missing_token"
 
@@ -518,7 +522,7 @@ def test_token_revoke_marks_family_revoked(management_session):
     base, _, mgmt_token = management_session
     auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {"things:read": "allow"}},
         headers=auth,
     )
@@ -526,13 +530,13 @@ def test_token_revoke_marks_family_revoked(management_session):
     access_token = create_body["access_token"]
 
     status, body = post(
-        f"{base}/agent-auth/token/revoke", data={"family_id": family_id}, headers=auth
+        f"{base}/agent-auth/v1/token/revoke", data={"family_id": family_id}, headers=auth
     )
     assert status == 200
     assert body == {"family_id": family_id, "revoked": True}
 
     validate_status, validate_body = post(
-        f"{base}/agent-auth/validate",
+        f"{base}/agent-auth/v1/validate",
         data={"token": access_token, "required_scope": "things:read"},
     )
     assert validate_status == 401
@@ -544,15 +548,15 @@ def test_token_revoke_is_idempotent_on_already_revoked_family(management_session
     base, _, mgmt_token = management_session
     auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {"things:read": "allow"}},
         headers=auth,
     )
     family_id = create_body["family_id"]
-    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id}, headers=auth)
+    post(f"{base}/agent-auth/v1/token/revoke", data={"family_id": family_id}, headers=auth)
 
     status, body = post(
-        f"{base}/agent-auth/token/revoke", data={"family_id": family_id}, headers=auth
+        f"{base}/agent-auth/v1/token/revoke", data={"family_id": family_id}, headers=auth
     )
     assert status == 200
     assert body["revoked"] is True
@@ -562,7 +566,7 @@ def test_token_revoke_is_idempotent_on_already_revoked_family(management_session
 def test_token_revoke_returns_404_for_unknown_family(management_session):
     base, _, mgmt_token = management_session
     status, body = post(
-        f"{base}/agent-auth/token/revoke",
+        f"{base}/agent-auth/v1/token/revoke",
         data={"family_id": "no-such"},
         headers={"Authorization": f"Bearer {mgmt_token}"},
     )
@@ -574,7 +578,7 @@ def test_token_revoke_returns_404_for_unknown_family(management_session):
 def test_token_revoke_rejects_malformed_json(management_session):
     base, _, mgmt_token = management_session
     status, body = post(
-        f"{base}/agent-auth/token/revoke",
+        f"{base}/agent-auth/v1/token/revoke",
         raw=b"{bad",
         headers={"Authorization": f"Bearer {mgmt_token}"},
     )
@@ -586,7 +590,7 @@ def test_token_revoke_rejects_malformed_json(management_session):
 def test_token_revoke_rejects_missing_family_id(management_session):
     base, _, mgmt_token = management_session
     status, body = post(
-        f"{base}/agent-auth/token/revoke",
+        f"{base}/agent-auth/v1/token/revoke",
         data={},
         headers={"Authorization": f"Bearer {mgmt_token}"},
     )
@@ -600,7 +604,7 @@ def test_token_revoke_rejects_missing_family_id(management_session):
 @pytest.mark.covers_function("Serve Token Rotate Endpoint")
 def test_token_rotate_requires_management_auth(in_process_server):
     _, base, _ = in_process_server
-    status, body = post(f"{base}/agent-auth/token/rotate", data={"family_id": "x"})
+    status, body = post(f"{base}/agent-auth/v1/token/rotate", data={"family_id": "x"})
     assert status == 401
     assert body["error"] == "missing_token"
 
@@ -610,7 +614,7 @@ def test_token_rotate_revokes_old_and_creates_new_family(management_session):
     base, _, mgmt_token = management_session
     auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {"things:read": "allow"}},
         headers=auth,
     )
@@ -618,7 +622,7 @@ def test_token_rotate_revokes_old_and_creates_new_family(management_session):
     old_access_token = create_body["access_token"]
 
     status, body = post(
-        f"{base}/agent-auth/token/rotate", data={"family_id": old_family_id}, headers=auth
+        f"{base}/agent-auth/v1/token/rotate", data={"family_id": old_family_id}, headers=auth
     )
     assert status == 200
     assert body["old_family_id"] == old_family_id
@@ -628,14 +632,14 @@ def test_token_rotate_revokes_old_and_creates_new_family(management_session):
     assert body["scopes"] == {"things:read": "allow"}
 
     old_validate_status, old_validate_body = post(
-        f"{base}/agent-auth/validate",
+        f"{base}/agent-auth/v1/validate",
         data={"token": old_access_token, "required_scope": "things:read"},
     )
     assert old_validate_status == 401
     assert old_validate_body["valid"] is False
 
     new_validate_status, new_validate_body = post(
-        f"{base}/agent-auth/validate",
+        f"{base}/agent-auth/v1/validate",
         data={"token": body["access_token"], "required_scope": "things:read"},
     )
     assert new_validate_status == 200
@@ -646,7 +650,7 @@ def test_token_rotate_revokes_old_and_creates_new_family(management_session):
 def test_token_rotate_returns_404_for_unknown_family(management_session):
     base, _, mgmt_token = management_session
     status, body = post(
-        f"{base}/agent-auth/token/rotate",
+        f"{base}/agent-auth/v1/token/rotate",
         data={"family_id": "no-such"},
         headers={"Authorization": f"Bearer {mgmt_token}"},
     )
@@ -659,15 +663,15 @@ def test_token_rotate_returns_409_for_revoked_family(management_session):
     base, _, mgmt_token = management_session
     auth = {"Authorization": f"Bearer {mgmt_token}"}
     _, create_body = post(
-        f"{base}/agent-auth/token/create",
+        f"{base}/agent-auth/v1/token/create",
         data={"scopes": {"things:read": "allow"}},
         headers=auth,
     )
     family_id = create_body["family_id"]
-    post(f"{base}/agent-auth/token/revoke", data={"family_id": family_id}, headers=auth)
+    post(f"{base}/agent-auth/v1/token/revoke", data={"family_id": family_id}, headers=auth)
 
     status, body = post(
-        f"{base}/agent-auth/token/rotate", data={"family_id": family_id}, headers=auth
+        f"{base}/agent-auth/v1/token/rotate", data={"family_id": family_id}, headers=auth
     )
     assert status == 409
     assert body["error"] == "family_revoked"
@@ -677,7 +681,7 @@ def test_token_rotate_returns_409_for_revoked_family(management_session):
 def test_token_rotate_rejects_malformed_json(management_session):
     base, _, mgmt_token = management_session
     status, body = post(
-        f"{base}/agent-auth/token/rotate",
+        f"{base}/agent-auth/v1/token/rotate",
         raw=b"{bad",
         headers={"Authorization": f"Bearer {mgmt_token}"},
     )
@@ -689,7 +693,7 @@ def test_token_rotate_rejects_malformed_json(management_session):
 def test_token_rotate_rejects_missing_family_id(management_session):
     base, _, mgmt_token = management_session
     status, body = post(
-        f"{base}/agent-auth/token/rotate",
+        f"{base}/agent-auth/v1/token/rotate",
         data={},
         headers={"Authorization": f"Bearer {mgmt_token}"},
     )


### PR DESCRIPTION
## Summary

Fixes #137 — `main` has been red on `Verify Standards` and `Test` since #126 merged.

- **#97** (11:57 UTC) merged the token-management routes at `/agent-auth/token/{create,modify,revoke,rotate,list}` while the `/v1/` namespace check didn't yet exist.
- **#126** (12:11 UTC) added the check and migrated the other routes, but missed these five plus three stray `/agent-auth/validate` references in `tests/test_server.py` and `design/functional_decomposition.yaml`.

This PR finishes the migration:

- Routes moved under `/v1/` in `src/agent_auth/server.py`.
- Docstrings, test URLs, and docs (`README.md`, `SECURITY.md`, `design/DESIGN.md`, `design/functional_decomposition.yaml`, `src/things_cli/client.py`) updated.
- `scripts/verify-token-cli-http-parity.sh` updated to assert the `/v1/` prefix.
- `CHANGELOG.md` entry added under `[Unreleased] → Changed`.

## Out of scope (follow-up)

Generated functional-decomposition artifacts (`.md`, `.csv`, `.d2`, `.png`, `.svg`) still show pre-`/v1/` paths — they were never regenerated after #97 and there's no generator wired into the Taskfile. Tracked in #141.

## Test plan

- [x] `bash scripts/verify-standards.sh` passes (was failing on `main`).
- [x] `uv run pytest tests/ --ignore=tests/integration` passes (two tests were failing on `main`; 320 passed, 3 skipped).
- [x] `bash scripts/verify-token-cli-http-parity.sh` passes.
- [x] `bash scripts/verify-function-tests.sh` still passes.
- [ ] CI green on the PR branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)