### PR TITLE
ci: pin release-affecting GitHub Actions to commit SHAs (#127)

### DIFF
--- a/.claude/instructions/tooling-and-ci.md
+++ b/.claude/instructions/tooling-and-ci.md
@@ -53,8 +53,10 @@ language: `python.md`, `bash.md`.
 
 - **Test runner script** — ensure a single-command test runner exists (e.g.
   `scripts/test.sh`) so the full test suite runs with one command.
+
 - **Wire all check scripts into CI** — every repeatable check script must
   have a CI workflow.
+
 - **Pin sha256 for tool binary downloads** — any CI step that downloads a
   CLI binary directly (curl/wget from a release CDN) must verify the
   artefact against a sha256 pinned in the repository before extracting or
@@ -66,6 +68,27 @@ language: `python.md`, `bash.md`.
   is preferred over fetching an upstream `checksums.txt`, because the
   checksum file would travel over the same TLS channel as the artefact
   it claims to verify.
+
+- **Pin release-affecting GitHub Actions to commit SHAs** — third-party
+  `uses:` references in any workflow that holds `id-token: write`,
+  `contents: write`, or otherwise sits on the release path must be pinned
+  to a full 40-character commit SHA, not a floating `@vX` tag. A
+  compromised action release on a floating tag can otherwise siphon the
+  runner's OIDC token or substitute a malicious signing binary in-flight.
+  Use the format `uses: ORG/REPO@<sha> # vX.Y.Z` — Dependabot reads the
+  trailing comment to track upgrades and rewrites both the SHA and the
+  comment on each bump, keeping the pin reviewable.
+
+  Scope today: `.github/workflows/release-please.yml`,
+  `.github/workflows/release-publish.yml`, `.github/workflows/reuse.yml`
+  (the REUSE gate is a release prerequisite), and
+  `.github/actions/setup-toolchain/action.yml` (indirectly part of the
+  release path via `reuse.yml`). Read-only workflows (`check.yml`,
+  `test.yml`, `verify-*.yml`, `typecheck.yml`, `security.yml`) stay on
+  floating-major tags — their blast radius is small enough that the
+  review cost of SHA-pinned bumps outweighs the benefit. Local composite
+  actions referenced as `uses: ./...` are version-locked to the repo
+  commit itself and need no extra pinning.
 
 ## IDE
 

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -71,7 +71,7 @@ runs:
   using: composite
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       with:
         enable-cache: true
 
@@ -99,7 +99,7 @@ runs:
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
     - name: Install go-task
-      uses: arduino/setup-task@v2
+      uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
       with:
         version: ${{ inputs.go-task-version }}
         repo-token: ${{ inputs.github-token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           # RELEASE_PLEASE_TOKEN must be a PAT or GitHub App token. Tags
           # and releases created by the default GITHUB_TOKEN do not fire

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -22,12 +22,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 
@@ -48,7 +48,7 @@ jobs:
           echo "wheel_sbom=${wheel[0]}.spdx.json" >> "${GITHUB_OUTPUT}"
 
       - name: Generate SPDX SBOM for sdist
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           file: ${{ steps.artefacts.outputs.sdist }}
           format: spdx-json
@@ -57,7 +57,7 @@ jobs:
           upload-artifact: false
 
       - name: Generate SPDX SBOM for wheel
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           file: ${{ steps.artefacts.outputs.wheel }}
           format: spdx-json
@@ -66,7 +66,7 @@ jobs:
           upload-artifact: false
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Sign artefacts and SBOMs (keyless)
         shell: bash

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -14,7 +14,7 @@ jobs:
   reuse:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup-toolchain
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   readability. Trims composite-action wall-time on every CI job.
   Completes the #165 follow-up sequenced in
   [#168](https://github.com/aidanns/agent-auth/issues/168).
+- **Release-adjacent GitHub Actions pinned to commit SHAs.**
+  `release-please.yml`, `release-publish.yml`, `reuse.yml`, and
+  `.github/actions/setup-toolchain/action.yml` now reference every
+  third-party action by full commit SHA with a trailing `# vX` comment
+  (e.g. `actions/checkout@de0fac2... # v6`). Read-only workflows
+  (`check.yml`, `test.yml`, `verify-*.yml`, `typecheck.yml`,
+  `security.yml`) stay on floating-major tags. Policy documented in
+  `.claude/instructions/tooling-and-ci.md` "Pin release-affecting GitHub
+  Actions to commit SHAs"; Dependabot's existing `github-actions`
+  ecosystem entry (minor/patch grouped, majors individual) keeps the
+  pins refreshed. Closes
+  [#127](https://github.com/aidanns/agent-auth/issues/127).
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

- Pin every third-party `uses:` in `release-please.yml`,
  `release-publish.yml`, `reuse.yml`, and
  `.github/actions/setup-toolchain/action.yml` to a full 40-char commit
  SHA with a `# vX` trailing comment. Read-only workflows
  (`check.yml`, `test.yml`, `verify-*.yml`, `typecheck.yml`,
  `security.yml`) stay on floating-major tags — they lack the
  `id-token: write` / `contents: write` blast radius that justifies
  SHA-pin review churn.
- Document the policy in `.claude/instructions/tooling-and-ci.md` under
  the existing CI "pinning" bullets (parallel to the sha256-pinning
  standard for tool binaries).
- Dependabot's existing `github-actions` ecosystem entry already
  refreshes SHA-pinned references and rewrites the trailing version
  comment on each bump — no config change needed.

Closes #127.

## Test plan

- [ ] `task format -- --check` passes
- [ ] `task lint` passes
- [ ] `task reuse-lint` passes
- [ ] `task verify-standards` passes
- [ ] CI green on the PR (`check`, `test`, `reuse`, `verify-*`,
      `typecheck`, `security`)
- [ ] Manual review of every pinned SHA — each points at the current
      head commit of the tagged major release it used to float on
      (documented in commit message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)