### PR TITLE
feat(audit): add schema_version field and stability policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Audit-log `schema_version` field (currently `1`) emitted on every
+  entry, with a documented stability policy in
+  `design/DESIGN.md` "Audit log fields" and a contract test that
+  fails if the version changes
+  ([#20](https://github.com/aidanns/agent-auth/issues/20)).
 - Community-health files to complete the GitHub Community Profile: Contributor
   Covenant v3.0 Code of Conduct, issue templates (bug report, feature request,
   security redirect), pull-request template, and SUPPORT.md. CoC and SUPPORT

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -807,9 +807,11 @@ Prometheus text and JSON-lines directly and does not depend on the
 OpenTelemetry SDK or OTLP transport.
 
 `GET /agent-auth/metrics` and `GET /things-bridge/metrics` are not
-yet implemented (tracked in #26). The audit log schema is not yet
-pinned by contract tests (tracked in #20). Log-level policy and
-retention policy are deferred to the dedicated observability design
+yet implemented (tracked in #26). The audit-log schema is pinned by
+contract tests in `tests/test_audit_schema.py` and versioned via
+`SCHEMA_VERSION` in `src/agent_auth/audit.py` (see "Audit log
+fields" below). Log-level policy and retention policy are deferred
+to the dedicated observability design
 document (tracked in #33), which will also hold the full metrics
 catalogue. This section pins the naming standard those efforts
 build against; it does not yet satisfy
@@ -838,6 +840,27 @@ only pins that they stay outside the OTel namespace.
 ### Audit log fields
 
 The audit log at `$XDG_STATE_HOME/agent-auth/audit.log` is JSON-lines.
+The on-disk format is part of the project's public surface and is
+versioned via the `schema_version` field emitted on every entry
+(current value: `1`; constant `SCHEMA_VERSION` in
+`src/agent_auth/audit.py`).
+
+**Stability policy** — downstream consumers (SIEM, compliance,
+forensics) can rely on the following guarantees within a given
+`schema_version`:
+
+- Adding a new optional field is non-breaking; the version stays the
+  same.
+- Adding a new `event` kind is non-breaking; the version stays the
+  same.
+- Renaming, removing, or re-typing an existing field is a breaking
+  change; `SCHEMA_VERSION` must be bumped and the change announced
+  in `CHANGELOG.md`.
+
+Contract tests in `tests/test_audit_schema.py` pin every documented
+event kind and fail if a field is renamed, removed, or re-typed
+without a version bump.
+
 Fields fall into two groups:
 
 **HTTP request attributes (OTel HTTP semconv keys)** — populated on
@@ -870,20 +893,21 @@ trails can be joined across services:
 state, not HTTP mechanics. No OTel equivalent exists; these keep
 their existing names:
 
-| Field        | Type   | Description                                                                                                                                                            |
-| ------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `timestamp`  | string | ISO 8601 UTC emit time. Kept as `timestamp` (flat JSON, not an OTel LogRecord envelope).                                                                               |
-| `event`      | string | Discriminator — `validation_allowed`, `validation_denied`, `token_created`, `token_refreshed`, `token_reissued`, `token_revoked`, `scopes_modified`, `reissue_denied`. |
-| `token_id`   | string | Opaque token identifier.                                                                                                                                               |
-| `family_id`  | string | Opaque token-family identifier.                                                                                                                                        |
-| `scope`      | string | The single requested scope.                                                                                                                                            |
-| `scopes`     | list   | Scopes on a family (on create / modify events).                                                                                                                        |
-| `tier`       | string | `allow`, `prompt`, or `deny`.                                                                                                                                          |
-| `grant_type` | string | JIT grant flavour on a `prompt`-tier approval.                                                                                                                         |
-| `reason`     | string | Denial reason code on `validation_denied` / `reissue_denied`.                                                                                                          |
+| Field            | Type   | Description                                                                                                                                                                                                                    |
+| ---------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `timestamp`      | string | ISO 8601 UTC emit time. Kept as `timestamp` (flat JSON, not an OTel LogRecord envelope).                                                                                                                                       |
+| `schema_version` | int    | Wire-format version of the audit-log schema (currently `1`). See the stability policy above.                                                                                                                                   |
+| `event`          | string | Discriminator — `validation_allowed`, `validation_denied`, `token_created`, `token_refreshed`, `token_reissued`, `token_revoked`, `token_rotated`, `scopes_modified`, `reissue_denied`, `approval_granted`, `approval_denied`. |
+| `token_id`       | string | Opaque token identifier.                                                                                                                                                                                                       |
+| `family_id`      | string | Opaque token-family identifier.                                                                                                                                                                                                |
+| `scope`          | string | The single requested scope.                                                                                                                                                                                                    |
+| `scopes`         | list   | Scopes on a family (on create / modify events).                                                                                                                                                                                |
+| `tier`           | string | `allow`, `prompt`, or `deny`.                                                                                                                                                                                                  |
+| `grant_type`     | string | JIT grant flavour on a `prompt`-tier approval.                                                                                                                                                                                 |
+| `reason`         | string | Denial reason code on `validation_denied` / `reissue_denied`.                                                                                                                                                                  |
 
-Contract tests pinning the schema (#20) and the dedicated
-observability design (#33) extend this mapping.
+The dedicated observability design (#33) will extend this mapping
+with log-level policy and retention details.
 
 ## Security Considerations
 

--- a/src/agent_auth/audit.py
+++ b/src/agent_auth/audit.py
@@ -10,14 +10,24 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+# Audit log schema version. Emitted on every entry so downstream consumers
+# (SIEM, compliance, forensics) can detect the schema at parse time.
+#
+# Stability policy (see design/DESIGN.md "Audit log fields"):
+#   - Adding a new optional field is non-breaking; version stays the same.
+#   - Adding a new `event` kind is non-breaking; version stays the same.
+#   - Renaming, removing, or re-typing an existing field is a breaking
+#     change; bump SCHEMA_VERSION and announce in CHANGELOG.md.
+SCHEMA_VERSION = 1
+
 
 class AuditLogger:
     """Writes JSON-lines audit log entries to a file.
 
     The on-disk format is part of the project's public surface: one JSON
-    object per line with at minimum ``timestamp`` (ISO 8601 UTC) and
-    ``event`` keys, plus any event-specific fields. See
-    ``tests/test_audit.py`` for the contract.
+    object per line with at minimum ``timestamp`` (ISO 8601 UTC),
+    ``schema_version`` (int), and ``event`` keys, plus any event-specific
+    fields. See ``tests/test_audit_schema.py`` for the contract.
     """
 
     def __init__(self, log_path: str):
@@ -29,6 +39,7 @@ class AuditLogger:
         """Write an audit log entry."""
         entry = {
             "timestamp": datetime.now(UTC).isoformat(),
+            "schema_version": SCHEMA_VERSION,
             "event": event,
             **details,
         }

--- a/tests/test_audit_schema.py
+++ b/tests/test_audit_schema.py
@@ -10,6 +10,9 @@ present with the correct names and types.
 
 Breaking schema changes (renaming a field, removing a field) will fail
 these tests, which is the intent: the on-disk format is public API.
+A breaking change must also bump ``SCHEMA_VERSION`` in
+``src/agent_auth/audit.py`` and announce in ``CHANGELOG.md`` (see
+``design/DESIGN.md`` "Audit log fields").
 
 Documented events
 -----------------
@@ -22,7 +25,7 @@ Authorization decisions: validation_allowed, validation_denied,
 import json
 from datetime import datetime
 
-from agent_auth.audit import AuditLogger
+from agent_auth.audit import SCHEMA_VERSION, AuditLogger
 
 # -- helpers --
 
@@ -38,9 +41,22 @@ def _read_last_entry(path: str) -> dict:
     return json.loads(lines[-1])
 
 
+def test_schema_version_value(tmp_path):
+    # The current wire-format schema version. A breaking change to the
+    # audit-log schema must bump this constant.
+    assert SCHEMA_VERSION == 1
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log("token_created", family_id="fam-1")
+    entry = _read_last_entry(_log_path(tmp_path))
+    assert entry["schema_version"] == SCHEMA_VERSION
+
+
 def _assert_base_fields(entry: dict) -> None:
     assert "timestamp" in entry
     assert "event" in entry
+    assert "schema_version" in entry
+    assert isinstance(entry["schema_version"], int)
+    assert entry["schema_version"] == SCHEMA_VERSION
     ts = entry["timestamp"]
     # Must be ISO 8601 UTC (ends with +00:00 or Z)
     assert ts.endswith("+00:00") or ts.endswith("Z"), f"timestamp not UTC: {ts!r}"


### PR DESCRIPTION
## Summary

- Every audit-log entry now carries a `schema_version` field (currently `1`) so downstream consumers (SIEM, compliance, forensics) can detect the schema at parse time.
- Stability policy documented in `design/DESIGN.md` "Audit log fields": additive changes (new field, new event kind) keep the version; rename / removal / retype bumps `SCHEMA_VERSION` and goes to `CHANGELOG.md`.
- Contract tests assert the new base field on every event and pin the current version number.

Closes the third acceptance item on #20 — the first two (explicit per-event schemas, field contract tests) landed in #126. Closes #20.

## Test plan

- [ ] `uv run pytest tests/test_audit.py tests/test_audit_schema.py --no-cov` passes
- [ ] `uv run pytest tests/ --ignore=tests/integration --no-cov` passes
- [ ] `bash scripts/verify-standards.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)