### PR TITLE
ci(setup-toolchain): consolidate release-asset downloads into shared helper

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -85,12 +85,11 @@ runs:
         SYSTEMS_ENGINEERING_REF: ${{ inputs.systems-engineering-ref }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        # Authenticated Contents API avoids raw.githubusercontent.com per-IP
-        # rate limits when parallel CI jobs race for install.sh. See #155.
-        # --retry-all-errors (curl 7.71+, shipped on GitHub ubuntu runners) is
-        # load-bearing: plain --retry skips HTTP 4xx, which is what the rate
-        # limit returns.
-        curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
+        # Stays inline (not via scripts/ci/fetch-release-asset.sh) because
+        # it fetches via the Contents API with a custom Accept header and
+        # has no pinned sha256 (dynamic ref). See the helper for retry-flag
+        # rationale.
+        curl -fsSL --retry 5 --retry-max-time 60 --retry-all-errors \
           -H "Accept: application/vnd.github.raw" \
           -H "Authorization: Bearer ${GITHUB_TOKEN}" \
           -o /tmp/systems-engineering-install.sh \
@@ -112,13 +111,10 @@ runs:
         SHELLCHECK_SHA256: ${{ inputs.shellcheck-sha256 }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        # Auth is safe: curl -L strips the Authorization header on the
-        # cross-origin redirect from github.com to the S3 asset URL. See #159.
-        curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
-          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-          -o /tmp/shellcheck.tar.xz \
-          "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
-        echo "${SHELLCHECK_SHA256}  /tmp/shellcheck.tar.xz" | sha256sum -c -
+        scripts/ci/fetch-release-asset.sh \
+          "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+          /tmp/shellcheck.tar.xz \
+          "${SHELLCHECK_SHA256}"
         tar -xJf /tmp/shellcheck.tar.xz -C /tmp
         sudo install -m0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
         shellcheck --version
@@ -130,11 +126,10 @@ runs:
         SHFMT_SHA256: ${{ inputs.shfmt-sha256 }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
-          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-          -o /tmp/shfmt \
-          "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
-        echo "${SHFMT_SHA256}  /tmp/shfmt" | sha256sum -c -
+        scripts/ci/fetch-release-asset.sh \
+          "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
+          /tmp/shfmt \
+          "${SHFMT_SHA256}"
         sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
         shfmt --version
 
@@ -145,11 +140,10 @@ runs:
         RUFF_SHA256: ${{ inputs.ruff-sha256 }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
-          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-          -o /tmp/ruff.tar.gz \
-          "https://github.com/astral-sh/ruff/releases/download/${RUFF_VERSION}/ruff-x86_64-unknown-linux-gnu.tar.gz"
-        echo "${RUFF_SHA256}  /tmp/ruff.tar.gz" | sha256sum -c -
+        scripts/ci/fetch-release-asset.sh \
+          "https://github.com/astral-sh/ruff/releases/download/${RUFF_VERSION}/ruff-x86_64-unknown-linux-gnu.tar.gz" \
+          /tmp/ruff.tar.gz \
+          "${RUFF_SHA256}"
         tar -xzf /tmp/ruff.tar.gz -C /tmp
         sudo install -m0755 /tmp/ruff-x86_64-unknown-linux-gnu/ruff /usr/local/bin/ruff
         ruff --version
@@ -174,11 +168,10 @@ runs:
         TAPLO_SHA256: ${{ inputs.taplo-sha256 }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
-          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-          -o /tmp/taplo.gz \
-          "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz"
-        echo "${TAPLO_SHA256}  /tmp/taplo.gz" | sha256sum -c -
+        scripts/ci/fetch-release-asset.sh \
+          "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
+          /tmp/taplo.gz \
+          "${TAPLO_SHA256}"
         gunzip -f /tmp/taplo.gz
         sudo install -m0755 /tmp/taplo /usr/local/bin/taplo
         taplo --version
@@ -190,11 +183,10 @@ runs:
         KEEP_SORTED_SHA256: ${{ inputs.keep-sorted-sha256 }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
-          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-          -o /tmp/keep-sorted \
-          "https://github.com/google/keep-sorted/releases/download/v${KEEP_SORTED_VERSION}/keep-sorted_linux"
-        echo "${KEEP_SORTED_SHA256}  /tmp/keep-sorted" | sha256sum -c -
+        scripts/ci/fetch-release-asset.sh \
+          "https://github.com/google/keep-sorted/releases/download/v${KEEP_SORTED_VERSION}/keep-sorted_linux" \
+          /tmp/keep-sorted \
+          "${KEEP_SORTED_SHA256}"
         sudo install -m0755 /tmp/keep-sorted /usr/local/bin/keep-sorted
         keep-sorted --version
 
@@ -205,11 +197,10 @@ runs:
         RIPSECRETS_SHA256: ${{ inputs.ripsecrets-sha256 }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
-          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-          -o /tmp/ripsecrets.tar.gz \
-          "https://github.com/sirwart/ripsecrets/releases/download/v${RIPSECRETS_VERSION}/ripsecrets-${RIPSECRETS_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-        echo "${RIPSECRETS_SHA256}  /tmp/ripsecrets.tar.gz" | sha256sum -c -
+        scripts/ci/fetch-release-asset.sh \
+          "https://github.com/sirwart/ripsecrets/releases/download/v${RIPSECRETS_VERSION}/ripsecrets-${RIPSECRETS_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+          /tmp/ripsecrets.tar.gz \
+          "${RIPSECRETS_SHA256}"
         tar -xzf /tmp/ripsecrets.tar.gz -C /tmp
         sudo install -m0755 "/tmp/ripsecrets-${RIPSECRETS_VERSION}-x86_64-unknown-linux-gnu/ripsecrets" /usr/local/bin/ripsecrets
         ripsecrets --version
@@ -221,11 +212,10 @@ runs:
         TREEFMT_SHA256: ${{ inputs.treefmt-sha256 }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
-          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-          -o /tmp/treefmt.tar.gz \
-          "https://github.com/numtide/treefmt/releases/download/v${TREEFMT_VERSION}/treefmt_${TREEFMT_VERSION}_linux_amd64.tar.gz"
-        echo "${TREEFMT_SHA256}  /tmp/treefmt.tar.gz" | sha256sum -c -
+        scripts/ci/fetch-release-asset.sh \
+          "https://github.com/numtide/treefmt/releases/download/v${TREEFMT_VERSION}/treefmt_${TREEFMT_VERSION}_linux_amd64.tar.gz" \
+          /tmp/treefmt.tar.gz \
+          "${TREEFMT_SHA256}"
         tar -xzf /tmp/treefmt.tar.gz -C /tmp
         sudo install -m0755 /tmp/treefmt /usr/local/bin/treefmt
         treefmt --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GET /agent-auth/token/list` are now served at `/agent-auth/v1/token/...`.
   Completes the `/v1/` API namespace migration so every non-health route is
   versioned (enforced by `scripts/verify-standards.sh`).
+- `setup-toolchain` release-binary installs now go through a shared
+  `scripts/ci/fetch-release-asset.sh` helper (curl + auth + sha256 verify)
+  rather than open-coding the same block in 7 steps. Retry flags retuned
+  to `--retry 5 --retry-max-time 60 --retry-all-errors` (no explicit
+  `--retry-delay`) so curl honours `Retry-After` and exponential backoff
+  on 429s/5xx. `Install systems-engineering` stays inline (Contents API
+  with a custom Accept header and no pinned sha256) but picks up the
+  same retry retune. Part 3 of the follow-up (parallelise downloads) is
+  tracked separately
+  ([#165](https://github.com/aidanns/agent-auth/issues/165)).
 
 ### Fixed
 

--- a/plans/setup-toolchain-fetch-release-asset-helper.md
+++ b/plans/setup-toolchain-fetch-release-asset-helper.md
@@ -1,0 +1,139 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# Plan: Consolidate setup-toolchain release-asset downloads into a shared helper
+
+Resolves parts 1 and 2 of [#165](https://github.com/aidanns/agent-auth/issues/165).
+Part 3 (parallelise downloads) is deferred to a follow-up issue because it
+is a larger structural change and the issue itself sequences it after
+part 1.
+
+## Problem
+
+After `#166` landed, `.github/actions/setup-toolchain/action.yml` has 7
+near-identical steps (`shellcheck`, `shfmt`, `ruff`, `taplo`,
+`keep-sorted`, `ripsecrets`, `treefmt`) that all run:
+
+```bash
+curl -fsSL --retry 2 --retry-delay 2 --retry-all-errors \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -o /tmp/<name>.<ext> \
+  "<release-url>"
+echo "${<NAME>_SHA256}  /tmp/<name>.<ext>" | sha256sum -c -
+```
+
+Two scoped-out opportunities from the simplify review of `#159`'s PR:
+
+1. The 7 blocks are pure duplication — any new hardening (connect
+   timeout, mirror fallback, log-suppression tweak) has to be applied
+   7 times.
+2. `--retry 2 --retry-delay 2` disables curl's built-in exponential
+   backoff and caps recovery at ~4s. `--retry 5 --retry-max-time 60`
+   with no explicit `--retry-delay` lets curl honour `Retry-After` and
+   exponential backoff on 429s/5xx — better recovery on the kind of
+   transient failure the retry is there to catch, at zero cost on the
+   happy path.
+
+## Approach
+
+1. **Extract `scripts/ci/fetch-release-asset.sh <url> <out-path> <sha256>`.**
+   The helper encapsulates the curl+auth+retry+sha256 pattern. Each of
+   the 7 action steps calls it once and then handles its own
+   extraction/install (which genuinely differs per tool — `.tar.xz`,
+   `.tar.gz`, `.gz`, raw binary).
+2. **Retune the retry params inside the helper.** One change point
+   rather than 7. Use `--retry 5 --retry-max-time 60 --retry-all-errors`
+   with no `--retry-delay`.
+3. **Also retune `Install systems-engineering`.** That step stays
+   inline because it fetches via the Contents API with
+   `Accept: application/vnd.github.raw` and has no sha256 to check —
+   it does not fit the helper's signature. But it benefits from the
+   same retry-param retune, so apply Part 2 to it in-place.
+
+Helper signature (verbatim from the issue):
+
+```
+scripts/ci/fetch-release-asset.sh <url> <out-path> <sha256>
+```
+
+- Reads `GITHUB_TOKEN` from env. Error out with a clear message if
+  unset — authenticated download is now the only path and missing
+  auth will just fail opaquely on the curl side otherwise.
+- `<out-path>` is where the asset ends up on disk.
+- `<sha256>` is the hex digest; verified with `sha256sum -c -` right
+  after download. Verification failure aborts the script.
+
+Rejected alternatives:
+
+- **Unify systems-engineering into the same helper** via an optional
+  `--accept`/`--no-sha256` flag. The flag surface makes the 7 simple
+  calls harder to read and systems-engineering is a one-off — the
+  duplication isn't here. Keep it inline.
+- **Move extraction (`tar -xJf`, `gunzip`, ...) into the helper.** The
+  extraction step is genuinely heterogeneous (4 shapes across 7 tools)
+  and the install target differs (path inside extracted dir vs.
+  standalone binary). A tar/gunzip dispatcher inside the helper adds
+  more complexity than it saves.
+- **Mirror fallback / connect-timeout now.** Out of scope for #165 —
+  the helper just makes it a one-line change when we want it.
+
+## Changes
+
+1. `scripts/ci/fetch-release-asset.sh` (new) — bash script following
+   the project's standard shape (`set -euo pipefail`, description
+   comment surrounded by single blank lines, SPDX header). Uses
+   `curl -fsSL --retry 5 --retry-max-time 60 --retry-all-errors`
+   with `Authorization: Bearer ${GITHUB_TOKEN}`, writes to
+   `<out-path>`, then runs `echo "<sha256>  <out-path>" | sha256sum -c -`.
+2. `.github/actions/setup-toolchain/action.yml` —
+   - Each of the 7 release-binary install steps calls
+     `${GITHUB_ACTION_PATH}/../../../scripts/ci/fetch-release-asset.sh`
+     instead of open-coding the curl+sha256 block.
+   - `GITHUB_TOKEN` is exported via `env:` to make it available to the
+     helper (same pattern as the current systems-engineering step).
+   - `Install systems-engineering` step retunes its curl flags to
+     `--retry 5 --retry-max-time 60 --retry-all-errors` (drops
+     `--retry-delay 2`). No other behaviour change.
+3. `CHANGELOG.md` — add an Unreleased "Changed" entry referencing #165.
+
+## Verification
+
+- `shellcheck scripts/ci/fetch-release-asset.sh` and `shfmt -d` clean
+  (via `treefmt` / `lefthook pre-commit`).
+- PR CI run passes: every setup-toolchain step still resolves the
+  binary, verifies sha256, and installs the tool. The wall-time is
+  unchanged on the happy path; only the retry shape differs on
+  failure.
+- Spot-check one install step's CI log for the new curl flags
+  (`--retry 5 --retry-max-time 60`) and absence of `--retry-delay 2`.
+- sha256 verification stays in place — confirm the `install tool`
+  step still fails if we deliberately corrupt the pinned digest
+  (mental smoke test, not an automated one).
+
+## Skipped plan-template steps
+
+- **Design / threat-model / ADR / cybersecurity / QM-SIL** — this is
+  CI-tooling refactor inside a composite action plus one new bash
+  helper. No runtime behaviour, no security posture change, no
+  external surface.
+- **Post-implementation standards review** — only
+  `tooling-and-ci.md` and `bash.md` are relevant.
+  `tooling-and-ci.md` § CI mandates sha256 pinning for tool binary
+  downloads — the helper preserves that contract (verification still
+  happens, and an unverified binary aborts the run).
+  `bash.md` requires `shellcheck` and `shfmt` clean — enforced by
+  `treefmt`/`lefthook` on the new script. `coding-standards.md`,
+  `service-design.md`, `testing-standards.md`,
+  `release-and-hygiene.md` do not apply.
+
+## Deferred
+
+Part 3 of #165 (parallelise release-binary downloads via
+`curl --parallel --parallel-max 7`) is tracked in a follow-up issue
+created at PR-open time. It is deferred because it restructures the
+composite action (merging 7 sequential steps into one `run:` block
+with separate per-tool extract/install steps) and the issue already
+calls it out as "a bigger structural change — do after (1)".

--- a/scripts/ci/fetch-release-asset.sh
+++ b/scripts/ci/fetch-release-asset.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Download a GitHub release asset with authenticated curl + retry, then
+# verify its sha256. Used by .github/actions/setup-toolchain to install CI
+# tools (shellcheck, shfmt, ruff, taplo, keep-sorted, ripsecrets, treefmt)
+# from a single code path so hardening (retry shape, auth header, mirror
+# fallback) lives in one place.
+#
+# Usage: fetch-release-asset.sh <url> <out-path> <sha256>
+#
+# Requires GITHUB_TOKEN in the environment — authenticated download is the
+# only supported path (shares the 5,000/hr token budget instead of the
+# anonymous per-IP limit). Extraction and install are the caller's
+# responsibility because binary shapes (.tar.xz, .tar.gz, .gz, raw) differ
+# per tool.
+#
+# Auth is safe: curl -L strips the Authorization header on cross-origin
+# redirects, so the bearer token only reaches github.com and never the
+# S3 asset URL it redirects to. See #159.
+
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "fetch-release-asset: expected 3 args (url, out-path, sha256); got $#" >&2
+  exit 2
+fi
+
+url="$1"
+out_path="$2"
+sha256="$3"
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "fetch-release-asset: GITHUB_TOKEN must be set (authenticated download is required)." >&2
+  exit 2
+fi
+
+# --retry-all-errors (curl 7.71+) is load-bearing: plain --retry skips HTTP
+# 4xx, which is what GitHub rate-limit responses return. --retry-max-time
+# bounds total retry wall-time and lets curl honour Retry-After and
+# exponential backoff between attempts without an explicit --retry-delay.
+curl -fsSL \
+  --retry 5 \
+  --retry-max-time 60 \
+  --retry-all-errors \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -o "${out_path}" \
+  "${url}"
+
+echo "${sha256}  ${out_path}" | sha256sum -c -


### PR DESCRIPTION
## Summary

- Extracts `scripts/ci/fetch-release-asset.sh` (curl + auth + retry + sha256 verify) and replaces the 7 near-identical install blocks in `.github/actions/setup-toolchain/action.yml` (shellcheck, shfmt, ruff, taplo, keep-sorted, ripsecrets, treefmt) with calls to it. New hardening (connect timeout, mirror fallback, logging tweaks) now lives in one place.
- Retunes retry flags to `--retry 5 --retry-max-time 60 --retry-all-errors` with no explicit `--retry-delay` so curl honours `Retry-After` and uses exponential backoff on 429s/5xx. The previous `--retry 2 --retry-delay 2` disabled backoff and capped recovery at ~4s.
- `Install systems-engineering` stays inline — it uses the Contents API with a custom `Accept: application/vnd.github.raw` header and has no pinned sha256 (dynamic ref), so it doesn't fit the helper's signature — but picks up the same retry retune.

Closes #165. Part 3 of that issue (parallelise the 7 downloads) is tracked in #168 because it's a bigger structural change.

## Security note

`curl -L` strips the `Authorization` header on cross-origin redirects (curl 7.64+, on all ubuntu runners). The bearer token is only seen by `github.com`, not the S3 asset URL it redirects to. Same property relied on by #159.

## Test plan

- [x] PR CI run completes cleanly — every setup-toolchain step installs its tool via the helper and reports the version.
- [x] Inspect a CI log for one of the refactored steps (e.g. `Install ruff`) and confirm: the helper path is invoked, curl is called with `--retry 5 --retry-max-time 60 --retry-all-errors` (and no `--retry-delay 2`), sha256 verification runs, tool is installed. (Confirmed in run 24719872565: 7 `scripts/ci/fetch-release-asset.sh` invocations, `/tmp/ruff.tar.gz: OK` from sha256sum.)
- [x] Confirm `Install systems-engineering` also logs `--retry 5 --retry-max-time 60 --retry-all-errors` after the retry retune. (Confirmed in same run's log.)
- [x] `shellcheck` / `shfmt` / `treefmt` / `reuse lint` all green on the new `scripts/ci/fetch-release-asset.sh`.
- [x] CHANGELOG.md "Unreleased → Changed" entry for #165 renders alongside the existing #155 / #159 "Fixed" entries.
- [x] Follow-up issue #168 (parallelise downloads) is filed and linked from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)