### PR TITLE
docs: fix stale credentials.json reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The fake CLI is not shipped in the sdist/wheel — it lives under `tests/` and i
 ```bash
 # Save credentials — the CLI prompts interactively for tokens so they
 # don't appear in shell history. Alternatively, pre-populate the
-# credentials file at ~/.config/things-cli/credentials.json.
+# credentials file at ~/.config/things-cli/credentials.yaml.
 things-cli login \
   --bridge-url http://127.0.0.1:9200 \
   --auth-url http://127.0.0.1:9100 \


### PR DESCRIPTION
## Summary

- README's `things-cli login` example still carried a comment referring to `~/.config/things-cli/credentials.json`, even though the surrounding prose and the actual fallback file format are YAML (migrated in #126).

Closes the final docs acceptance item on #24. Closes #24.

## Test plan

- [ ] README renders with consistent YAML wording throughout the `things-cli` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)