### PR TITLE
ci(setup-toolchain): authenticate + retry release-binary downloads

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -110,8 +110,13 @@ runs:
       env:
         SHELLCHECK_VERSION: ${{ inputs.shellcheck-version }}
         SHELLCHECK_SHA256: ${{ inputs.shellcheck-sha256 }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        curl -fsSL -o /tmp/shellcheck.tar.xz \
+        # Auth is safe: curl -L strips the Authorization header on the
+        # cross-origin redirect from github.com to the S3 asset URL. See #159.
+        curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
+          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+          -o /tmp/shellcheck.tar.xz \
           "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
         echo "${SHELLCHECK_SHA256}  /tmp/shellcheck.tar.xz" | sha256sum -c -
         tar -xJf /tmp/shellcheck.tar.xz -C /tmp
@@ -123,8 +128,11 @@ runs:
       env:
         SHFMT_VERSION: ${{ inputs.shfmt-version }}
         SHFMT_SHA256: ${{ inputs.shfmt-sha256 }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        curl -fsSL -o /tmp/shfmt \
+        curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
+          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+          -o /tmp/shfmt \
           "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
         echo "${SHFMT_SHA256}  /tmp/shfmt" | sha256sum -c -
         sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
@@ -135,8 +143,11 @@ runs:
       env:
         RUFF_VERSION: ${{ inputs.ruff-version }}
         RUFF_SHA256: ${{ inputs.ruff-sha256 }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        curl -fsSL -o /tmp/ruff.tar.gz \
+        curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
+          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+          -o /tmp/ruff.tar.gz \
           "https://github.com/astral-sh/ruff/releases/download/${RUFF_VERSION}/ruff-x86_64-unknown-linux-gnu.tar.gz"
         echo "${RUFF_SHA256}  /tmp/ruff.tar.gz" | sha256sum -c -
         tar -xzf /tmp/ruff.tar.gz -C /tmp
@@ -161,8 +172,11 @@ runs:
       env:
         TAPLO_VERSION: ${{ inputs.taplo-version }}
         TAPLO_SHA256: ${{ inputs.taplo-sha256 }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        curl -fsSL -o /tmp/taplo.gz \
+        curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
+          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+          -o /tmp/taplo.gz \
           "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz"
         echo "${TAPLO_SHA256}  /tmp/taplo.gz" | sha256sum -c -
         gunzip -f /tmp/taplo.gz
@@ -174,8 +188,11 @@ runs:
       env:
         KEEP_SORTED_VERSION: ${{ inputs.keep-sorted-version }}
         KEEP_SORTED_SHA256: ${{ inputs.keep-sorted-sha256 }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        curl -fsSL -o /tmp/keep-sorted \
+        curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
+          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+          -o /tmp/keep-sorted \
           "https://github.com/google/keep-sorted/releases/download/v${KEEP_SORTED_VERSION}/keep-sorted_linux"
         echo "${KEEP_SORTED_SHA256}  /tmp/keep-sorted" | sha256sum -c -
         sudo install -m0755 /tmp/keep-sorted /usr/local/bin/keep-sorted
@@ -186,8 +203,11 @@ runs:
       env:
         RIPSECRETS_VERSION: ${{ inputs.ripsecrets-version }}
         RIPSECRETS_SHA256: ${{ inputs.ripsecrets-sha256 }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        curl -fsSL -o /tmp/ripsecrets.tar.gz \
+        curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
+          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+          -o /tmp/ripsecrets.tar.gz \
           "https://github.com/sirwart/ripsecrets/releases/download/v${RIPSECRETS_VERSION}/ripsecrets-${RIPSECRETS_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
         echo "${RIPSECRETS_SHA256}  /tmp/ripsecrets.tar.gz" | sha256sum -c -
         tar -xzf /tmp/ripsecrets.tar.gz -C /tmp
@@ -199,8 +219,11 @@ runs:
       env:
         TREEFMT_VERSION: ${{ inputs.treefmt-version }}
         TREEFMT_SHA256: ${{ inputs.treefmt-sha256 }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        curl -fsSL -o /tmp/treefmt.tar.gz \
+        curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
+          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+          -o /tmp/treefmt.tar.gz \
           "https://github.com/numtide/treefmt/releases/download/v${TREEFMT_VERSION}/treefmt_${TREEFMT_VERSION}_linux_amd64.tar.gz"
         echo "${TREEFMT_SHA256}  /tmp/treefmt.tar.gz" | sha256sum -c -
         tar -xzf /tmp/treefmt.tar.gz -C /tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   eliminating flakes where 6 parallel CI jobs tripped the unauthenticated
   `raw.githubusercontent.com` per-IP rate limit
   ([#155](https://github.com/aidanns/agent-auth/issues/155)).
+- `setup-toolchain` release-binary installs (shellcheck, shfmt, ruff, taplo,
+  keep-sorted, ripsecrets, treefmt) now download with the same
+  `--retry 2 --retry-delay 2 --retry-all-errors` flags and authenticated
+  `Authorization: Bearer ${github-token}` header used by the
+  systems-engineering step, absorbing transient GitHub-release-download
+  flakes and lifting the per-IP anonymous rate limit
+  ([#159](https://github.com/aidanns/agent-auth/issues/159)).
 
 ## [0.1.0] - 2026-04-19
 


### PR DESCRIPTION
## Summary

- Applies the retry + auth pattern from #155 (systems-engineering install) to the 7 sibling release-binary installs in `.github/actions/setup-toolchain/action.yml`: shellcheck, shfmt, ruff, taplo, keep-sorted, ripsecrets, treefmt.
- Each `curl` now uses `--retry 2 --retry-delay 2 --retry-all-errors` and sends `Authorization: Bearer ${github-token}`, lifting the per-IP anonymous rate limit and absorbing transient flakes.
- sha256 pinning + verification are preserved unchanged; no other behaviour change.

Closes #159. Follow-up simplify review opportunities (extract a shared fetch helper, retune retry params to honour `Retry-After`, parallelise downloads) tracked in #165.

## Security note

curl strips the `Authorization` header on cross-origin redirects (curl 7.64+, covered on all ubuntu runners). The github.com → S3 asset redirect is cross-origin, so the token is only seen by github.com.

## Test plan

- [x] New PR CI run against this branch completes cleanly (every install step passes with the auth-header + retry flags present). *All 13 checks green on f501847.*
- [x] Inspect a CI log for one of the touched steps (e.g. `Install ruff`) and confirm the curl invocation shows `--retry 2 --retry-delay 2 --retry-all-errors` and no 403/429. *Confirmed in `check` run 24719266861 — `/tmp/ruff.tar.gz: OK` and retry flags visible.*
- [x] Confirm the sha256 verification step still runs after each download (integrity check not dropped). *Confirmed: `echo \"\${RUFF_SHA256}  /tmp/ruff.tar.gz\" | sha256sum -c -` runs immediately after each curl.*
- [x] CHANGELOG.md \"Unreleased → Fixed\" entry for #159 renders alongside the existing #155 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)