### PR TITLE
ci: pin sha256 for tool binary downloads in setup-toolchain

### DIFF
--- a/.claude/instructions/tooling-and-ci.md
+++ b/.claude/instructions/tooling-and-ci.md
@@ -55,6 +55,17 @@ language: `python.md`, `bash.md`.
   `scripts/test.sh`) so the full test suite runs with one command.
 - **Wire all check scripts into CI** — every repeatable check script must
   have a CI workflow.
+- **Pin sha256 for tool binary downloads** — any CI step that downloads a
+  CLI binary directly (curl/wget from a release CDN) must verify the
+  artefact against a sha256 pinned in the repository before extracting or
+  installing it. Pair the version input with a sibling `<tool>-sha256`
+  input so version bumps and hash updates travel together. Verify with
+  `echo "<sha256>  <path>" | sha256sum -c -` immediately after download
+  and before any `tar`/`install`/`gunzip` step. A failed check must abort
+  the action — never fall back to the unverified binary. Pinning in-repo
+  is preferred over fetching an upstream `checksums.txt`, because the
+  checksum file would travel over the same TLS channel as the artefact
+  it claims to verify.
 
 ## IDE
 

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -12,6 +12,9 @@ inputs:
   keep-sorted-version:
     description: keep-sorted version to install
     default: "0.8.0"
+  keep-sorted-sha256:
+    description: sha256 of the keep-sorted linux x86_64 binary
+    default: "0d9801785ac354232ea754bbfd8cc204a5e255905e14bcbff5fe8733e4dbd85c"
   mdformat-version:
     description: mdformat version to install
     default: "0.7.22"
@@ -24,21 +27,39 @@ inputs:
   shellcheck-version:
     description: shellcheck version to install
     default: "0.10.0"
+  shellcheck-sha256:
+    description: sha256 of the shellcheck linux x86_64 tarball
+    default: "6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87"
   ripsecrets-version:
     description: ripsecrets version to install
     default: "0.1.11"
+  ripsecrets-sha256:
+    description: sha256 of the ripsecrets linux x86_64 tarball
+    default: "9daf017dfdea242a58f672450a2526f0406211afe9e872c740adc49b42feccf5"
   ruff-version:
     description: ruff version to install
     default: "0.6.9"
+  ruff-sha256:
+    description: sha256 of the ruff linux x86_64 tarball
+    default: "ed8ba4cac0c6dfc1c0e9c6c720daa5ea404a3bff0497a95d6e25293a7910e903"
   shfmt-version:
     description: shfmt version to install
     default: "3.8.0"
+  shfmt-sha256:
+    description: sha256 of the shfmt linux x86_64 binary
+    default: "27b3c6f9d9592fc5b4856c341d1ff2c88856709b9e76469313642a1d7b558fe0"
   taplo-version:
     description: taplo version to install
     default: "0.10.0"
+  taplo-sha256:
+    description: sha256 of the taplo linux x86_64 gzipped binary
+    default: "8fe196b894ccf9072f98d4e1013a180306e17d244830b03986ee5e8eabeb6156"
   treefmt-version:
     description: treefmt version to install
     default: "2.5.0"
+  treefmt-sha256:
+    description: sha256 of the treefmt linux x86_64 tarball
+    default: "95f707bf9666d08b50888b116768fd77f042ad5af92aa3b795f063160e72758f"
   systems-engineering-ref:
     description: Commit SHA or ref of aidanns/systems-engineering to install
     default: "d8e664a5ad20c071d4ec1cd62377597f9404b6e9"
@@ -76,9 +97,11 @@ runs:
       shell: bash
       env:
         SHELLCHECK_VERSION: ${{ inputs.shellcheck-version }}
+        SHELLCHECK_SHA256: ${{ inputs.shellcheck-sha256 }}
       run: |
         curl -fsSL -o /tmp/shellcheck.tar.xz \
           "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+        echo "${SHELLCHECK_SHA256}  /tmp/shellcheck.tar.xz" | sha256sum -c -
         tar -xJf /tmp/shellcheck.tar.xz -C /tmp
         sudo install -m0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
         shellcheck --version
@@ -87,9 +110,11 @@ runs:
       shell: bash
       env:
         SHFMT_VERSION: ${{ inputs.shfmt-version }}
+        SHFMT_SHA256: ${{ inputs.shfmt-sha256 }}
       run: |
         curl -fsSL -o /tmp/shfmt \
           "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
+        echo "${SHFMT_SHA256}  /tmp/shfmt" | sha256sum -c -
         sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
         shfmt --version
 
@@ -97,9 +122,11 @@ runs:
       shell: bash
       env:
         RUFF_VERSION: ${{ inputs.ruff-version }}
+        RUFF_SHA256: ${{ inputs.ruff-sha256 }}
       run: |
         curl -fsSL -o /tmp/ruff.tar.gz \
           "https://github.com/astral-sh/ruff/releases/download/${RUFF_VERSION}/ruff-x86_64-unknown-linux-gnu.tar.gz"
+        echo "${RUFF_SHA256}  /tmp/ruff.tar.gz" | sha256sum -c -
         tar -xzf /tmp/ruff.tar.gz -C /tmp
         sudo install -m0755 /tmp/ruff-x86_64-unknown-linux-gnu/ruff /usr/local/bin/ruff
         ruff --version
@@ -121,9 +148,11 @@ runs:
       shell: bash
       env:
         TAPLO_VERSION: ${{ inputs.taplo-version }}
+        TAPLO_SHA256: ${{ inputs.taplo-sha256 }}
       run: |
         curl -fsSL -o /tmp/taplo.gz \
           "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz"
+        echo "${TAPLO_SHA256}  /tmp/taplo.gz" | sha256sum -c -
         gunzip -f /tmp/taplo.gz
         sudo install -m0755 /tmp/taplo /usr/local/bin/taplo
         taplo --version
@@ -132,9 +161,11 @@ runs:
       shell: bash
       env:
         KEEP_SORTED_VERSION: ${{ inputs.keep-sorted-version }}
+        KEEP_SORTED_SHA256: ${{ inputs.keep-sorted-sha256 }}
       run: |
         curl -fsSL -o /tmp/keep-sorted \
           "https://github.com/google/keep-sorted/releases/download/v${KEEP_SORTED_VERSION}/keep-sorted_linux"
+        echo "${KEEP_SORTED_SHA256}  /tmp/keep-sorted" | sha256sum -c -
         sudo install -m0755 /tmp/keep-sorted /usr/local/bin/keep-sorted
         keep-sorted --version
 
@@ -142,9 +173,11 @@ runs:
       shell: bash
       env:
         RIPSECRETS_VERSION: ${{ inputs.ripsecrets-version }}
+        RIPSECRETS_SHA256: ${{ inputs.ripsecrets-sha256 }}
       run: |
         curl -fsSL -o /tmp/ripsecrets.tar.gz \
           "https://github.com/sirwart/ripsecrets/releases/download/v${RIPSECRETS_VERSION}/ripsecrets-${RIPSECRETS_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+        echo "${RIPSECRETS_SHA256}  /tmp/ripsecrets.tar.gz" | sha256sum -c -
         tar -xzf /tmp/ripsecrets.tar.gz -C /tmp
         sudo install -m0755 "/tmp/ripsecrets-${RIPSECRETS_VERSION}-x86_64-unknown-linux-gnu/ripsecrets" /usr/local/bin/ripsecrets
         ripsecrets --version
@@ -153,9 +186,11 @@ runs:
       shell: bash
       env:
         TREEFMT_VERSION: ${{ inputs.treefmt-version }}
+        TREEFMT_SHA256: ${{ inputs.treefmt-sha256 }}
       run: |
         curl -fsSL -o /tmp/treefmt.tar.gz \
           "https://github.com/numtide/treefmt/releases/download/v${TREEFMT_VERSION}/treefmt_${TREEFMT_VERSION}_linux_amd64.tar.gz"
+        echo "${TREEFMT_SHA256}  /tmp/treefmt.tar.gz" | sha256sum -c -
         tar -xzf /tmp/treefmt.tar.gz -C /tmp
         sudo install -m0755 /tmp/treefmt /usr/local/bin/treefmt
         treefmt --version

--- a/plans/setup-toolchain-checksums.md
+++ b/plans/setup-toolchain-checksums.md
@@ -1,0 +1,108 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# Plan: Verify checksums on tool binary downloads in setup-toolchain
+
+Resolves [#135](https://github.com/aidanns/agent-auth/issues/135).
+
+## Problem
+
+`.github/actions/setup-toolchain/action.yml` downloads seven CLI
+binaries directly over HTTPS (`shellcheck`, `shfmt`, `ruff`, `taplo`,
+`keep-sorted`, `ripsecrets`, `treefmt`) with no integrity check. TLS
+to the GitHub release CDN is the only barrier; a compromised release
+artefact or server-side tampering would land attacker-controlled
+binaries in CI (which has write access to the repo and read access
+to any secrets scoped to the workflow).
+
+## Approach
+
+Pin a sha256 for each tool directly in the composite action, alongside
+the version input, and verify with `sha256sum -c` after download and
+before `install(1)` / `tar`. This gives the strongest integrity
+property — tampering would have to land in the pinned repo, not
+merely in transit or on the CDN — and a single uniform verification
+mechanism across tools.
+
+Rejected alternatives:
+
+- **Fetch and parse upstream `checksums.txt`** — only some of the
+  seven tools publish one (shfmt, treefmt). The rest do not, so we'd
+  still need an in-repo pin for them. A mixed scheme is worse than a
+  uniform one.
+- **Sigstore / cosign verification** — only ruff and shellcheck offer
+  it among these seven. Same heterogeneity problem, plus more moving
+  parts.
+- **Pin the download URL by digest via `gh release download --digest`**
+  — GitHub's release API does not expose artefact digests for any of
+  the seven releases we use (verified: `digest: null` on shellcheck
+  assets).
+
+## Changes
+
+1. Add one input per tool holding the expected sha256 of the Linux
+   x86_64 artefact we download, defaulted to the current pinned
+   value.
+2. Modify each of the seven install steps to:
+   - Download to `/tmp/<artefact>`.
+   - Verify `echo "<sha256>  /tmp/<artefact>" | sha256sum -c -` before
+     extract/install. On mismatch `sha256sum -c` exits non-zero and
+     the step fails — the composite action propagates that up.
+3. Update `.claude/instructions/tooling-and-ci.md` to require
+   checksum pinning for any new binary install added to CI.
+
+## Out of scope
+
+- The `curl -fsSL https://d2lang.com/install.sh | sh` and
+  `systems-engineering/install.sh` pipe-to-shell installers have a
+  similar but distinct threat surface (arbitrary scripts vs. archived
+  binaries). The fix is different (pin the install script's sha256,
+  or switch to a packaged release). Tracked as
+  [#157](https://github.com/aidanns/agent-auth/issues/157) rather
+  than bundled here, per the acceptance criteria that scope this
+  change to the seven listed binary downloads.
+- `astral-sh/setup-uv`, `arduino/setup-task` — these are third-party
+  GitHub Actions, verified by action-pinning / Dependabot for
+  actions, not by our download verification.
+
+## Verification
+
+- CI runs the workflow, which exercises the modified composite action
+  on every check job. If any sha256 is wrong, the affected install
+  step fails and CI fails.
+- Manually confirm one failure path by temporarily flipping a byte
+  of one pinned sha and observing that `sha256sum -c` aborts the
+  step. (Done locally; not committed.)
+
+## Design and verification
+
+- **Design doc** — no behaviour or schema change visible to the
+  project; `design/DESIGN.md` does not describe CI toolchain
+  provisioning. No update required.
+- **Threat model** — `SECURITY.md` is scoped to the running service's
+  runtime trust boundaries and the outbound release supply chain
+  (signed SBOMs); inbound CI tool integrity sits under build-time
+  hygiene, which is owned by `.claude/instructions/tooling-and-ci.md`
+  (updated by this PR). No SECURITY.md change.
+- **ADR** — single, localised CI-hygiene change; does not meet the
+  "significant design decision" bar. Skip.
+- **Cybersecurity standard compliance** — this change *advances*
+  compliance (supply-chain integrity) rather than risks regressing
+  it. No new gap.
+- **QM / SIL** — no functional behaviour change. No QM/SIL artefact
+  required.
+
+## Post-implementation standards review
+
+- `coding-standards.md` — n/a (YAML + shell).
+- `service-design.md` — n/a.
+- `release-and-hygiene.md` — n/a (no versioned artefact or release
+  changes).
+- `testing-standards.md` — n/a (no runtime code changes).
+- `tooling-and-ci.md` — *updated by this PR* to require checksum
+  pinning for new tool installs.
+- `bash.md` — the shell snippets in each install step follow the
+  existing one-liner style; no new scripts added.


### PR DESCRIPTION
## Summary

- Pins sha256 for each binary downloaded by `.github/actions/setup-toolchain/action.yml` (shellcheck, shfmt, ruff, taplo, keep-sorted, ripsecrets, treefmt) and verifies it with `sha256sum -c -` before extract/install. A tampered artefact aborts the action; no silent fallback.
- Documents the rule in `.claude/instructions/tooling-and-ci.md` so future tool installs follow it.
- Defers the `d2` / `systems-engineering` `curl | sh` installers to #157 — different fix shape (pin script sha256 vs. pin binary sha256).

Resolves #135. See `plans/setup-toolchain-checksums.md` for the full rationale.

## Test plan

- [x] CI runs `Setup Toolchain` on this PR — every install step passes `sha256sum -c -` against its pinned hash.
- [x] Local sanity check: positive case (`echo "<correct sha>  <file>" | sha256sum -c -`) returns 0; negative case (zero-hash) returns 1.
- [x] `task lint`, `task format -- --check`, `task reuse-lint`, and `task verify-standards` all pass on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)