### PR TITLE
ci(setup-toolchain): parallelise release-binary downloads

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -104,50 +104,6 @@ runs:
         version: ${{ inputs.go-task-version }}
         repo-token: ${{ inputs.github-token }}
 
-    - name: Install shellcheck
-      shell: bash
-      env:
-        SHELLCHECK_VERSION: ${{ inputs.shellcheck-version }}
-        SHELLCHECK_SHA256: ${{ inputs.shellcheck-sha256 }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: |
-        scripts/ci/fetch-release-asset.sh \
-          "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
-          /tmp/shellcheck.tar.xz \
-          "${SHELLCHECK_SHA256}"
-        tar -xJf /tmp/shellcheck.tar.xz -C /tmp
-        sudo install -m0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
-        shellcheck --version
-
-    - name: Install shfmt
-      shell: bash
-      env:
-        SHFMT_VERSION: ${{ inputs.shfmt-version }}
-        SHFMT_SHA256: ${{ inputs.shfmt-sha256 }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: |
-        scripts/ci/fetch-release-asset.sh \
-          "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
-          /tmp/shfmt \
-          "${SHFMT_SHA256}"
-        sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
-        shfmt --version
-
-    - name: Install ruff
-      shell: bash
-      env:
-        RUFF_VERSION: ${{ inputs.ruff-version }}
-        RUFF_SHA256: ${{ inputs.ruff-sha256 }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: |
-        scripts/ci/fetch-release-asset.sh \
-          "https://github.com/astral-sh/ruff/releases/download/${RUFF_VERSION}/ruff-x86_64-unknown-linux-gnu.tar.gz" \
-          /tmp/ruff.tar.gz \
-          "${RUFF_SHA256}"
-        tar -xzf /tmp/ruff.tar.gz -C /tmp
-        sudo install -m0755 /tmp/ruff-x86_64-unknown-linux-gnu/ruff /usr/local/bin/ruff
-        ruff --version
-
     - name: Install mdformat
       shell: bash
       env:
@@ -161,64 +117,128 @@ runs:
           --with "mdformat-tables==${MDFORMAT_TABLES_VERSION}"
         mdformat --version
 
-    - name: Install taplo
-      shell: bash
-      env:
-        TAPLO_VERSION: ${{ inputs.taplo-version }}
-        TAPLO_SHA256: ${{ inputs.taplo-sha256 }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: |
-        scripts/ci/fetch-release-asset.sh \
-          "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
-          /tmp/taplo.gz \
-          "${TAPLO_SHA256}"
-        gunzip -f /tmp/taplo.gz
-        sudo install -m0755 /tmp/taplo /usr/local/bin/taplo
-        taplo --version
-
-    - name: Install keep-sorted
+    - name: Install release binaries
       shell: bash
       env:
         KEEP_SORTED_VERSION: ${{ inputs.keep-sorted-version }}
         KEEP_SORTED_SHA256: ${{ inputs.keep-sorted-sha256 }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: |
-        scripts/ci/fetch-release-asset.sh \
-          "https://github.com/google/keep-sorted/releases/download/v${KEEP_SORTED_VERSION}/keep-sorted_linux" \
-          /tmp/keep-sorted \
-          "${KEEP_SORTED_SHA256}"
-        sudo install -m0755 /tmp/keep-sorted /usr/local/bin/keep-sorted
-        keep-sorted --version
-
-    - name: Install ripsecrets
-      shell: bash
-      env:
         RIPSECRETS_VERSION: ${{ inputs.ripsecrets-version }}
         RIPSECRETS_SHA256: ${{ inputs.ripsecrets-sha256 }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: |
-        scripts/ci/fetch-release-asset.sh \
-          "https://github.com/sirwart/ripsecrets/releases/download/v${RIPSECRETS_VERSION}/ripsecrets-${RIPSECRETS_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
-          /tmp/ripsecrets.tar.gz \
-          "${RIPSECRETS_SHA256}"
-        tar -xzf /tmp/ripsecrets.tar.gz -C /tmp
-        sudo install -m0755 "/tmp/ripsecrets-${RIPSECRETS_VERSION}-x86_64-unknown-linux-gnu/ripsecrets" /usr/local/bin/ripsecrets
-        ripsecrets --version
-
-    - name: Install treefmt
-      shell: bash
-      env:
+        RUFF_VERSION: ${{ inputs.ruff-version }}
+        RUFF_SHA256: ${{ inputs.ruff-sha256 }}
+        SHELLCHECK_VERSION: ${{ inputs.shellcheck-version }}
+        SHELLCHECK_SHA256: ${{ inputs.shellcheck-sha256 }}
+        SHFMT_VERSION: ${{ inputs.shfmt-version }}
+        SHFMT_SHA256: ${{ inputs.shfmt-sha256 }}
+        TAPLO_VERSION: ${{ inputs.taplo-version }}
+        TAPLO_SHA256: ${{ inputs.taplo-sha256 }}
         TREEFMT_VERSION: ${{ inputs.treefmt-version }}
         TREEFMT_SHA256: ${{ inputs.treefmt-sha256 }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
+        set -euo pipefail
+
+        # Composite-action steps run sequentially, so the 7 independent
+        # release-binary downloads (~tens of MB each) are the one place
+        # where cross-step concurrency can be recovered. Fire them all as
+        # background jobs, redirect each child's combined output to a
+        # per-tool log so the 7 streams don't interleave, then replay
+        # each log inside its own `::group::` from the wait loop. Plain
+        # `wait` with no arg reports only the last job's exit code, so
+        # wait on each PID individually and accumulate failures. See
+        # #168.
+        declare -A pids=()
+        scripts/ci/fetch-release-asset.sh \
+          "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+          /tmp/shellcheck.tar.xz \
+          "${SHELLCHECK_SHA256}" >/tmp/shellcheck.fetch.log 2>&1 &
+        pids[shellcheck]=$!
+        scripts/ci/fetch-release-asset.sh \
+          "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
+          /tmp/shfmt \
+          "${SHFMT_SHA256}" >/tmp/shfmt.fetch.log 2>&1 &
+        pids[shfmt]=$!
+        scripts/ci/fetch-release-asset.sh \
+          "https://github.com/astral-sh/ruff/releases/download/${RUFF_VERSION}/ruff-x86_64-unknown-linux-gnu.tar.gz" \
+          /tmp/ruff.tar.gz \
+          "${RUFF_SHA256}" >/tmp/ruff.fetch.log 2>&1 &
+        pids[ruff]=$!
+        scripts/ci/fetch-release-asset.sh \
+          "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
+          /tmp/taplo.gz \
+          "${TAPLO_SHA256}" >/tmp/taplo.fetch.log 2>&1 &
+        pids[taplo]=$!
+        scripts/ci/fetch-release-asset.sh \
+          "https://github.com/google/keep-sorted/releases/download/v${KEEP_SORTED_VERSION}/keep-sorted_linux" \
+          /tmp/keep-sorted \
+          "${KEEP_SORTED_SHA256}" >/tmp/keep-sorted.fetch.log 2>&1 &
+        pids[keep-sorted]=$!
+        scripts/ci/fetch-release-asset.sh \
+          "https://github.com/sirwart/ripsecrets/releases/download/v${RIPSECRETS_VERSION}/ripsecrets-${RIPSECRETS_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+          /tmp/ripsecrets.tar.gz \
+          "${RIPSECRETS_SHA256}" >/tmp/ripsecrets.fetch.log 2>&1 &
+        pids[ripsecrets]=$!
         scripts/ci/fetch-release-asset.sh \
           "https://github.com/numtide/treefmt/releases/download/v${TREEFMT_VERSION}/treefmt_${TREEFMT_VERSION}_linux_amd64.tar.gz" \
           /tmp/treefmt.tar.gz \
-          "${TREEFMT_SHA256}"
+          "${TREEFMT_SHA256}" >/tmp/treefmt.fetch.log 2>&1 &
+        pids[treefmt]=$!
+
+        # Iterate a fixed tool list (not "${!pids[@]}") so the replayed
+        # log order is deterministic across runs.
+        fail=0
+        for tool in shellcheck shfmt ruff taplo keep-sorted ripsecrets treefmt; do
+          if wait "${pids[$tool]}"; then
+            status=OK
+          else
+            status=FAILED
+            fail=1
+          fi
+          echo "::group::Download ${tool} (${status})"
+          cat "/tmp/${tool}.fetch.log"
+          echo "::endgroup::"
+        done
+        [[ $fail -eq 0 ]]
+
+        echo "::group::Install shellcheck"
+        tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+        sudo install -m0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+        shellcheck --version
+        echo "::endgroup::"
+
+        echo "::group::Install shfmt"
+        sudo install -m0755 /tmp/shfmt /usr/local/bin/shfmt
+        shfmt --version
+        echo "::endgroup::"
+
+        echo "::group::Install ruff"
+        tar -xzf /tmp/ruff.tar.gz -C /tmp
+        sudo install -m0755 /tmp/ruff-x86_64-unknown-linux-gnu/ruff /usr/local/bin/ruff
+        ruff --version
+        echo "::endgroup::"
+
+        echo "::group::Install taplo"
+        gunzip -f /tmp/taplo.gz
+        sudo install -m0755 /tmp/taplo /usr/local/bin/taplo
+        taplo --version
+        echo "::endgroup::"
+
+        echo "::group::Install keep-sorted"
+        sudo install -m0755 /tmp/keep-sorted /usr/local/bin/keep-sorted
+        keep-sorted --version
+        echo "::endgroup::"
+
+        echo "::group::Install ripsecrets"
+        tar -xzf /tmp/ripsecrets.tar.gz -C /tmp
+        sudo install -m0755 "/tmp/ripsecrets-${RIPSECRETS_VERSION}-x86_64-unknown-linux-gnu/ripsecrets" /usr/local/bin/ripsecrets
+        ripsecrets --version
+        echo "::endgroup::"
+
+        echo "::group::Install treefmt"
         tar -xzf /tmp/treefmt.tar.gz -C /tmp
         sudo install -m0755 /tmp/treefmt /usr/local/bin/treefmt
         treefmt --version
+        echo "::endgroup::"
 
     - name: Verify Required Tooling
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same retry retune. Part 3 of the follow-up (parallelise downloads) is
   tracked separately
   ([#165](https://github.com/aidanns/agent-auth/issues/165)).
+- `setup-toolchain` release-binary installs now run the 7 downloads
+  concurrently in a single `Install release binaries` step
+  (`fetch-release-asset.sh ... &` plus a per-PID `wait` loop that
+  fails fast on any curl / sha256 error). Extract + install + version
+  echo stays serial with `::group::` markers for per-tool log
+  readability. Trims composite-action wall-time on every CI job.
+  Completes the #165 follow-up sequenced in
+  [#168](https://github.com/aidanns/agent-auth/issues/168).
 
 ### Fixed
 

--- a/plans/setup-toolchain-parallelise-downloads.md
+++ b/plans/setup-toolchain-parallelise-downloads.md
@@ -1,0 +1,119 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# Plan: Parallelise the 7 release-binary downloads in setup-toolchain
+
+Resolves [#168](https://github.com/aidanns/agent-auth/issues/168) (part 3 of
+the #165 follow-up work; parts 1 and 2 landed in #169).
+
+## Problem
+
+`.github/actions/setup-toolchain/action.yml` now has 7 install steps
+(`shellcheck`, `shfmt`, `ruff`, `taplo`, `keep-sorted`, `ripsecrets`,
+`treefmt`) that each call `scripts/ci/fetch-release-asset.sh` to
+download a release binary and verify its sha256. Composite-action
+steps run sequentially, so those 7 independent network downloads
+(~tens of MB each) are serialised on every CI job.
+
+## Approach
+
+Collapse the 7 `Install <tool>` steps into one composite-action step
+that:
+
+1. Fires all 7 `fetch-release-asset.sh` invocations as background
+   jobs in a single `bash` block, then waits on each and fails fast
+   if any sha256 / curl failure happens.
+2. After every download has landed on disk, runs the per-tool
+   extract/install commands sequentially. Extraction is cheap
+   (local disk IO) compared to the network downloads, so there's no
+   point parallelising it too.
+
+Single-step is chosen over "download step + install step" because:
+
+- The env-var set is the same (all 7 `*_VERSION` + `*_SHA256` are
+  needed — versions by the URL at download time and by the install
+  paths at install time).
+- The combined step log is still readable if we emit clear
+  `::group::` markers around each tool.
+- Two steps would just duplicate the 14-line `env:` block.
+
+Failure semantics:
+
+- Each backgrounded `fetch-release-asset.sh` has `set -euo pipefail`
+  and exits nonzero on curl or sha256 failure.
+- The wait loop captures each job's exit code via `wait "$pid"`. A
+  plain `wait` without args returns only the last job's exit code
+  and hides the rest.
+- Accumulate failures into a single nonzero exit so the step fails
+  if any download failed, with every failing job's output still in
+  the log.
+
+Concurrency and auth:
+
+- 7 concurrent downloads × ~tens of MB is well inside GitHub-hosted
+  runner bandwidth and memory budget (each helper invocation is a
+  `curl` + `sha256sum`, neither of which pins memory).
+- Every download uses the same `${GITHUB_TOKEN}` so the 5,000/hr
+  token budget is shared as today — no change in rate-limit
+  behaviour.
+
+Rejected alternatives:
+
+- **`curl --parallel --parallel-max 7` in the helper.** Changes the
+  helper's interface — it'd take a list of `(url, path, sha256)`
+  triples and become a small batch runner. The `&`/`wait` pattern
+  keeps the helper as a single-asset primitive and lives entirely
+  at the call site.
+- **Two separate steps (download then install).** Would require the
+  step-level `env:` block to be duplicated and doesn't buy
+  anything — both steps run on the same runner in the same
+  composite action.
+- **GitHub Actions matrix job.** Loses the per-job environment
+  (`/usr/local/bin`, `$GITHUB_PATH`) propagation and complicates
+  caller workflows. Out of scope.
+
+## Changes
+
+1. `.github/actions/setup-toolchain/action.yml` — replace the 7
+   `Install <tool>` steps with a single `Install release binaries`
+   step containing one bash block that:
+   - Declares `SHELLCHECK_VERSION`/`SHELLCHECK_SHA256`/... +
+     `GITHUB_TOKEN` in `env:`.
+   - Backgrounds 7 `scripts/ci/fetch-release-asset.sh` invocations,
+     recording PIDs.
+   - Waits on each PID, accumulating failures.
+   - Emits `::group::` markers around each tool's extract/install
+     and version-echo so the step log reads per-tool.
+2. `CHANGELOG.md` — add an Unreleased "Changed" entry referencing
+   #168 and cross-linking #165 / #169.
+
+## Verification
+
+- PR CI run passes: every workflow still reaches tool commands
+  (shellcheck/shfmt/ruff/taplo/keep-sorted/ripsecrets/treefmt) after
+  the setup-toolchain action runs.
+- Spot-check the `Install release binaries` step log and confirm:
+  - Multiple `scripts/ci/fetch-release-asset.sh` invocations appear
+    with overlapping/interleaved start timestamps (parallel).
+  - Each sha256 verification reports OK.
+  - Each `<tool> --version` line appears.
+  - Step wall-time is visibly lower than the sum of the old 7
+    steps' wall-times in the pre-#168 PRs.
+- `shellcheck` / `shfmt` / `treefmt` clean on the bash block (via
+  `treefmt --no-cache --fail-on-change` in CI).
+
+## Skipped plan-template steps
+
+- **Design / threat-model / ADR / cybersecurity / QM-SIL** — this is
+  a composite-action refactor that preserves every
+  behaviour-observable property (sha256 verify, auth, retry,
+  extract, install). No runtime, no security posture, no external
+  surface change.
+- **Post-implementation standards review** — only
+  `tooling-and-ci.md` applies. sha256 pinning contract is
+  preserved (each `scripts/ci/fetch-release-asset.sh` call still
+  runs `sha256sum -c -`). `bash.md` shellcheck/shfmt gates still
+  pass.


### PR DESCRIPTION
## Summary

- Collapses the 7 sequential `Install <tool>` steps in `.github/actions/setup-toolchain/action.yml` into a single `Install release binaries` step that backgrounds every `scripts/ci/fetch-release-asset.sh` invocation, waits on each PID individually (plain `wait` with no arg reports only the last job's exit code), and fails fast if any download / sha256 check fails.
- Redirects each child's combined stdout+stderr to `/tmp/<tool>.fetch.log` so the 7 concurrent curls don't interleave, then replays each log inside its own `::group::Download <tool> (OK|FAILED)` from the wait loop. Iteration order is a fixed tool list so the replayed logs are deterministic across runs.
- Extract / install / version echo stays serial — it's local-disk work and cheap compared to the network downloads. Each tool still gets its own `::group::Install <tool>` marker for log readability.

Completes the #165 follow-up (parts 1 and 2 landed in #169). Closes #168.

## Test plan

- [x] PR CI run completes cleanly — every workflow installs every release binary through the new step and reaches its tool commands (shellcheck, shfmt, ruff, taplo, keep-sorted, ripsecrets, treefmt). (14/14 checks green.)
- [x] Inspect the `Install release binaries` step log and confirm: 7 `::group::Download <tool> (OK)` blocks appear with each sha256sum `OK`, followed by 7 `::group::Install <tool>` blocks with each `<tool> --version` line. (Confirmed in run 24720347606.)
- [x] Confirm step wall-time is visibly lower than the sum of the pre-#168 per-step wall-times. (Confirmed: all 7 downloads complete within ~100ms of each other in run 24720347606 at 11:40:34.2–34.3; the pre-refactor sequential downloads in PR #169's run 24719872565 spanned ~3s from 11:28:46 to 11:28:49.)
- [x] `treefmt --no-cache --fail-on-change` clean on the bash block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)