### PR TITLE
feat(verify-standards): gate health-endpoint standard (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   directly instead of
   [#112](https://github.com/aidanns/agent-auth/issues/112)
   (closed by this change).
+- `scripts/verify-standards.sh` now gates the health-endpoint standard:
+  `/agent-auth/health` and `/things-bridge/health` must be registered in
+  their server modules and tests must cover both a healthy (200)
+  response and a subsystem-failure response (503 for agent-auth,
+  502 for things-bridge). Deletes of the route or its unhealthy-case
+  tests now fail CI
+  ([#25](https://github.com/aidanns/agent-auth/issues/25)).
 - Published OpenAPI 3.1 specs for both HTTP surfaces:
   `openapi/agent-auth.v1.yaml` and `openapi/things-bridge.v1.yaml`.
   A contract test in `tests/test_openapi_spec.py` (1) validates both

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -1081,3 +1081,99 @@ if [[ ${openapi_missing} -ne 0 ]]; then
 fi
 
 echo "verify-standards: openapi/*.v1.yaml exist and ${openapi_contract_test} references both."
+
+# Health endpoints per .claude/instructions/service-design.md
+# ("Health endpoint") and the deterministic regression check from
+# issue #25:
+#
+#   - /agent-auth/health is registered in src/agent_auth/server.py
+#     and /things-bridge/health is registered in src/things_bridge/server.py.
+#   - At least one test function per route asserts a healthy (200)
+#     response, and at least one asserts an unhealthy subsystem-failure
+#     response (503 for agent-auth when the store ping fails; 502 for
+#     things-bridge when the authz upstream is unavailable).
+#
+# The check is scoped per-function (not per-file): without that,
+# tests/test_error_taxonomy.py would satisfy the gate for any route
+# because it mentions every route and every status code somewhere in
+# the file.
+
+health_drift="$(
+  python3 - <<'PY'
+import pathlib
+import re
+import sys
+
+# Accept either the literal path or a call to ``health_url()`` — the
+# integration fixtures expose the latter to let tests flip between
+# direct and in-process transports without hard-coding the path.
+SERVICES = (
+    ("agent-auth", "src/agent_auth/server.py", 503),
+    ("things-bridge", "src/things_bridge/server.py", 502),
+)
+
+def function_blocks(source: str) -> list[str]:
+    return re.split(r"\n(?=(?:async )?def )", source)
+
+
+def block_targets_route(block: str, route: str, service: str) -> bool:
+    if route in block:
+        return True
+    # ``health_url()`` is only surfaced by the service's own integration
+    # fixtures, so it's unambiguous which route it references once the
+    # file's service scope is known.
+    if "health_url()" in block and service in block:
+        return True
+    return False
+
+
+errors: list[str] = []
+
+for service, server_path, unhealthy_status in SERVICES:
+    route = f"/{service}/health"
+    server_src = pathlib.Path(server_path).read_text()
+    if f'"{route}"' not in server_src:
+        errors.append(f"{route} is not registered in {server_path}")
+        continue
+
+    healthy_found = False
+    unhealthy_found = False
+    for test_file in sorted(pathlib.Path("tests").rglob("*.py")):
+        source = test_file.read_text()
+        if route not in source and "health_url()" not in source:
+            continue
+        # ``health_url()`` fixtures live under the matching service
+        # directory; fall back to checking the whole file's service
+        # context when the literal route isn't present.
+        file_service_hint = service if service in str(test_file) or service in source else ""
+        if route not in source and not file_service_hint:
+            continue
+        for block in function_blocks(source):
+            if not block_targets_route(block, route, service):
+                continue
+            if re.search(r"status\s*==\s*200", block):
+                healthy_found = True
+            if re.search(rf"status\s*==\s*{unhealthy_status}", block):
+                unhealthy_found = True
+
+    if not healthy_found:
+        errors.append(f"no test function asserts status == 200 on {route}")
+    if not unhealthy_found:
+        errors.append(
+            f"no test function asserts status == {unhealthy_status} on {route}"
+        )
+
+for err in errors:
+    print(err)
+if errors:
+    sys.exit(1)
+PY
+)" || {
+  echo "verify-standards: health endpoint coverage gaps:" >&2
+  while IFS= read -r line; do
+    echo "  - ${line}" >&2
+  done <<<"${health_drift}"
+  exit 1
+}
+
+echo "verify-standards: /agent-auth/health and /things-bridge/health are registered with healthy + unhealthy test coverage."


### PR DESCRIPTION
## Summary

- Adds a deterministic regression check to `scripts/verify-standards.sh` that fails CI if `/agent-auth/health` or `/things-bridge/health` is deleted from the server source, or if the healthy-case (200) / subsystem-failure-case (503 on agent-auth, 502 on things-bridge) test coverage disappears.
- Impl of both endpoints was already on `main`; this closes the last acceptance criterion in #25 (the regression check).

Closes #25.

## Notes on the check

- Scoped per function rather than per file. `tests/test_error_taxonomy.py` mentions every route and every status code, so a file-level check would be vacuously satisfied regardless of whether each route is actually exercised.
- Accepts either the literal `/<service>/health` path or `health_url()` (the fixture helper the integration tests use) so the gate stays honest across the two test transports.

## Test plan

- [x] `bash scripts/verify-standards.sh` passes locally.
- [x] `shellcheck` + `shfmt` clean on the modified file.
- [x] `scripts/verify-function-tests.sh` unchanged (same 55/57 coverage as `main`).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)