### PR TITLE
docs: mention /metrics in the API versioning policy

### DIFF
--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -403,9 +403,10 @@ All HTTP endpoints (both agent-auth and things-bridge) are versioned under a
 `/v1/` path segment. This allows breaking changes to be introduced under `/v2/`
 while existing clients continue to use `/v1/`.
 
-Health endpoints (`/agent-auth/health`, `/things-bridge/health`) are unversioned
-by convention — probes and monitoring tools should always be able to reach them
-regardless of API version.
+Health and metrics endpoints (`/agent-auth/health`, `/things-bridge/health`,
+and the future `/agent-auth/metrics` / `/things-bridge/metrics` — tracked in
+#26) are unversioned by convention — probes, monitoring tools, and Prometheus
+scrapes should always be able to reach them regardless of API version.
 
 **What constitutes a breaking change (requires `/v2/`):**
 

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -968,25 +968,29 @@ fi
 
 echo "verify-standards: config files use YAML (no config.json or json.load in config.py)."
 
-# API versioning: every registered HTTP route (outside /health) must match
-# ^/(agent-auth|things-bridge)/v[0-9]+/
-# (.claude/instructions/service-design.md — URL-versioned APIs).
+# API versioning: every registered HTTP route (outside /health and /metrics)
+# must match ^/(agent-auth|things-bridge)/v[0-9]+/
+# (.claude/instructions/service-design.md — URL-versioned APIs; see
+# design/DESIGN.md "API Versioning Policy" for the health/metrics
+# convention). /metrics is unimplemented today (#26) but is pre-excluded
+# so the check stays honest once the endpoint lands.
 # agent-auth/server.py uses `self.path ==`; things_bridge/server.py uses
 # bare `path ==` / `path.startswith` — both patterns are checked.
 unversioned_routes=$(grep -En \
   '(self\.path|[^_]path) (==|\.startswith\() "/' \
   src/agent_auth/server.py src/things_bridge/server.py 2>/dev/null \
   | grep -v '/health' \
+  | grep -v '/metrics' \
   | grep -v '/v[0-9]\+/' \
   | grep -v '# unversioned' || true)
 if [[ -n "${unversioned_routes}" ]]; then
   echo "verify-standards: unversioned HTTP routes found in server files:" >&2
   echo "${unversioned_routes}" >&2
-  echo "  All endpoints (except /health) must use the /v1/ namespace." >&2
+  echo "  All endpoints (except /health and /metrics) must use the /v1/ namespace." >&2
   exit 1
 fi
 
-echo "verify-standards: all non-health HTTP routes are versioned (/v1/)."
+echo "verify-standards: all non-health/metrics HTTP routes are versioned (/v1/)."
 
 # Audit schema contract tests: tests/test_audit_schema.py must exist and
 # reference each documented event kind


### PR DESCRIPTION
## Summary

- `design/DESIGN.md` "API Versioning Policy" documented `/health` as unversioned by convention but omitted `/metrics`. Add metrics alongside health — Prometheus scrapes need the same stability guarantee.
- Pre-exclude `/metrics` in `scripts/verify-standards.sh`'s unversioned-route check so the gate stays correct once #26 lands the endpoint.

Closes the last acceptance bullet on #27. Closes #27.

## Test plan

- [ ] `bash scripts/verify-standards.sh` passes with the updated success message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)