### PR TITLE
feat(typecheck): ratchet agent_auth/* to strict mypy + pyright

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,22 +147,6 @@ module = [
 ]
 ignore_missing_imports = true
 
-# Ratchet targets — agent_auth/*. Each listed module currently fails
-# strict mode; see #145 for the per-module fix list.
-[[tool.mypy.overrides]]
-module = [
-    # keep-sorted start
-    "agent_auth.approval",
-    "agent_auth.audit",
-    "agent_auth.cli",
-    "agent_auth.config",
-    "agent_auth.plugins",
-    "agent_auth.server",
-    "agent_auth.store",
-    "agent_auth.tokens",
-    # keep-sorted end
-]
-ignore_errors = true
 
 # Tests use pytest fixture magic and parametrize decorators heavily;
 # `disallow_untyped_defs` in particular produces a large amount of

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -15,14 +15,6 @@
   "pythonVersion": "3.11",
   "reportMissingTypeStubs": "warning",
   "ignore": [
-    "src/agent_auth/approval.py",
-    "src/agent_auth/audit.py",
-    "src/agent_auth/cli.py",
-    "src/agent_auth/config.py",
-    "src/agent_auth/plugins",
-    "src/agent_auth/server.py",
-    "src/agent_auth/store.py",
-    "src/agent_auth/tokens.py",
     "tests",
     "src/tests_support"
   ]

--- a/src/agent_auth/approval.py
+++ b/src/agent_auth/approval.py
@@ -91,7 +91,7 @@ class ApprovalManager:
 
         return result
 
-    def _record_timed_grant(self, family_id: str, scope: str, result: ApprovalResult):
+    def _record_timed_grant(self, family_id: str, scope: str, result: ApprovalResult) -> None:
         """Cache a timed grant until its duration elapses."""
         if not result.duration_minutes:
             return
@@ -99,7 +99,7 @@ class ApprovalManager:
             expires = datetime.now(UTC) + timedelta(minutes=result.duration_minutes)
             self._timed_grants[GrantKey(family_id, scope)] = expires
 
-    def _expire_timed_grants(self):
+    def _expire_timed_grants(self) -> None:
         """Remove expired timed grants. Must be called with lock held."""
         now = datetime.now(UTC)
         expired = [key for key, exp in self._timed_grants.items() if exp <= now]

--- a/src/agent_auth/audit.py
+++ b/src/agent_auth/audit.py
@@ -8,6 +8,7 @@ import json
 import threading
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 
 class AuditLogger:
@@ -24,7 +25,7 @@ class AuditLogger:
         self._lock = threading.Lock()
         Path(log_path).parent.mkdir(parents=True, exist_ok=True)
 
-    def log(self, event: str, **details):
+    def log(self, event: str, **details: Any) -> None:
         """Write an audit log entry."""
         entry = {
             "timestamp": datetime.now(UTC).isoformat(),
@@ -35,8 +36,8 @@ class AuditLogger:
         with self._lock, open(self._log_path, "a", encoding="utf-8") as f:
             f.write(line)
 
-    def log_token_operation(self, event: str, **details):
+    def log_token_operation(self, event: str, **details: Any) -> None:
         self.log(event, **details)
 
-    def log_authorization_decision(self, event: str, **details):
+    def log_authorization_decision(self, event: str, **details: Any) -> None:
         self.log(event, **details)

--- a/src/agent_auth/cli.py
+++ b/src/agent_auth/cli.py
@@ -37,9 +37,10 @@ def handle_token_create(
     audit: AuditLogger,
 ) -> None:
     """Create a new token family with a token pair."""
+    scope_args: list[str] = list(args.scope)
     scopes: dict[str, str] = {}
-    for scope_arg in args.scope:
-        name, tier = parse_scope_arg(str(scope_arg))
+    for scope_arg in scope_args:
+        name, tier = parse_scope_arg(scope_arg)
         scopes[name] = tier
 
     if not scopes:

--- a/src/agent_auth/cli.py
+++ b/src/agent_auth/cli.py
@@ -29,11 +29,17 @@ def _init_services(
     return config, signing_key, store, audit, key_manager
 
 
-def handle_token_create(args, config, signing_key, store, audit):
+def handle_token_create(
+    args: argparse.Namespace,
+    config: Config,
+    signing_key: SigningKey,
+    store: TokenStore,
+    audit: AuditLogger,
+) -> None:
     """Create a new token family with a token pair."""
-    scopes = {}
+    scopes: dict[str, str] = {}
     for scope_arg in args.scope:
-        name, tier = parse_scope_arg(scope_arg)
+        name, tier = parse_scope_arg(str(scope_arg))
         scopes[name] = tier
 
     if not scopes:
@@ -67,7 +73,13 @@ def handle_token_create(args, config, signing_key, store, audit):
         print("WARNING: Tokens are displayed only once. Store them securely.")
 
 
-def handle_token_list(args, config, signing_key, store, audit):
+def handle_token_list(
+    args: argparse.Namespace,
+    config: Config,
+    signing_key: SigningKey,
+    store: TokenStore,
+    audit: AuditLogger,
+) -> None:
     """List all token families."""
     families = store.list_families()
 
@@ -87,7 +99,13 @@ def handle_token_list(args, config, signing_key, store, audit):
         )
 
 
-def handle_token_modify(args, config, signing_key, store, audit):
+def handle_token_modify(
+    args: argparse.Namespace,
+    config: Config,
+    signing_key: SigningKey,
+    store: TokenStore,
+    audit: AuditLogger,
+) -> None:
     """Modify scopes on an existing token family."""
     family = store.get_family(args.family_id)
     if family is None:
@@ -97,16 +115,19 @@ def handle_token_modify(args, config, signing_key, store, audit):
         print(f"Error: family '{args.family_id}' is revoked", file=sys.stderr)
         sys.exit(1)
 
-    scopes = dict(family["scopes"])
+    scopes: dict[str, str] = dict(family["scopes"])
+    add_scope_args: list[str] = list(args.add_scope or [])
+    remove_scope_args: list[str] = list(args.remove_scope or [])
+    set_tier_args: list[str] = list(args.set_tier or [])
 
-    for scope_arg in args.add_scope or []:
+    for scope_arg in add_scope_args:
         name, tier = parse_scope_arg(scope_arg)
         scopes[name] = tier
 
-    for name in args.remove_scope or []:
-        scopes.pop(name, None)
+    for remove_name in remove_scope_args:
+        scopes.pop(remove_name, None)
 
-    for tier_arg in args.set_tier or []:
+    for tier_arg in set_tier_args:
         name, tier = parse_scope_arg(tier_arg)
         if name in scopes:
             scopes[name] = tier
@@ -127,7 +148,13 @@ def handle_token_modify(args, config, signing_key, store, audit):
             print(f"  {name}={tier}")
 
 
-def handle_token_revoke(args, config, signing_key, store, audit):
+def handle_token_revoke(
+    args: argparse.Namespace,
+    config: Config,
+    signing_key: SigningKey,
+    store: TokenStore,
+    audit: AuditLogger,
+) -> None:
     """Revoke a token family."""
     family = store.get_family(args.family_id)
     if family is None:
@@ -143,7 +170,13 @@ def handle_token_revoke(args, config, signing_key, store, audit):
         print(f"Family {args.family_id} revoked.")
 
 
-def handle_token_rotate(args, config, signing_key, store, audit):
+def handle_token_rotate(
+    args: argparse.Namespace,
+    config: Config,
+    signing_key: SigningKey,
+    store: TokenStore,
+    audit: AuditLogger,
+) -> None:
     """Rotate a token family: revoke old, create new with same scopes."""
     old_family = store.get_family(args.family_id)
     if old_family is None:
@@ -187,14 +220,28 @@ def handle_token_rotate(args, config, signing_key, store, audit):
         print("WARNING: Tokens are displayed only once. Store them securely.")
 
 
-def handle_serve(args, config, signing_key, store, audit, key_manager):
+def handle_serve(
+    args: argparse.Namespace,
+    config: Config,
+    signing_key: SigningKey,
+    store: TokenStore,
+    audit: AuditLogger,
+    key_manager: KeyManager,
+) -> None:
     """Start the agent-auth HTTP server."""
     from agent_auth.server import run_server
 
     run_server(config, signing_key, store, audit, key_manager)
 
 
-def handle_management_token_show(args, config, signing_key, store, audit, key_manager):
+def handle_management_token_show(
+    args: argparse.Namespace,
+    config: Config,
+    signing_key: SigningKey,
+    store: TokenStore,
+    audit: AuditLogger,
+    key_manager: KeyManager,
+) -> None:
     """Print the management refresh token from the keyring."""
     try:
         refresh_token = key_manager.get_management_refresh_token()
@@ -281,7 +328,7 @@ COMMAND_HANDLERS = {
 }
 
 
-def main():
+def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
 

--- a/src/agent_auth/config.py
+++ b/src/agent_auth/config.py
@@ -12,6 +12,7 @@ Paths follow the XDG Base Directory Specification:
 
 import os
 from dataclasses import dataclass, field
+from typing import Any, cast
 
 import yaml
 
@@ -40,11 +41,11 @@ class Config:
     access_token_ttl_seconds: int = 900
     refresh_token_ttl_seconds: int = 28800
     notification_plugin: str = "terminal"
-    notification_plugin_config: dict = field(default_factory=dict)
+    notification_plugin_config: dict[str, Any] = field(default_factory=lambda: {})
     db_path: str = ""
     log_path: str = ""
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if not self.db_path:
             self.db_path = os.path.join(_default_data_dir(), "tokens.db")
         if not self.log_path:
@@ -68,7 +69,15 @@ def load_config(config_dir: str | None = None) -> Config:
 
     if os.path.exists(config_path):
         with open(config_path) as f:
-            data = yaml.safe_load(f) or {}
+            raw = yaml.safe_load(f)
+        if raw is None:
+            data: dict[str, Any] = {}
+        elif isinstance(raw, dict):
+            data = cast(dict[str, Any], raw)
+        else:
+            raise ValueError(
+                f"Config file at {config_path} must be a YAML mapping, " f"got {type(raw).__name__}"
+            )
         return Config(**{k: v for k, v in data.items() if k in valid_fields})
 
     if config_dir:

--- a/src/agent_auth/config.py
+++ b/src/agent_auth/config.py
@@ -41,7 +41,7 @@ class Config:
     access_token_ttl_seconds: int = 900
     refresh_token_ttl_seconds: int = 28800
     notification_plugin: str = "terminal"
-    notification_plugin_config: dict[str, Any] = field(default_factory=lambda: {})
+    notification_plugin_config: dict[str, Any] = field(default_factory=dict[str, Any])
     db_path: str = ""
     log_path: str = ""
 

--- a/src/agent_auth/plugins/__init__.py
+++ b/src/agent_auth/plugins/__init__.py
@@ -6,6 +6,7 @@
 
 import importlib
 from dataclasses import dataclass
+from typing import Any, cast
 
 
 @dataclass
@@ -25,7 +26,7 @@ class ApprovalResult:
 class NotificationPlugin:
     """Base class for approval notification plugins."""
 
-    def __init__(self, config: dict | None = None):
+    def __init__(self, config: dict[str, Any] | None = None):
         self.config = config or {}
 
     def request_approval(
@@ -38,7 +39,7 @@ class NotificationPlugin:
         raise NotImplementedError
 
 
-def load_plugin(name: str, config: dict | None = None) -> NotificationPlugin:
+def load_plugin(name: str, config: dict[str, Any] | None = None) -> NotificationPlugin:
     """Load a notification plugin by name.
 
     Looks for the plugin in agent_auth.plugins.<name> or as a fully-qualified module path.
@@ -48,4 +49,4 @@ def load_plugin(name: str, config: dict | None = None) -> NotificationPlugin:
 
     module = importlib.import_module(module_path)
     plugin_class = module.Plugin
-    return plugin_class(config)
+    return cast(NotificationPlugin, plugin_class(config))

--- a/src/agent_auth/server.py
+++ b/src/agent_auth/server.py
@@ -7,6 +7,7 @@
 import json
 from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, cast
 
 from agent_auth.approval import ApprovalManager
 from agent_auth.audit import AuditLogger
@@ -31,12 +32,12 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
     """HTTP request handler for agent-auth API endpoints."""
 
     @property
-    def _server(self):
-        return self.server
+    def _server(self) -> "AgentAuthServer":
+        return cast("AgentAuthServer", self.server)
 
     MAX_BODY_SIZE = 1_048_576  # 1 MiB
 
-    def _read_json(self) -> dict | None:
+    def _read_json(self) -> dict[str, Any] | None:
         length = int(self.headers.get("Content-Length", 0))
         if length == 0:
             return {}
@@ -44,11 +45,14 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             return None
         body = self.rfile.read(length)
         try:
-            return json.loads(body)
+            parsed = json.loads(body)
         except (json.JSONDecodeError, UnicodeDecodeError):
             return None
+        if not isinstance(parsed, dict):
+            return None
+        return cast(dict[str, Any], parsed)
 
-    def _send_json(self, status: int, data: dict):
+    def _send_json(self, status: int, data: dict[str, Any] | list[dict[str, Any]]) -> None:
         body = json.dumps(data).encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
@@ -56,10 +60,10 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
-    def log_message(self, format, *args):
+    def log_message(self, format: str, *args: Any) -> None:
         pass
 
-    def do_POST(self):
+    def do_POST(self) -> None:
         if self.path == "/agent-auth/v1/validate":
             self._handle_validate()
         elif self.path == "/agent-auth/v1/token/refresh":
@@ -77,7 +81,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         else:
             self._send_json(404, {"error": "not_found"})
 
-    def do_GET(self):
+    def do_GET(self) -> None:
         if self.path == "/agent-auth/v1/token/status":
             self._handle_status()
         elif self.path == "/agent-auth/health":
@@ -87,7 +91,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         else:
             self._send_json(404, {"error": "not_found"})
 
-    def _handle_validate(self):
+    def _handle_validate(self) -> None:
         data = self._read_json()
         if data is None:
             self._send_json(400, {"error": "malformed_request"})
@@ -191,7 +195,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
                 self._send_json(403, {"valid": False, "error": "scope_denied"})
             return
 
-    def _handle_refresh(self):
+    def _handle_refresh(self) -> None:
         data = self._read_json()
         if data is None:
             self._send_json(400, {"error": "malformed_request"})
@@ -261,7 +265,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             },
         )
 
-    def _handle_reissue(self):
+    def _handle_reissue(self) -> None:
         data = self._read_json()
         if data is None:
             self._send_json(400, {"error": "malformed_request"})
@@ -360,7 +364,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
 
         return True
 
-    def _get_active_family(self, store: TokenStore, family_id: str) -> dict | None:
+    def _get_active_family(self, store: TokenStore, family_id: str) -> dict[str, Any] | None:
         """Return family if it exists and is not revoked; send 404/409 and return None otherwise."""
         family = store.get_family(family_id)
         if family is None:
@@ -371,17 +375,18 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             return None
         return family
 
-    def _handle_token_create(self):
+    def _handle_token_create(self) -> None:
         if not self._require_management_auth():
             return
         data = self._read_json()
         if data is None:
             self._send_json(400, {"error": "malformed_request"})
             return
-        scopes = data.get("scopes")
-        if not isinstance(scopes, dict) or not scopes:
+        scopes_raw = data.get("scopes")
+        if not isinstance(scopes_raw, dict) or not scopes_raw:
             self._send_json(400, {"error": "no_scopes"})
             return
+        scopes: dict[str, str] = cast(dict[str, str], scopes_raw)
         invalid_tiers = {k: v for k, v in scopes.items() if v not in VALID_TIERS}
         if invalid_tiers:
             self._send_json(400, {"error": "invalid_tier", "detail": invalid_tiers})
@@ -408,14 +413,14 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             },
         )
 
-    def _handle_token_list(self):
+    def _handle_token_list(self) -> None:
         if not self._require_management_auth():
             return
         store: TokenStore = self._server.store
         families = [f for f in store.list_families() if MANAGEMENT_SCOPE not in f.get("scopes", {})]
         self._send_json(200, families)
 
-    def _handle_token_modify(self):
+    def _handle_token_modify(self) -> None:
         if not self._require_management_auth():
             return
         data = self._read_json()
@@ -426,16 +431,25 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         if not isinstance(family_id, str) or not family_id:
             self._send_json(400, {"error": "malformed_request"})
             return
-        add_scopes = data.get("add_scopes") or {}
-        remove_scopes = data.get("remove_scopes") or []
-        set_tiers = data.get("set_tiers") or {}
+        add_scopes_raw: object = data.get("add_scopes")
+        remove_scopes_raw: object = data.get("remove_scopes")
+        set_tiers_raw: object = data.get("set_tiers")
+        if add_scopes_raw is None:
+            add_scopes_raw = {}
+        if remove_scopes_raw is None:
+            remove_scopes_raw = []
+        if set_tiers_raw is None:
+            set_tiers_raw = {}
         if (
-            not isinstance(add_scopes, dict)
-            or not isinstance(set_tiers, dict)
-            or not isinstance(remove_scopes, list)
+            not isinstance(add_scopes_raw, dict)
+            or not isinstance(set_tiers_raw, dict)
+            or not isinstance(remove_scopes_raw, list)
         ):
             self._send_json(400, {"error": "malformed_request"})
             return
+        add_scopes: dict[str, str] = cast(dict[str, str], add_scopes_raw)
+        remove_scopes: list[str] = cast(list[str], remove_scopes_raw)
+        set_tiers: dict[str, str] = cast(dict[str, str], set_tiers_raw)
 
         if not add_scopes and not remove_scopes and not set_tiers:
             self._send_json(400, {"error": "no_modifications"})
@@ -467,7 +481,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
 
         self._send_json(200, {"family_id": family_id, "scopes": scopes})
 
-    def _handle_token_revoke(self):
+    def _handle_token_revoke(self) -> None:
         if not self._require_management_auth():
             return
         data = self._read_json()
@@ -492,7 +506,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
 
         self._send_json(200, {"family_id": family_id, "revoked": True})
 
-    def _handle_token_rotate(self):
+    def _handle_token_rotate(self) -> None:
         if not self._require_management_auth():
             return
         data = self._read_json()
@@ -540,7 +554,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
 
     HEALTH_SCOPE = "agent-auth:health"
 
-    def _handle_health(self):
+    def _handle_health(self) -> None:
         auth_header = self.headers.get("Authorization", "")
         if not auth_header.startswith("Bearer "):
             self._send_json(401, {"error": "missing_token"})
@@ -588,7 +602,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             return
         self._send_json(200, {"status": "ok"})
 
-    def _handle_status(self):
+    def _handle_status(self) -> None:
         auth_header = self.headers.get("Authorization", "")
         if not auth_header.startswith("Bearer "):
             self._send_json(401, {"error": "missing_token"})

--- a/src/agent_auth/store.py
+++ b/src/agent_auth/store.py
@@ -9,6 +9,7 @@ import sqlite3
 import threading
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, cast
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
@@ -34,9 +35,9 @@ class TokenStore:
             conn.execute("PRAGMA journal_mode=WAL")
             conn.execute("PRAGMA foreign_keys=ON")
             self._local.conn = conn
-        return self._local.conn
+        return cast(sqlite3.Connection, self._local.conn)
 
-    def _init_schema(self):
+    def _init_schema(self) -> None:
         conn = self._get_conn()
         conn.executescript("""
             CREATE TABLE IF NOT EXISTS token_families (
@@ -66,7 +67,7 @@ class TokenStore:
 
     # -- Token families --
 
-    def create_family(self, family_id: str, scopes: dict[str, str]) -> dict:
+    def create_family(self, family_id: str, scopes: dict[str, str]) -> dict[str, Any]:
         """Create a new token family with the given scopes."""
         now = datetime.now(UTC).isoformat()
         encrypted_scopes = self._encrypt(json.dumps(scopes))
@@ -78,7 +79,7 @@ class TokenStore:
         conn.commit()
         return {"id": family_id, "scopes": scopes, "created_at": now, "revoked": False}
 
-    def get_family(self, family_id: str) -> dict | None:
+    def get_family(self, family_id: str) -> dict[str, Any] | None:
         """Retrieve a token family by ID."""
         conn = self._get_conn()
         row = conn.execute("SELECT * FROM token_families WHERE id = ?", (family_id,)).fetchone()
@@ -91,7 +92,7 @@ class TokenStore:
             "revoked": bool(row["revoked"]),
         }
 
-    def list_families(self) -> list[dict]:
+    def list_families(self) -> list[dict[str, Any]]:
         """List all token families."""
         conn = self._get_conn()
         rows = conn.execute("SELECT * FROM token_families ORDER BY created_at DESC").fetchall()
@@ -105,13 +106,13 @@ class TokenStore:
             for row in rows
         ]
 
-    def mark_family_revoked(self, family_id: str):
+    def mark_family_revoked(self, family_id: str) -> None:
         """Mark a token family and all its tokens as revoked."""
         conn = self._get_conn()
         conn.execute("UPDATE token_families SET revoked = 1 WHERE id = ?", (family_id,))
         conn.commit()
 
-    def update_family_scopes(self, family_id: str, scopes: dict[str, str]):
+    def update_family_scopes(self, family_id: str, scopes: dict[str, str]) -> None:
         """Update the scopes on a token family."""
         encrypted_scopes = self._encrypt(json.dumps(scopes))
         conn = self._get_conn()
@@ -130,7 +131,7 @@ class TokenStore:
         family_id: str,
         token_type: str,
         expires_at: str,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Store a new access or refresh token."""
         encrypted_sig = self._encrypt(hmac_signature)
         conn = self._get_conn()
@@ -148,7 +149,7 @@ class TokenStore:
             "consumed": False,
         }
 
-    def get_token(self, token_id: str) -> dict | None:
+    def get_token(self, token_id: str) -> dict[str, Any] | None:
         """Retrieve a token by ID."""
         conn = self._get_conn()
         row = conn.execute("SELECT * FROM tokens WHERE id = ?", (token_id,)).fetchone()
@@ -163,7 +164,7 @@ class TokenStore:
             "consumed": bool(row["consumed"]),
         }
 
-    def get_tokens_by_family(self, family_id: str) -> list[dict]:
+    def get_tokens_by_family(self, family_id: str) -> list[dict[str, Any]]:
         """Retrieve all tokens for a family."""
         conn = self._get_conn()
         rows = conn.execute("SELECT * FROM tokens WHERE family_id = ?", (family_id,)).fetchall()

--- a/src/agent_auth/tokens.py
+++ b/src/agent_auth/tokens.py
@@ -8,9 +8,14 @@ import hashlib
 import hmac
 import uuid
 from datetime import UTC
+from typing import TYPE_CHECKING
 
 from agent_auth.errors import TokenInvalidError
 from agent_auth.keys import SigningKey
+
+if TYPE_CHECKING:
+    from agent_auth.config import Config
+    from agent_auth.store import TokenStore
 
 PREFIX_ACCESS = "aa"
 PREFIX_REFRESH = "rt"
@@ -50,7 +55,12 @@ def parse_token(raw: str) -> tuple[str, str, str]:
     return prefix, token_id, signature
 
 
-def create_token_pair(signing_key: SigningKey, store, family_id: str, config) -> tuple[str, str]:
+def create_token_pair(
+    signing_key: SigningKey,
+    store: "TokenStore",
+    family_id: str,
+    config: "Config",
+) -> tuple[str, str]:
     """Create an access + refresh token pair, persist both, return (access_token, refresh_token)."""
     from datetime import datetime, timedelta
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@
 
 import os
 
+import pytest
 import yaml
 
 from agent_auth.config import Config, load_config
@@ -38,6 +39,30 @@ def test_loads_existing_config(tmp_dir):
     config = load_config(tmp_dir)
     assert config.port == 9999
     assert config.notification_plugin == "desktop"
+
+
+def test_non_mapping_yaml_root_raises_value_error(tmp_dir):
+    # A config file whose YAML root is not a mapping (list, scalar, ...)
+    # must fail loudly with the offending type rather than silently
+    # falling through to defaults — a silent fallthrough would hide a
+    # typo'd config file that users expect to take effect.
+    config_path = os.path.join(tmp_dir, "config.yaml")
+    with open(config_path, "w") as f:
+        f.write("- port: 9999\n- notification_plugin: desktop\n")
+
+    with pytest.raises(ValueError, match="YAML mapping"):
+        load_config(tmp_dir)
+
+
+def test_empty_yaml_file_falls_back_to_defaults(tmp_dir):
+    # An empty ``config.yaml`` parses to ``None`` — treat it the same as
+    # a missing file so operators can leave a placeholder in place.
+    config_path = os.path.join(tmp_dir, "config.yaml")
+    with open(config_path, "w"):
+        pass
+
+    config = load_config(tmp_dir)
+    assert config.port == 9100
 
 
 def test_config_post_init_xdg_defaults(monkeypatch, tmp_path):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -132,6 +132,18 @@ def test_oversize_body_returns_400(in_process_server):
     assert body["error"] == "malformed_request"
 
 
+def test_non_object_json_body_returns_400(in_process_server):
+    # A syntactically-valid JSON value that is not an object (array, string,
+    # number, ...) must surface as ``malformed_request`` rather than
+    # propagating through handlers that call ``.get(...)`` on the parsed body
+    # and producing an unhelpful 500.
+    _, base, _ = in_process_server
+    for raw in (b"[1, 2, 3]", b'"token"', b"42", b"null", b"true"):
+        status, body = post(f"{base}/agent-auth/v1/validate", raw=raw)
+        assert status == 400, f"raw={raw!r} unexpectedly produced {status}"
+        assert body["error"] == "malformed_request"
+
+
 # --- management-token bootstrap ---
 
 


### PR DESCRIPTION
## Summary

- Closes all 8 agent_auth modules listed in #145 by removing their `ignore_errors` / pyright `ignore` entries and fixing the 68 mypy + 26 residual pyright errors they surfaced.
- Annotation additions: argparse handler signatures (`args: argparse.Namespace`, keyword-typed service deps), handler return types, typed `**details: Any` for AuditLogger helpers, and parameterised `dict` / `list` return types across `store.py` / `server.py` / `plugins/__init__.py`.
- Widened `_send_json` to accept `dict[str, Any] | list[dict[str, Any]]` because `/v1/token/list` returns a JSON array.
- Narrowed `_read_json` via `isinstance(parsed, dict) + cast`: malformed non-object bodies now surface as 400 `malformed_request` rather than propagating `Any` downstream.
- Introduced `TYPE_CHECKING` forward refs in `tokens.py` for `TokenStore` / `Config` to avoid circular imports.
- Fixed a silent non-dict YAML fall-through in `load_config` (raises `ValueError` with the offending type, matching the similar fix in `things_cli/credentials.py`).
- `server.py` `_handle_token_modify` now explicitly normalises the `add_scopes` / `remove_scopes` / `set_tiers` request fields from `Any | None` to typed containers before isinstance-guarding, so pyright can infer the scope/tier chains through `.items()` / iteration.

Closes #145.

## Test plan

- [ ] `uv run mypy --strict src/` passes
- [ ] `uv run pyright` passes
- [ ] `uv run pytest tests/` passes (full suite, coverage floor met)
- [ ] `scripts/verify-standards.sh` passes (mypy ↔ pyright ratchet lists still in sync)
- [ ] `uv run ruff check src/ tests/` passes
- [ ] CI `typecheck` job stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)