### PR TITLE
feat(metrics): /agent-auth/metrics and /things-bridge/metrics Prometheus endpoints (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   502 for things-bridge). Deletes of the route or its unhealthy-case
   tests now fail CI
   ([#25](https://github.com/aidanns/agent-auth/issues/25)).
+- `GET /agent-auth/metrics` and `GET /things-bridge/metrics`
+  Prometheus scrape endpoints. Both emit text exposition
+  format v0.0.4 gated by an `<service>:metrics` scope. Agent-auth
+  tracks HTTP duration + active requests, validation outcomes by
+  reason, token lifecycle operations, and JIT approval outcomes;
+  things-bridge tracks HTTP duration + active requests. Names
+  follow OTel semconv (ADR 0017); primitives live in the new
+  `src/server_metrics/` package (Counter / Gauge / Histogram /
+  Registry + text formatter). `design/DESIGN.md` "Observability"
+  fills in the domain-counter catalogue previously deferred to
+  this issue; `design/error-codes.md` gains `/metrics` taxonomy
+  rows; OpenAPI specs add the endpoint on both services.
+  `scripts/verify-standards.sh` gates the route registration and
+  per-metric test coverage
+  ([#26](https://github.com/aidanns/agent-auth/issues/26)).
 - Published OpenAPI 3.1 specs for both HTTP surfaces:
   `openapi/agent-auth.v1.yaml` and `openapi/things-bridge.v1.yaml`.
   A contract test in `tests/test_openapi_spec.py` (1) validates both

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -807,36 +807,57 @@ pin refers to semconv attribute names only; the project emits
 Prometheus text and JSON-lines directly and does not depend on the
 OpenTelemetry SDK or OTLP transport.
 
-`GET /agent-auth/metrics` and `GET /things-bridge/metrics` are not
-yet implemented (tracked in #26). The audit-log schema is pinned by
-contract tests in `tests/test_audit_schema.py` and versioned via
-`SCHEMA_VERSION` in `src/agent_auth/audit.py` (see "Audit log
-fields" below). Log-level policy and retention policy are deferred
-to the dedicated observability design
-document (tracked in #33), which will also hold the full metrics
-catalogue. This section pins the naming standard those efforts
-build against; it does not yet satisfy
+`GET /agent-auth/metrics` and `GET /things-bridge/metrics` emit
+Prometheus text exposition (v0.0.4) gated by an
+`<service>:metrics` scope, paralleling the `<service>:health` model.
+The audit-log schema is pinned by contract tests in
+`tests/test_audit_schema.py` and versioned via `SCHEMA_VERSION` in
+`src/agent_auth/audit.py` (see "Audit log fields" below).
+Log-level policy and retention policy are deferred to the dedicated
+observability design document (tracked in #33), which will hold the
+full metrics catalogue in one place. This section pins the naming
+standard those efforts build against; it does not yet satisfy
 `.claude/instructions/service-design.md`'s Observability-design
 standard in full — the missing log-level and retention pieces are
 deliberately scoped to #33.
 
 ### HTTP server metrics
 
-Emitted on `/metrics` once #26 lands. Metric names follow OTel
-semconv; Prometheus exposition replaces `.` with `_` and appends
-units per the Prometheus convention.
+Emitted on `/metrics`. Metric names follow OTel semconv; Prometheus
+exposition replaces `.` with `_` and appends units per the
+Prometheus convention. The attribute set is a pragmatic subset of
+semconv: `http.request.method` / `http.route` /
+`http.response.status_code` are carried on the duration histogram;
+`url.scheme` and `server.*` are omitted because both services bind
+to a fixed host and speak HTTP only, so the attributes would add
+cardinality with no distinguishing power.
 
-| OTel metric name               | Prometheus name                        | Instrument (Prometheus type) | Attributes / labels                                                                                                                                         |
-| ------------------------------ | -------------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `http.server.request.duration` | `http_server_request_duration_seconds` | Histogram (histogram)        | `http.request.method`, `http.route`, `url.scheme`, `http.response.status_code` (on non-error), `error.type` (on error)                                      |
-| `http.server.active_requests`  | `http_server_active_requests`          | UpDownCounter (gauge)        | `http.request.method`, `url.scheme` (required); `server.address`, `server.port` (opt-in per semconv; emitted because local bind address varies per service) |
+| OTel metric name               | Prometheus name                        | Instrument (Prometheus type) | Attributes / labels              |
+| ------------------------------ | -------------------------------------- | ---------------------------- | -------------------------------- |
+| `http.server.request.duration` | `http_server_request_duration_seconds` | Histogram (histogram)        | `method`, `route`, `status_code` |
+| `http.server.active_requests`  | `http_server_active_requests`          | UpDownCounter (gauge)        | `method`                         |
 
-Domain counters for validation outcomes, token operations, and JIT
-approval outcomes have no OTel equivalent and will use
-project-namespaced names (e.g. prefixed `agent_auth_` /
-`things_bridge_`). The specific metric names and label sets are
-designed with #26 when the metrics endpoint lands; this section
-only pins that they stay outside the OTel namespace.
+Histogram bucket boundaries (seconds): `0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10` — the OTel-recommended
+HTTP-latency defaults.
+
+### Domain metrics
+
+Agent-auth emits three domain counters outside the OTel namespace;
+things-bridge has no domain state of its own (authz denials and
+Things-app failures fold into the `status_code` label on the HTTP
+duration histogram).
+
+| Prometheus name                        | Type    | Labels              | Notes                                                                                                                   |
+| -------------------------------------- | ------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `agent_auth_token_operations_total`    | Counter | `operation`         | `operation` ∈ `{created, refreshed, reissued, revoked, rotated}`                                                        |
+| `agent_auth_validation_outcomes_total` | Counter | `outcome`, `reason` | `outcome` ∈ `{allowed, denied}`; `reason` mirrors the `validation_denied` audit reasons, plus `ok` for the allowed path |
+| `agent_auth_approval_outcomes_total`   | Counter | `outcome`           | `outcome` ∈ `{approved, denied}`                                                                                        |
+
+The endpoint is authenticated under the `agent-auth:metrics` and
+`things-bridge:metrics` scopes; unauthenticated probes return 401.
+Token-family and per-token labels are deliberately excluded to
+bound cardinality and to keep high-churn labels out of the audit
+surface.
 
 ### Audit log fields
 

--- a/design/error-codes.md
+++ b/design/error-codes.md
@@ -94,6 +94,18 @@ The health endpoint is unversioned by convention (see versioning policy in
 `DESIGN.md`). A 503 body of `{"status": "unhealthy"}` (not an error code)
 indicates the backing store is unreachable.
 
+### `GET /agent-auth/metrics` *(unversioned)*
+
+| Error code      | HTTP status | Meaning                                             |
+| --------------- | ----------- | --------------------------------------------------- |
+| `missing_token` | 401         | No `Authorization: Bearer` header present.          |
+| `invalid_token` | 401         | Token is malformed or not an access token.          |
+| `token_expired` | 401         | Access token has passed its TTL.                    |
+| `scope_denied`  | 403         | Token does not have the `agent-auth:metrics` scope. |
+
+Successful scrapes return 200 with a Prometheus text exposition body
+(`Content-Type: text/plain; version=0.0.4`).
+
 ### Server-wide codes (any endpoint)
 
 | Error code  | HTTP status | Meaning                                      |
@@ -133,6 +145,18 @@ All data endpoints share the same authorization and Things-layer error codes:
 | `token_expired`     | 401         | Access token has passed its TTL.                      |
 | `scope_denied`      | 403         | Token does not have the `things-bridge:health` scope. |
 | `authz_unavailable` | 502         | The agent-auth service is unreachable.                |
+
+### `GET /things-bridge/metrics` *(unversioned)*
+
+| Error code          | HTTP status | Meaning                                                |
+| ------------------- | ----------- | ------------------------------------------------------ |
+| `unauthorized`      | 401         | No bearer token present.                               |
+| `token_expired`     | 401         | Access token has passed its TTL.                       |
+| `scope_denied`      | 403         | Token does not have the `things-bridge:metrics` scope. |
+| `authz_unavailable` | 502         | The agent-auth service is unreachable.                 |
+
+Successful scrapes return 200 with a Prometheus text exposition body
+(`Content-Type: text/plain; version=0.0.4`).
 
 ### Server-wide codes (any endpoint)
 

--- a/openapi/agent-auth.v1.yaml
+++ b/openapi/agent-auth.v1.yaml
@@ -413,6 +413,37 @@ paths:
               schema:
                 $ref: '#/components/schemas/HealthUnhealthy'
 
+  /agent-auth/metrics:
+    get:
+      tags: [health]
+      summary: Prometheus metrics scrape endpoint (unversioned).
+      description: |
+        Unversioned by convention — scrape configs must keep working
+        across API major bumps. Requires the `agent-auth:metrics`
+        scope. Emits Prometheus text exposition format v0.0.4.
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Current metric values.
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Prometheus text exposition.
+        '401':
+          description: Missing, invalid, or expired token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '403':
+          description: Token does not have the `agent-auth:metrics` scope.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
 components:
   securitySchemes:
     BearerAuth:

--- a/openapi/things-bridge.v1.yaml
+++ b/openapi/things-bridge.v1.yaml
@@ -275,6 +275,36 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorEnvelope'
 
+  /things-bridge/metrics:
+    get:
+      tags: [health]
+      summary: Prometheus metrics scrape endpoint (unversioned).
+      description: |
+        Unversioned by convention — scrape configs must keep working
+        across API major bumps. Requires the `things-bridge:metrics`
+        scope (delegated to agent-auth). Emits Prometheus text
+        exposition format v0.0.4.
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Current metric values.
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Prometheus text exposition.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/ScopeDenied'
+        '502':
+          description: agent-auth is unreachable.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
 components:
   securitySchemes:
     BearerAuth:

--- a/plans/metrics-endpoint-issue-26.md
+++ b/plans/metrics-endpoint-issue-26.md
@@ -1,0 +1,169 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# Plan: `/metrics` Prometheus Endpoint (#26)
+
+Closes #26.
+
+## Summary
+
+Implement `GET /agent-auth/metrics` and `GET /things-bridge/metrics`
+emitting Prometheus text exposition format. Metrics are hand-rolled
+(no `prometheus_client` or OpenTelemetry SDK dependency — see ADR
+0017, which pins OTel semconv *names* but does not mandate the SDK).
+
+Existing design anchors:
+
+- `design/DESIGN.md` "Observability" pre-declares the HTTP metric
+  names and types. Domain counter names were deferred to this work.
+- `scripts/verify-standards.sh` already exempts `/metrics` from the
+  versioning gate.
+
+## Design verification
+
+No new ADR. Decisions:
+
+- **Auth on `/metrics`**: require a `:metrics` scope, parallel to
+  `/health`. The server already binds 127.0.0.1-only, but
+  authenticating the endpoint matches the `/health` model and makes
+  the surface uniform for future remote-operator workflows.
+- **Histogram buckets**: OTel-recommended HTTP latency buckets
+  (`0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10`).
+- **Shared primitives**: new `src/server_metrics/` package holds the
+  `Counter` / `Gauge` / `Histogram` / `Registry` primitives and the
+  Prometheus text formatter. Both services import from it. Matches
+  the existing `things_client_common` precedent for cross-service
+  library code.
+- **Instrumentation scope**: HTTP duration histogram + active-requests
+  gauge are emitted on every endpoint (including `/health` and
+  `/metrics` itself); domain counters live only on agent-auth.
+
+## Metrics catalogue
+
+### Agent-auth
+
+| Name                                   | Type      | Labels                                                       |
+| -------------------------------------- | --------- | ------------------------------------------------------------ |
+| `http_server_request_duration_seconds` | histogram | `method`, `route`, `status_code`                             |
+| `http_server_active_requests`          | gauge     | `method`                                                     |
+| `agent_auth_token_operations_total`    | counter   | `operation` (created, refreshed, reissued, revoked, rotated) |
+| `agent_auth_validation_outcomes_total` | counter   | `outcome` (allowed, denied), `reason`                        |
+| `agent_auth_approval_outcomes_total`   | counter   | `outcome` (approved, denied)                                 |
+
+`reason` values for validation outcomes mirror the audit-log
+`validation_denied` reasons plus `ok` for `validation_allowed`:
+`invalid_token`, `not_access_token`, `token_not_found`,
+`token_expired`, `family_revoked`, `scope_denied`, `approval_denied`,
+`ok`.
+
+### Things-bridge
+
+| Name                                   | Type      | Labels                           |
+| -------------------------------------- | --------- | -------------------------------- |
+| `http_server_request_duration_seconds` | histogram | `method`, `route`, `status_code` |
+| `http_server_active_requests`          | gauge     | `method`                         |
+
+Things-bridge has no persistent state; its domain events (authz
+outcomes, Things-app failures) are reflected in the HTTP status
+labels on the duration histogram.
+
+## Wiring points
+
+- `src/server_metrics/` — new package. `__init__.py` re-exports
+  primitives. `registry.py` holds `Counter`, `Gauge`, `Histogram`,
+  `Registry`. `formatter.py` holds `render_prometheus_text`.
+- `src/agent_auth/metrics.py` — constructs the registry + named
+  metrics.
+- `src/agent_auth/server.py`:
+  - `AgentAuthServer.__init__` takes a `registry` + `metrics` dict.
+  - New `/agent-auth/metrics` GET handler: `_require_scope_auth`
+    with scope `agent-auth:metrics`, respond 200 text/plain;
+    version=0.0.4.
+  - `handle_one_request` (or an explicit dispatch wrapper)
+    brackets every request with a start timer + active-requests
+    inc/dec, records `(method, route, status_code)` on return.
+  - Instrument validate/refresh/reissue/token_create/modify/
+    revoke/rotate handlers at the relevant success/failure points.
+  - `ApprovalManager.request_approval` takes optional metrics
+    hook to increment `approval_outcomes_total`.
+- `src/things_bridge/metrics.py` + `server.py`: same HTTP-level
+  instrumentation only.
+- `run_server` in both services: build registry, pass into server
+  constructor.
+
+### Route-template problem
+
+Per-request `route` label cannot be the raw `self.path` — id-carrying
+paths like `/things-bridge/v1/todos/ABC123` would blow label
+cardinality. Map to templated routes matching the OpenAPI path
+entries: `/things-bridge/v1/todos/{id}`, etc. Implementation: each
+handler function is responsible for setting a
+`self._route_template` string on itself before returning, which the
+post-dispatch wrapper reads and passes into `observe()`. Unknown
+routes map to `/unknown`.
+
+## Tests
+
+- `tests/test_server_metrics.py` — unit tests for the primitives:
+  counter monotonicity, gauge inc/dec, histogram bucket semantics,
+  label-value escaping, Prometheus-text round-trip through a
+  parser (use the `openapi-spec-validator`-style approach: validate
+  shape, not just grep).
+- `tests/test_server.py` — new metrics-endpoint unit tests: 401 on
+  missing token, 403 on missing scope, 200 with text/plain body on
+  authorised, body contains each required metric name, domain
+  counters increment on validate / approval success+denial / token
+  ops.
+- `tests/test_things_bridge_server.py` — equivalent for bridge.
+- `tests/integration/agent_auth/test_metrics.py` — scrape via Docker
+  compose, assert metric names.
+- `tests/integration/things_bridge/test_bridge.py` — add analogous
+  integration scrape.
+- `tests/test_error_taxonomy.py` — add `/metrics` `missing_token`,
+  `invalid_token`, `token_expired`, `scope_denied` coverage rows.
+- `tests/test_openapi_spec.py` — no change (contract test walks
+  registered handlers; /metrics lands automatically).
+
+## Docs
+
+- `design/DESIGN.md` "Observability" — fill in the domain-counter
+  table, note the label sets and escape rules.
+- `design/error-codes.md` — add `/metrics` entry mirroring
+  `/health` entries.
+- `openapi/agent-auth.v1.yaml`, `openapi/things-bridge.v1.yaml` —
+  add `/metrics` paths (text/plain response schema).
+- `CLAUDE.md` "Project-specific notes" — note that `/metrics` now
+  exists.
+- `CHANGELOG.md` — `### Added` entry under `[Unreleased]`.
+- `CONTRIBUTING.md` / `README.md` — no updates needed.
+
+## Regression check
+
+Append to `scripts/verify-standards.sh` (after the health block):
+
+- Grep `"/agent-auth/metrics"` / `"/things-bridge/metrics"` in each
+  server module.
+- Walk test files for a function block that references the route
+  and asserts status 200 AND references at least one required
+  metric name (e.g. `http_server_request_duration_seconds`).
+
+## Post-implementation standards review
+
+Per `.claude/instructions/plan-template.md`:
+
+- Coding standards review (naming, types, safety).
+- Service-design review (config, file paths, HTTP, resilience).
+- Release / hygiene (CHANGELOG, OpenAPI, error taxonomy).
+- Testing standards (public API only, named coverage).
+- Tooling / CI (no new workflow needed; existing gates pick up
+  the new code).
+
+## Out of scope
+
+- OTLP export (keeps us off the OTel SDK).
+- Per-token or per-family cardinality (privacy + cost).
+- Histogram buckets configurable per-endpoint (one global choice).
+- Metrics persistence across restarts (accepted — counters reset).

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -1265,3 +1265,86 @@ if [[ "${mutation_workflow_found}" -eq 0 ]]; then
 fi
 
 echo "verify-standards: mutation testing configured ([tool.mutmut] / [tool.mutation_score]) and scheduled via ${mutation_workflow}."
+
+# Metrics endpoints per .claude/instructions/service-design.md
+# ("Metrics endpoint") and the deterministic regression check from
+# issue #26:
+#
+#   - /agent-auth/metrics is registered in src/agent_auth/server.py
+#     and /things-bridge/metrics is registered in src/things_bridge/server.py.
+#   - At least one test function per route scrapes the endpoint (200
+#     response) and validates that every declared metric name appears
+#     in the response body. Name lists are hard-coded below so a
+#     rename fails the gate deliberately.
+
+metrics_drift="$(
+  python3 - <<'PY'
+import pathlib
+import re
+import sys
+
+AGENT_AUTH_METRICS = (
+    "http_server_request_duration_seconds",
+    "http_server_active_requests",
+    "agent_auth_token_operations_total",
+    "agent_auth_validation_outcomes_total",
+    "agent_auth_approval_outcomes_total",
+)
+THINGS_BRIDGE_METRICS = (
+    "http_server_request_duration_seconds",
+    "http_server_active_requests",
+)
+SERVICES = (
+    ("agent-auth", "src/agent_auth/server.py", AGENT_AUTH_METRICS),
+    ("things-bridge", "src/things_bridge/server.py", THINGS_BRIDGE_METRICS),
+)
+
+
+def function_blocks(source: str) -> list[str]:
+    return re.split(r"\n(?=(?:async )?def )", source)
+
+
+errors: list[str] = []
+
+for service, server_path, required in SERVICES:
+    route = f"/{service}/metrics"
+    server_src = pathlib.Path(server_path).read_text()
+    if f'"{route}"' not in server_src:
+        errors.append(f"{route} is not registered in {server_path}")
+        continue
+
+    covered: set[str] = set()
+    for test_file in sorted(pathlib.Path("tests").rglob("*.py")):
+        source = test_file.read_text()
+        if route not in source:
+            continue
+        for block in function_blocks(source):
+            if route not in block:
+                continue
+            if not re.search(r"status\s*==\s*200", block):
+                continue
+            for name in required:
+                if name in block:
+                    covered.add(name)
+
+    missing = [n for n in required if n not in covered]
+    if missing:
+        errors.append(
+            f"{route}: no 200-response test block references metric(s) "
+            + ", ".join(missing)
+        )
+
+for err in errors:
+    print(err)
+if errors:
+    sys.exit(1)
+PY
+)" || {
+  echo "verify-standards: metrics endpoint coverage gaps:" >&2
+  while IFS= read -r line; do
+    echo "  - ${line}" >&2
+  done <<<"${metrics_drift}"
+  exit 1
+}
+
+echo "verify-standards: /agent-auth/metrics and /things-bridge/metrics are registered with metric-name test coverage."

--- a/scripts/verify-token-cli-http-parity.sh
+++ b/scripts/verify-token-cli-http-parity.sh
@@ -36,10 +36,18 @@ except ImportError as e:
     print(f"verify-token-cli-http-parity: could not import agent_auth modules: {e}", file=sys.stderr)
     sys.exit(1)
 
-routing_source = (
-    inspect.getsource(AgentAuthHandler.do_POST)
-    + inspect.getsource(AgentAuthHandler.do_GET)
-)
+# The handler dispatches through class-level route tables
+# (_POST_ROUTES / _GET_ROUTES). Join every literal path key so renames
+# that slip out of the tables still trip this gate. Also fall back to
+# the whole-class source in case a future refactor inlines the
+# routes back into do_POST / do_GET.
+routing_source_parts: list[str] = []
+for table_attr in ("_POST_ROUTES", "_GET_ROUTES"):
+    table = getattr(AgentAuthHandler, table_attr, None)
+    if isinstance(table, dict):
+        routing_source_parts.extend(table.keys())
+routing_source_parts.append(inspect.getsource(AgentAuthHandler))
+routing_source = "\n".join(routing_source_parts)
 
 missing = []
 for cmd in sorted(COMMAND_HANDLERS):
@@ -49,7 +57,7 @@ for cmd in sorted(COMMAND_HANDLERS):
         missing.append(f"  token {cmd!r}: no handler method {method!r}")
     elif route not in routing_source:
         missing.append(
-            f"  token {cmd!r}: method exists but route {route!r} is not wired in do_POST/do_GET"
+            f"  token {cmd!r}: method exists but route {route!r} is not wired via the route tables or do_POST/do_GET"
         )
 
 if missing:

--- a/src/agent_auth/metrics.py
+++ b/src/agent_auth/metrics.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Metric declarations and registry builder for agent-auth.
+
+Names + attributes follow the catalogue in
+``design/DESIGN.md`` "Observability". HTTP metrics use OTel semconv
+names; domain counters use the ``agent_auth_`` prefix. The registry
+is owned by ``AgentAuthServer`` so every request handler can update
+counters without threading a registry through every call site.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from server_metrics import Counter, Gauge, Histogram, Registry
+
+
+@dataclass(frozen=True)
+class AgentAuthMetrics:
+    """Handle to every metric agent-auth emits."""
+
+    http_request_duration: Histogram
+    http_active_requests: Gauge
+    token_operations: Counter
+    validation_outcomes: Counter
+    approval_outcomes: Counter
+
+
+# Canonical reason labels for ``agent_auth_validation_outcomes_total``.
+# "ok" is used for the allowed path; the denied reasons mirror the
+# ``validation_denied`` audit-log reason strings so the two surfaces
+# stay in step.
+VALIDATION_REASON_OK = "ok"
+VALIDATION_DENIED_REASONS = (
+    "invalid_token",
+    "not_access_token",
+    "token_not_found",
+    "token_expired",
+    "family_revoked",
+    "scope_denied",
+    "approval_denied",
+)
+
+
+def build_registry() -> tuple[Registry, AgentAuthMetrics]:
+    """Return a fresh registry and the named metric handles."""
+    http_request_duration = Histogram(
+        "http_server_request_duration_seconds",
+        "Duration of HTTP server requests in seconds.",
+        label_names=("method", "route", "status_code"),
+    )
+    http_active_requests = Gauge(
+        "http_server_active_requests",
+        "Number of HTTP server requests currently in flight.",
+        label_names=("method",),
+    )
+    token_operations = Counter(
+        "agent_auth_token_operations_total",
+        "Count of token lifecycle operations by type.",
+        label_names=("operation",),
+    )
+    validation_outcomes = Counter(
+        "agent_auth_validation_outcomes_total",
+        "Count of token validation outcomes by reason.",
+        label_names=("outcome", "reason"),
+    )
+    approval_outcomes = Counter(
+        "agent_auth_approval_outcomes_total",
+        "Count of JIT approval outcomes.",
+        label_names=("outcome",),
+    )
+
+    registry = Registry()
+    for metric in (
+        http_request_duration,
+        http_active_requests,
+        token_operations,
+        validation_outcomes,
+        approval_outcomes,
+    ):
+        registry.register(metric)
+
+    return registry, AgentAuthMetrics(
+        http_request_duration=http_request_duration,
+        http_active_requests=http_active_requests,
+        token_operations=token_operations,
+        validation_outcomes=validation_outcomes,
+        approval_outcomes=approval_outcomes,
+    )

--- a/src/agent_auth/server.py
+++ b/src/agent_auth/server.py
@@ -9,15 +9,17 @@ import os
 import signal
 import sys
 import threading
+import time
 from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 from agent_auth.approval import ApprovalManager
 from agent_auth.audit import AuditLogger
 from agent_auth.config import Config
 from agent_auth.errors import ScopeDeniedError, TokenInvalidError
 from agent_auth.keys import KeyManager, SigningKey
+from agent_auth.metrics import AgentAuthMetrics, build_registry
 from agent_auth.plugins import load_plugin
 from agent_auth.scopes import VALID_TIERS, check_scope
 from agent_auth.store import TokenStore
@@ -28,8 +30,18 @@ from agent_auth.tokens import (
     generate_token_id,
     verify_token,
 )
+from server_metrics import (
+    PROMETHEUS_CONTENT_TYPE,
+    Registry,
+    render_prometheus_text,
+)
 
 MANAGEMENT_SCOPE = "agent-auth:manage"
+METRICS_SCOPE = "agent-auth:metrics"
+
+# Sentinel route label for unmatched paths; keeps label cardinality
+# bounded when a scraper pokes arbitrary URLs.
+_UNKNOWN_ROUTE = "/unknown"
 
 
 class AgentAuthHandler(BaseHTTPRequestHandler):
@@ -67,33 +79,62 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
     def log_message(self, format: str, *args: Any) -> None:
         pass
 
+    # Route tables. Agent-auth paths have no path parameters, so the
+    # literal path is the route-label template.
+    _POST_ROUTES: ClassVar[dict[str, str]] = {
+        # keep-sorted start
+        "/agent-auth/v1/token/create": "_handle_token_create",
+        "/agent-auth/v1/token/modify": "_handle_token_modify",
+        "/agent-auth/v1/token/refresh": "_handle_refresh",
+        "/agent-auth/v1/token/reissue": "_handle_reissue",
+        "/agent-auth/v1/token/revoke": "_handle_token_revoke",
+        "/agent-auth/v1/token/rotate": "_handle_token_rotate",
+        "/agent-auth/v1/validate": "_handle_validate",
+        # keep-sorted end
+    }
+    _GET_ROUTES: ClassVar[dict[str, str]] = {
+        # keep-sorted start
+        "/agent-auth/health": "_handle_health",
+        "/agent-auth/metrics": "_handle_metrics",
+        "/agent-auth/v1/token/list": "_handle_token_list",
+        "/agent-auth/v1/token/status": "_handle_status",
+        # keep-sorted end
+    }
+
+    def send_response(self, code: int, message: str | None = None) -> None:
+        # Capture the status code so ``_dispatch`` can label the request
+        # duration histogram. ``BaseHTTPRequestHandler`` accepts either
+        # an ``HTTPStatus`` or a bare int; normalise here.
+        self._last_status_code = int(code)
+        super().send_response(code, message)
+
+    def _dispatch(self, method: str, routes: dict[str, str]) -> None:
+        handler_name = routes.get(self.path)
+        route = self.path if handler_name else _UNKNOWN_ROUTE
+        metrics = self._server.metrics
+        metrics.http_active_requests.inc(method=method)
+        start = time.perf_counter()
+        try:
+            if handler_name is None:
+                self._send_json(404, {"error": "not_found"})
+            else:
+                getattr(self, handler_name)()
+        finally:
+            duration = time.perf_counter() - start
+            metrics.http_active_requests.dec(method=method)
+            status_code = str(getattr(self, "_last_status_code", 0))
+            metrics.http_request_duration.observe(
+                duration,
+                method=method,
+                route=route,
+                status_code=status_code,
+            )
+
     def do_POST(self) -> None:
-        if self.path == "/agent-auth/v1/validate":
-            self._handle_validate()
-        elif self.path == "/agent-auth/v1/token/refresh":
-            self._handle_refresh()
-        elif self.path == "/agent-auth/v1/token/reissue":
-            self._handle_reissue()
-        elif self.path == "/agent-auth/v1/token/create":
-            self._handle_token_create()
-        elif self.path == "/agent-auth/v1/token/modify":
-            self._handle_token_modify()
-        elif self.path == "/agent-auth/v1/token/revoke":
-            self._handle_token_revoke()
-        elif self.path == "/agent-auth/v1/token/rotate":
-            self._handle_token_rotate()
-        else:
-            self._send_json(404, {"error": "not_found"})
+        self._dispatch("POST", self._POST_ROUTES)
 
     def do_GET(self) -> None:
-        if self.path == "/agent-auth/v1/token/status":
-            self._handle_status()
-        elif self.path == "/agent-auth/health":
-            self._handle_health()
-        elif self.path == "/agent-auth/v1/token/list":
-            self._handle_token_list()
-        else:
-            self._send_json(404, {"error": "not_found"})
+        self._dispatch("GET", self._GET_ROUTES)
 
     def _handle_validate(self) -> None:
         data = self._read_json()
@@ -108,6 +149,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         signing_key: SigningKey = self._server.signing_key
         approval_manager: ApprovalManager = self._server.approval_manager
         audit: AuditLogger = self._server.audit
+        metrics = self._server.metrics
 
         try:
             prefix, token_id = verify_token(token_raw, signing_key)
@@ -115,6 +157,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             audit.log_authorization_decision(
                 "validation_denied", reason="invalid_token", scope=required_scope
             )
+            metrics.validation_outcomes.inc(outcome="denied", reason="invalid_token")
             self._send_json(401, {"valid": False, "error": "invalid_token"})
             return
 
@@ -122,6 +165,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             audit.log_authorization_decision(
                 "validation_denied", reason="not_access_token", scope=required_scope
             )
+            metrics.validation_outcomes.inc(outcome="denied", reason="not_access_token")
             self._send_json(401, {"valid": False, "error": "invalid_token"})
             return
 
@@ -130,6 +174,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             audit.log_authorization_decision(
                 "validation_denied", reason="token_not_found", scope=required_scope
             )
+            metrics.validation_outcomes.inc(outcome="denied", reason="token_not_found")
             self._send_json(401, {"valid": False, "error": "invalid_token"})
             return
 
@@ -142,6 +187,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
                 token_id=token_id,
                 scope=required_scope,
             )
+            metrics.validation_outcomes.inc(outcome="denied", reason="token_expired")
             self._send_json(401, {"valid": False, "error": "token_expired"})
             return
 
@@ -153,6 +199,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
                 token_id=token_id,
                 scope=required_scope,
             )
+            metrics.validation_outcomes.inc(outcome="denied", reason="family_revoked")
             self._send_json(401, {"valid": False, "error": "token_revoked"})
             return
 
@@ -165,6 +212,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
                 token_id=token_id,
                 scope=required_scope,
             )
+            metrics.validation_outcomes.inc(outcome="denied", reason="scope_denied")
             self._send_json(403, {"valid": False, "error": "scope_denied"})
             return
 
@@ -175,6 +223,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
                 scope=required_scope,
                 tier="allow",
             )
+            metrics.validation_outcomes.inc(outcome="allowed", reason="ok")
             self._send_json(200, {"valid": True})
             return
 
@@ -188,6 +237,8 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
                     tier="prompt",
                     grant_type=result.grant_type,
                 )
+                metrics.approval_outcomes.inc(outcome="approved")
+                metrics.validation_outcomes.inc(outcome="allowed", reason="ok")
                 self._send_json(200, {"valid": True})
             else:
                 audit.log_authorization_decision(
@@ -196,6 +247,8 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
                     token_id=token_id,
                     scope=required_scope,
                 )
+                metrics.approval_outcomes.inc(outcome="denied")
+                metrics.validation_outcomes.inc(outcome="denied", reason="approval_denied")
                 self._send_json(403, {"valid": False, "error": "scope_denied"})
             return
 
@@ -237,6 +290,8 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             self._send_json(401, {"error": "refresh_token_expired"})
             return
 
+        metrics = self._server.metrics
+
         # Atomically mark consumed — if already consumed, this is reuse
         if not store.mark_consumed(token_id):
             store.mark_family_revoked(token_record["family_id"])
@@ -245,6 +300,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
                 family_id=token_record["family_id"],
                 reason="refresh_token_reuse_detected",
             )
+            metrics.token_operations.inc(operation="revoked")
             self._send_json(
                 401,
                 {
@@ -258,6 +314,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         access_token, new_refresh_token = create_token_pair(signing_key, store, family_id, config)
 
         audit.log_token_operation("token_refreshed", family_id=family_id)
+        metrics.token_operations.inc(operation="refreshed")
 
         self._send_json(
             200,
@@ -304,17 +361,21 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             self._send_json(401, {"error": "family_revoked"})
             return
 
+        metrics = self._server.metrics
         result = approval_manager.request_approval(
             family_id, "token:reissue", "Re-issue token pair for expired refresh token"
         )
         if not result.approved:
             audit.log_token_operation("reissue_denied", family_id=family_id)
+            metrics.approval_outcomes.inc(outcome="denied")
             self._send_json(403, {"error": "reissue_denied"})
             return
 
+        metrics.approval_outcomes.inc(outcome="approved")
         access_token, new_refresh_token = create_token_pair(signing_key, store, family_id, config)
 
         audit.log_token_operation("token_reissued", family_id=family_id)
+        metrics.token_operations.inc(operation="reissued")
 
         self._send_json(
             200,
@@ -405,6 +466,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         store.create_family(family_id, scopes)
         access_token, refresh_token = create_token_pair(signing_key, store, family_id, config)
         audit.log_token_operation("token_created", family_id=family_id, scopes=scopes)
+        self._server.metrics.token_operations.inc(operation="created")
 
         self._send_json(
             200,
@@ -507,6 +569,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
 
         store.mark_family_revoked(family_id)
         audit.log_token_operation("token_revoked", family_id=family_id)
+        self._server.metrics.token_operations.inc(operation="revoked")
 
         self._send_json(200, {"family_id": family_id, "revoked": True})
 
@@ -543,6 +606,7 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
             new_family_id=new_family_id,
             scopes=scopes,
         )
+        self._server.metrics.token_operations.inc(operation="rotated")
 
         self._send_json(
             200,
@@ -557,6 +621,66 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         )
 
     HEALTH_SCOPE = "agent-auth:health"
+
+    def _authenticate_bearer_scope(self, scope: str) -> bool:
+        """Validate the ``Bearer`` token and check it carries ``scope``.
+
+        Writes the appropriate 401 / 403 JSON response and returns
+        ``False`` on failure. Used by ``/health`` and ``/metrics`` —
+        both are unversioned, operator-facing endpoints gated by a
+        scoped access token.
+        """
+        auth_header = self.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            self._send_json(401, {"error": "missing_token"})
+            return False
+
+        token_raw = auth_header[7:]
+        store: TokenStore = self._server.store
+        signing_key: SigningKey = self._server.signing_key
+
+        try:
+            prefix, token_id = verify_token(token_raw, signing_key)
+        except TokenInvalidError:
+            self._send_json(401, {"error": "invalid_token"})
+            return False
+        if prefix != PREFIX_ACCESS:
+            self._send_json(401, {"error": "invalid_token"})
+            return False
+
+        token_record = store.get_token(token_id)
+        if token_record is None:
+            self._send_json(401, {"error": "invalid_token"})
+            return False
+
+        family = store.get_family(token_record["family_id"])
+        if family is None or family["revoked"]:
+            self._send_json(401, {"error": "invalid_token"})
+            return False
+
+        now = datetime.now(UTC)
+        expires_at = datetime.fromisoformat(token_record["expires_at"])
+        if now >= expires_at:
+            self._send_json(401, {"error": "token_expired"})
+            return False
+
+        try:
+            check_scope(scope, family["scopes"])
+        except ScopeDeniedError:
+            self._send_json(403, {"error": "scope_denied"})
+            return False
+        return True
+
+    def _handle_metrics(self) -> None:
+        if not self._authenticate_bearer_scope(METRICS_SCOPE):
+            return
+        registry: Registry = self._server.registry
+        body = render_prometheus_text(registry).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", PROMETHEUS_CONTENT_TYPE)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
 
     def _handle_health(self) -> None:
         auth_header = self.headers.get("Authorization", "")
@@ -666,12 +790,16 @@ class AgentAuthServer(ThreadingHTTPServer):
         store: TokenStore,
         audit: AuditLogger,
         approval_manager: ApprovalManager,
+        registry: Registry,
+        metrics: AgentAuthMetrics,
     ):
         self.config = config
         self.signing_key = signing_key
         self.store = store
         self.audit = audit
         self.approval_manager = approval_manager
+        self.registry = registry
+        self.metrics = metrics
         super().__init__((config.host, config.port), AgentAuthHandler)
 
 
@@ -768,7 +896,8 @@ def run_server(
     _bootstrap_management_token(store, signing_key, config, key_manager)
     plugin = load_plugin(config.notification_plugin, config.notification_plugin_config)
     approval_manager = ApprovalManager(plugin, store, audit)
-    server = AgentAuthServer(config, signing_key, store, audit, approval_manager)
+    registry, metrics = build_registry()
+    server = AgentAuthServer(config, signing_key, store, audit, approval_manager, registry, metrics)
     drain_complete = _install_shutdown_handler(server, config.shutdown_deadline_seconds)
     # Read the bound port from ``server_address`` (populated during
     # ``server_bind``) so a ``port: 0`` config surfaces the real port.

--- a/src/server_metrics/__init__.py
+++ b/src/server_metrics/__init__.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Thread-safe Prometheus metrics primitives and exposition formatter.
+
+Hand-rolled so agent-auth and things-bridge can expose `/metrics`
+without taking a dependency on `prometheus_client` or the
+OpenTelemetry SDK. ADR 0017 pins the project to OTel semconv names,
+not their SDK. Primitives are intentionally minimal — `Counter`,
+`Gauge`, `Histogram`, `Registry` — and reproduce only the Prometheus
+text-exposition features the two services emit today.
+"""
+
+from server_metrics.formatter import (
+    PROMETHEUS_CONTENT_TYPE,
+    render_prometheus_text,
+)
+from server_metrics.registry import (
+    DEFAULT_HTTP_DURATION_BUCKETS,
+    Counter,
+    Gauge,
+    Histogram,
+    Registry,
+)
+
+__all__ = [
+    "Counter",
+    "DEFAULT_HTTP_DURATION_BUCKETS",
+    "Gauge",
+    "Histogram",
+    "PROMETHEUS_CONTENT_TYPE",
+    "Registry",
+    "render_prometheus_text",
+]

--- a/src/server_metrics/formatter.py
+++ b/src/server_metrics/formatter.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Render a Registry to Prometheus text exposition format v0.0.4."""
+
+from __future__ import annotations
+
+from server_metrics.registry import Counter, Gauge, Registry
+
+# Content type for `Content-Type: text/plain; version=0.0.4; charset=utf-8`
+# per https://prometheus.io/docs/instrumenting/exposition_formats/
+PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+
+
+def _escape_help(text: str) -> str:
+    # HELP lines only need backslash and newline escaping per the spec.
+    return text.replace("\\", "\\\\").replace("\n", "\\n")
+
+
+def _escape_label_value(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _format_labels(label_names: tuple[str, ...], label_values: tuple[str, ...]) -> str:
+    if not label_names:
+        return ""
+    pairs = [
+        f'{name}="{_escape_label_value(value)}"'
+        for name, value in zip(label_names, label_values, strict=True)
+    ]
+    return "{" + ",".join(pairs) + "}"
+
+
+def _format_float(value: float) -> str:
+    # Prometheus accepts Go-style float formatting. Integer-valued
+    # floats emit without a fractional part for readability, matching
+    # prometheus_client's output.
+    if value != value:  # NaN
+        return "NaN"
+    if value == float("inf"):
+        return "+Inf"
+    if value == float("-inf"):
+        return "-Inf"
+    if value.is_integer() and abs(value) < 1e16:
+        return str(int(value))
+    return repr(value)
+
+
+def render_prometheus_text(registry: Registry) -> str:
+    """Serialise a registry to Prometheus text exposition.
+
+    Output is newline-terminated (the spec requires a trailing newline
+    at EOF) and encodes one ``# HELP`` + ``# TYPE`` block per metric
+    followed by its samples in registration order. A metric with no
+    recorded samples still emits the HELP / TYPE lines so scrapers
+    see the metric existence before the first observation.
+    """
+    parts: list[str] = []
+    for metric in registry.metrics():
+        parts.append(f"# HELP {metric.name} {_escape_help(metric.description)}")
+        if isinstance(metric, Counter):
+            parts.append(f"# TYPE {metric.name} counter")
+            for label_values, value in metric.samples():
+                parts.append(
+                    f"{metric.name}{_format_labels(metric.label_names, label_values)} "
+                    f"{_format_float(value)}"
+                )
+        elif isinstance(metric, Gauge):
+            parts.append(f"# TYPE {metric.name} gauge")
+            for label_values, value in metric.samples():
+                parts.append(
+                    f"{metric.name}{_format_labels(metric.label_names, label_values)} "
+                    f"{_format_float(value)}"
+                )
+        else:
+            # Metric = Counter | Gauge | Histogram; the two branches
+            # above cover Counter / Gauge exhaustively, so anything
+            # left is a Histogram (pyright narrows this automatically).
+            parts.append(f"# TYPE {metric.name} histogram")
+            bucket_label_names = (*metric.label_names, "le")
+            for label_values, counts, sum_value in metric.samples():
+                for i, upper in enumerate(metric.buckets):
+                    bucket_label_values = (*label_values, _format_float(upper))
+                    parts.append(
+                        f"{metric.name}_bucket"
+                        f"{_format_labels(bucket_label_names, bucket_label_values)} "
+                        f"{counts[i]}"
+                    )
+                inf_label_values = (*label_values, "+Inf")
+                parts.append(
+                    f"{metric.name}_bucket"
+                    f"{_format_labels(bucket_label_names, inf_label_values)} "
+                    f"{counts[-1]}"
+                )
+                parts.append(
+                    f"{metric.name}_sum"
+                    f"{_format_labels(metric.label_names, label_values)} "
+                    f"{_format_float(sum_value)}"
+                )
+                parts.append(
+                    f"{metric.name}_count"
+                    f"{_format_labels(metric.label_names, label_values)} "
+                    f"{counts[-1]}"
+                )
+    return "\n".join(parts) + "\n"

--- a/src/server_metrics/registry.py
+++ b/src/server_metrics/registry.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""In-process metric storage with label sets.
+
+Each primitive is independently thread-safe. Labels are presented as
+keyword arguments and stored as positional tuples in declaration order
+to keep both snapshot reads and formatting O(1) per sample.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterable, Mapping
+
+# OTel semconv's recommended HTTP latency buckets (seconds).
+DEFAULT_HTTP_DURATION_BUCKETS: tuple[float, ...] = (
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.075,
+    0.1,
+    0.25,
+    0.5,
+    0.75,
+    1.0,
+    2.5,
+    5.0,
+    7.5,
+    10.0,
+)
+
+
+def _validate_name(name: str) -> None:
+    if not name:
+        raise ValueError("metric name must be non-empty")
+    # Prometheus metric-name grammar: [a-zA-Z_:][a-zA-Z0-9_:]*
+    # We use a simpler, stricter subset that excludes ':' (reserved for
+    # recording rules in ops-land) so nothing emitted here collides.
+    valid = all(c.isalnum() or c == "_" for c in name)
+    if not valid or not (name[0].isalpha() or name[0] == "_"):
+        raise ValueError(f"invalid metric name: {name!r}")
+
+
+def _labels_to_key(label_names: tuple[str, ...], labels: Mapping[str, str]) -> tuple[str, ...]:
+    """Project a user-supplied label mapping onto the declared label order.
+
+    Missing labels become the empty string rather than raising — mirrors
+    prometheus_client's "labelless" path and lets callers omit labels
+    they don't care about. Extra labels raise, since a silent drop would
+    hide typos.
+    """
+    extra = set(labels) - set(label_names)
+    if extra:
+        raise ValueError(f"unexpected label(s): {sorted(extra)}")
+    return tuple(labels.get(name, "") for name in label_names)
+
+
+class Counter:
+    """Monotonically increasing counter."""
+
+    def __init__(self, name: str, description: str, label_names: Iterable[str] = ()) -> None:
+        _validate_name(name)
+        self.name = name
+        self.description = description
+        self.label_names: tuple[str, ...] = tuple(label_names)
+        self._values: dict[tuple[str, ...], float] = {}
+        self._lock = threading.Lock()
+
+    def inc(self, amount: float = 1.0, **labels: str) -> None:
+        if amount < 0:
+            raise ValueError(f"Counter {self.name!r} cannot decrement")
+        key = _labels_to_key(self.label_names, labels)
+        with self._lock:
+            self._values[key] = self._values.get(key, 0.0) + amount
+
+    def samples(self) -> list[tuple[tuple[str, ...], float]]:
+        """Return a point-in-time snapshot of label-values pairs."""
+        with self._lock:
+            return list(self._values.items())
+
+
+class Gauge:
+    """Gauge value that may go up or down."""
+
+    def __init__(self, name: str, description: str, label_names: Iterable[str] = ()) -> None:
+        _validate_name(name)
+        self.name = name
+        self.description = description
+        self.label_names: tuple[str, ...] = tuple(label_names)
+        self._values: dict[tuple[str, ...], float] = {}
+        self._lock = threading.Lock()
+
+    def inc(self, amount: float = 1.0, **labels: str) -> None:
+        key = _labels_to_key(self.label_names, labels)
+        with self._lock:
+            self._values[key] = self._values.get(key, 0.0) + amount
+
+    def dec(self, amount: float = 1.0, **labels: str) -> None:
+        self.inc(-amount, **labels)
+
+    def set(self, value: float, **labels: str) -> None:
+        key = _labels_to_key(self.label_names, labels)
+        with self._lock:
+            self._values[key] = value
+
+    def samples(self) -> list[tuple[tuple[str, ...], float]]:
+        with self._lock:
+            return list(self._values.items())
+
+
+class Histogram:
+    """Cumulative histogram with caller-supplied bucket boundaries.
+
+    Prometheus semantics: each ``_bucket{le="x"}`` count is the total
+    number of observations with value <= x. The synthetic ``+Inf``
+    bucket equals the total observation count and is emitted verbatim
+    in the text format.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        label_names: Iterable[str] = (),
+        buckets: Iterable[float] = DEFAULT_HTTP_DURATION_BUCKETS,
+    ) -> None:
+        _validate_name(name)
+        self.name = name
+        self.description = description
+        self.label_names: tuple[str, ...] = tuple(label_names)
+        sorted_buckets = tuple(sorted(buckets))
+        if not sorted_buckets:
+            raise ValueError(f"Histogram {name!r} requires at least one bucket")
+        self.buckets: tuple[float, ...] = sorted_buckets
+        # ``counts[i]`` for i in [0, len(buckets)] = <= buckets[i] count;
+        # ``counts[len(buckets)]`` = +Inf bucket (== total observations).
+        self._counts: dict[tuple[str, ...], list[int]] = {}
+        self._sums: dict[tuple[str, ...], float] = {}
+        self._lock = threading.Lock()
+
+    def observe(self, value: float, **labels: str) -> None:
+        key = _labels_to_key(self.label_names, labels)
+        with self._lock:
+            counts = self._counts.get(key)
+            if counts is None:
+                counts = [0] * (len(self.buckets) + 1)
+                self._counts[key] = counts
+            for i, upper in enumerate(self.buckets):
+                if value <= upper:
+                    counts[i] += 1
+            counts[-1] += 1  # +Inf / total count
+            self._sums[key] = self._sums.get(key, 0.0) + value
+
+    def samples(self) -> list[tuple[tuple[str, ...], list[int], float]]:
+        with self._lock:
+            return [
+                (key, list(counts), self._sums.get(key, 0.0))
+                for key, counts in self._counts.items()
+            ]
+
+
+Metric = Counter | Gauge | Histogram
+
+
+class Registry:
+    """An ordered collection of metrics.
+
+    Registration order is preserved so the exposition output is
+    deterministic for tests and eyeballing a ``curl`` response.
+    """
+
+    def __init__(self) -> None:
+        self._metrics: list[Metric] = []
+        self._names: set[str] = set()
+
+    def register(self, metric: Metric) -> None:
+        if metric.name in self._names:
+            raise ValueError(f"metric {metric.name!r} already registered")
+        self._metrics.append(metric)
+        self._names.add(metric.name)
+
+    def metrics(self) -> list[Metric]:
+        return list(self._metrics)

--- a/src/things_bridge/metrics.py
+++ b/src/things_bridge/metrics.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Metric declarations and registry builder for things-bridge.
+
+The bridge has no persistent state — its domain outcomes (authz
+denials, Things-app failures) are captured as ``status_code`` labels
+on the HTTP duration histogram rather than as separate counters.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from server_metrics import Gauge, Histogram, Registry
+
+
+@dataclass(frozen=True)
+class ThingsBridgeMetrics:
+    """Handle to every metric things-bridge emits."""
+
+    http_request_duration: Histogram
+    http_active_requests: Gauge
+
+
+def build_registry() -> tuple[Registry, ThingsBridgeMetrics]:
+    http_request_duration = Histogram(
+        "http_server_request_duration_seconds",
+        "Duration of HTTP server requests in seconds.",
+        label_names=("method", "route", "status_code"),
+    )
+    http_active_requests = Gauge(
+        "http_server_active_requests",
+        "Number of HTTP server requests currently in flight.",
+        label_names=("method",),
+    )
+
+    registry = Registry()
+    for metric in (http_request_duration, http_active_requests):
+        registry.register(metric)
+
+    return registry, ThingsBridgeMetrics(
+        http_request_duration=http_request_duration,
+        http_active_requests=http_active_requests,
+    )

--- a/src/things_bridge/server.py
+++ b/src/things_bridge/server.py
@@ -9,10 +9,16 @@ import os
 import signal
 import sys
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from urllib.parse import parse_qs, urlsplit
 
+from server_metrics import (
+    PROMETHEUS_CONTENT_TYPE,
+    Registry,
+    render_prometheus_text,
+)
 from things_bridge.authz import AgentAuthClient
 from things_bridge.config import Config
 from things_bridge.errors import (
@@ -24,10 +30,16 @@ from things_bridge.errors import (
     ThingsNotFoundError,
     ThingsPermissionError,
 )
+from things_bridge.metrics import ThingsBridgeMetrics, build_registry
 from things_models.client import ThingsClient
 
 READ_SCOPE = "things:read"
 HEALTH_SCOPE = "things-bridge:health"
+METRICS_SCOPE = "things-bridge:metrics"
+
+# Sentinel route label for unmatched paths; bounds label cardinality
+# when a scraper hits arbitrary URLs.
+_UNKNOWN_ROUTE = "/unknown"
 
 # Upper bound on ids accepted from URL paths. Things ids are short; reject
 # anything excessive before it ever reaches AppleScript.
@@ -116,13 +128,60 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
             return
         self._send_json(502, {"error": "things_unavailable"})
 
+    def send_response(self, code: int, message: str | None = None) -> None:
+        # Capture the status code so ``do_GET`` can label the request
+        # duration histogram. ``BaseHTTPRequestHandler`` accepts either
+        # an ``HTTPStatus`` or a bare int; normalise here.
+        self._last_status_code = int(code)
+        super().send_response(code, message)
+
+    def _handle_metrics(self) -> None:
+        token = self._extract_bearer()
+        if token is None:
+            self._send_json(401, {"error": "unauthorized"})
+            return
+        if not self._validate(token, METRICS_SCOPE, "things-bridge metrics scrape"):
+            return
+        registry: Registry = self._bridge.registry
+        body = render_prometheus_text(registry).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", PROMETHEUS_CONTENT_TYPE)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
     def do_GET(self) -> None:
+        metrics = self._bridge.metrics
+        metrics.http_active_requests.inc(method="GET")
+        start = time.perf_counter()
+        # ``_route_template`` is set by ``_dispatch_get`` before it hands
+        # off to a handler; default preserves _UNKNOWN_ROUTE if the
+        # dispatcher returns without matching.
+        self._route_template = _UNKNOWN_ROUTE
+        try:
+            self._dispatch_get()
+        finally:
+            duration = time.perf_counter() - start
+            metrics.http_active_requests.dec(method="GET")
+            status_code = str(getattr(self, "_last_status_code", 0))
+            metrics.http_request_duration.observe(
+                duration,
+                method="GET",
+                route=self._route_template,
+                status_code=status_code,
+            )
+
+    def _dispatch_get(self) -> None:
         url = urlsplit(self.path)
         path = url.path
         params = parse_qs(url.query)
 
         token = self._extract_bearer()
         if token is None:
+            # Unauthenticated probe: no route resolution is possible
+            # without leaking whether the path is known. Label as
+            # unknown to keep label cardinality bounded against
+            # scanners.
             self._send_json(401, {"error": "unauthorized"})
             return
 
@@ -131,15 +190,22 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
         # without a token can probe the 401 (server-is-up signal); the
         # 200 path requires the scope. Health remains unversioned by convention.
         if path == "/things-bridge/health":
+            self._route_template = path
             if not self._validate(token, HEALTH_SCOPE, "things-bridge health check"):
                 return
             self._send_json(200, {"status": "ok"})
+            return
+
+        if path == "/things-bridge/metrics":
+            self._route_template = path
+            self._handle_metrics()
             return
 
         things: ThingsClient = self._bridge.things
 
         # Routing: longest-prefix specific paths first.
         if path == "/things-bridge/v1/todos":
+            self._route_template = path
             if not self._validate(token, READ_SCOPE, "List Things todos"):
                 return
             try:
@@ -157,6 +223,7 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
             return
 
         if path.startswith("/things-bridge/v1/todos/"):
+            self._route_template = "/things-bridge/v1/todos/{id}"
             todo_id = _safe_id(path[len("/things-bridge/v1/todos/") :])
             if todo_id is None:
                 self._send_json(404, {"error": "not_found"})
@@ -172,6 +239,7 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
             return
 
         if path == "/things-bridge/v1/projects":
+            self._route_template = path
             if not self._validate(token, READ_SCOPE, "List Things projects"):
                 return
             try:
@@ -183,6 +251,7 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
             return
 
         if path.startswith("/things-bridge/v1/projects/"):
+            self._route_template = "/things-bridge/v1/projects/{id}"
             project_id = _safe_id(path[len("/things-bridge/v1/projects/") :])
             if project_id is None:
                 self._send_json(404, {"error": "not_found"})
@@ -198,6 +267,7 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
             return
 
         if path == "/things-bridge/v1/areas":
+            self._route_template = path
             if not self._validate(token, READ_SCOPE, "List Things areas"):
                 return
             try:
@@ -209,6 +279,7 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
             return
 
         if path.startswith("/things-bridge/v1/areas/"):
+            self._route_template = "/things-bridge/v1/areas/{id}"
             area_id = _safe_id(path[len("/things-bridge/v1/areas/") :])
             if area_id is None:
                 self._send_json(404, {"error": "not_found"})
@@ -226,6 +297,10 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
         self._send_json(404, {"error": "not_found"})
 
     def _method_not_allowed(self) -> None:
+        # Other methods still participate in metrics. Set the sentinel
+        # route template so do_GET's wrapper isn't the only accounting
+        # path. (Method labels disambiguate POST /path from GET /path.)
+        self._route_template = _UNKNOWN_ROUTE
         self.send_response(405)
         self.send_header("Allow", "GET")
         body = json.dumps({"error": "method_not_allowed"}).encode("utf-8")
@@ -258,10 +333,19 @@ class ThingsBridgeServer(ThreadingHTTPServer):
     # The shutdown watchdog in ``run_server`` bounds the wait.
     daemon_threads = False
 
-    def __init__(self, config: Config, things: ThingsClient, authz: AgentAuthClient):
+    def __init__(
+        self,
+        config: Config,
+        things: ThingsClient,
+        authz: AgentAuthClient,
+        registry: Registry,
+        metrics: ThingsBridgeMetrics,
+    ):
         self.config = config
         self.things = things
         self.authz = authz
+        self.registry = registry
+        self.metrics = metrics
         super().__init__((config.host, config.port), ThingsBridgeHandler)
 
 
@@ -319,7 +403,8 @@ def run_server(config: Config, things: ThingsClient, authz: AgentAuthClient) -> 
     Registers SIGTERM and SIGINT handlers that drain in-flight requests
     within ``config.shutdown_deadline_seconds`` before returning.
     """
-    server = ThingsBridgeServer(config, things, authz)
+    registry, metrics = build_registry()
+    server = ThingsBridgeServer(config, things, authz, registry, metrics)
     drain_complete = _install_shutdown_handler(server, config.shutdown_deadline_seconds)
     # Read the bound port from ``server_address`` (populated during
     # ``server_bind``) so a ``port: 0`` config surfaces the real port.

--- a/tests/_http.py
+++ b/tests/_http.py
@@ -21,6 +21,24 @@ def get(url: str, headers: dict[str, str] | None = None) -> tuple[int, Any]:
         return e.code, json.loads(e.read())
 
 
+def get_text(url: str, headers: dict[str, str] | None = None) -> tuple[int, str, str]:
+    """GET a text/plain endpoint; return (status, content_type, body)."""
+    req = urllib.request.Request(url, headers=headers or {})
+    try:
+        resp = urllib.request.urlopen(req)
+        return (
+            resp.status,
+            resp.headers.get("Content-Type", ""),
+            resp.read().decode("utf-8"),
+        )
+    except urllib.error.HTTPError as e:
+        return (
+            e.code,
+            e.headers.get("Content-Type", "") if e.headers else "",
+            e.read().decode("utf-8"),
+        )
+
+
 def post(
     url: str,
     data: dict[str, Any] | None = None,

--- a/tests/test_error_taxonomy.py
+++ b/tests/test_error_taxonomy.py
@@ -23,6 +23,9 @@ agent-auth /v1/token/reissue:
 agent-auth /health (unversioned):
   missing_token (401), invalid_token (401), token_expired (401),
   scope_denied (403).
+agent-auth /metrics (unversioned):
+  missing_token (401), invalid_token (401), token_expired (401),
+  scope_denied (403).
 agent-auth server-wide:
   not_found (404).
 things-bridge /v1/* data endpoints:
@@ -30,6 +33,9 @@ things-bridge /v1/* data endpoints:
   authz_unavailable (502), not_found (404),
   things_permission_denied (503), things_unavailable (502).
 things-bridge /health (unversioned):
+  unauthorized (401), token_expired (401), scope_denied (403),
+  authz_unavailable (502).
+things-bridge /metrics (unversioned):
   unauthorized (401), token_expired (401), scope_denied (403),
   authz_unavailable (502).
 things-bridge server-wide:
@@ -46,6 +52,7 @@ import pytest
 from agent_auth.approval import ApprovalManager
 from agent_auth.audit import AuditLogger
 from agent_auth.config import Config
+from agent_auth.metrics import build_registry as build_auth_registry
 from agent_auth.plugins import ApprovalResult, NotificationPlugin
 from agent_auth.server import AgentAuthServer
 from agent_auth.store import TokenStore
@@ -61,6 +68,7 @@ from things_bridge.errors import (
     ThingsError,
     ThingsPermissionError,
 )
+from things_bridge.metrics import build_registry as build_bridge_registry
 from things_bridge.server import ThingsBridgeServer
 
 # -- test infrastructure --
@@ -82,7 +90,8 @@ def auth_server(tmp_dir, signing_key, encryption_key):
     store = TokenStore(config.db_path, encryption_key)
     audit = AuditLogger(config.log_path)
     approval_manager = ApprovalManager(_DenyPlugin(), store, audit)
-    server = AgentAuthServer(config, signing_key, store, audit, approval_manager)
+    registry, metrics = build_auth_registry()
+    server = AgentAuthServer(config, signing_key, store, audit, approval_manager, registry, metrics)
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -165,7 +174,8 @@ def bridge_server():
     authz = _FakeAuthz()
     store = FakeThingsStore()
     things = _InjectableThings(store)
-    server = ThingsBridgeServer(config, things, authz)
+    registry, metrics = build_bridge_registry()
+    server = ThingsBridgeServer(config, things, authz, registry, metrics)
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -375,6 +385,45 @@ def test_health_scope_denied(auth_server):
     assert body["error"] == "scope_denied"
 
 
+# == agent-auth: GET /agent-auth/metrics (unversioned) ==
+
+
+def test_metrics_missing_token(auth_server):
+    _, _, _, base = auth_server
+    status, body = get(f"{base}/agent-auth/metrics")
+    assert status == 401
+    assert body["error"] == "missing_token"
+
+
+def test_metrics_invalid_token(auth_server):
+    _, _, _, base = auth_server
+    status, body = get(f"{base}/agent-auth/metrics", _bearer("aa_fake_badsig"))
+    assert status == 401
+    assert body["error"] == "invalid_token"
+
+
+def test_metrics_token_expired(auth_server):
+    config, signing_key, store, base = auth_server
+    family_id = "fam-metrics-exp"
+    store.create_family(family_id, {"agent-auth:metrics": "allow"})
+    access_token, _ = create_token_pair(signing_key, store, family_id, config)
+    token_id = _extract_token_id(access_token)
+    _expire_token(config.db_path, token_id)
+    status, body = get(f"{base}/agent-auth/metrics", _bearer(access_token))
+    assert status == 401
+    assert body["error"] == "token_expired"
+
+
+def test_metrics_scope_denied(auth_server):
+    config, signing_key, store, base = auth_server
+    family_id = "fam-metrics-scope"
+    store.create_family(family_id, {"things:read": "allow"})
+    access_token, _ = create_token_pair(signing_key, store, family_id, config)
+    status, body = get(f"{base}/agent-auth/metrics", _bearer(access_token))
+    assert status == 403
+    assert body["error"] == "scope_denied"
+
+
 # == agent-auth: server-wide ==
 
 
@@ -472,6 +521,40 @@ def test_bridge_health_authz_unavailable(bridge_server):
     authz, _, base = bridge_server
     authz.exc = AuthzUnavailableError("down")
     status, body = get(f"{base}/things-bridge/health", _bearer("tok"))
+    assert status == 502
+    assert body["error"] == "authz_unavailable"
+
+
+# == things-bridge: GET /things-bridge/metrics (unversioned) ==
+
+
+def test_bridge_metrics_unauthorized_no_token(bridge_server):
+    _, _, base = bridge_server
+    status, body = get(f"{base}/things-bridge/metrics")
+    assert status == 401
+    assert body["error"] == "unauthorized"
+
+
+def test_bridge_metrics_token_expired(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzTokenExpiredError("expired")
+    status, body = get(f"{base}/things-bridge/metrics", _bearer("tok"))
+    assert status == 401
+    assert body["error"] == "token_expired"
+
+
+def test_bridge_metrics_scope_denied(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzScopeDeniedError("denied")
+    status, body = get(f"{base}/things-bridge/metrics", _bearer("tok"))
+    assert status == 403
+    assert body["error"] == "scope_denied"
+
+
+def test_bridge_metrics_authz_unavailable(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzUnavailableError("down")
+    status, body = get(f"{base}/things-bridge/metrics", _bearer("tok"))
     assert status == 502
     assert body["error"] == "authz_unavailable"
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,6 +14,7 @@ from agent_auth.approval import ApprovalManager
 from agent_auth.audit import AuditLogger
 from agent_auth.config import Config
 from agent_auth.keys import KeyManager
+from agent_auth.metrics import build_registry
 from agent_auth.plugins import ApprovalResult, NotificationPlugin
 from agent_auth.server import (
     MANAGEMENT_SCOPE,
@@ -23,7 +24,7 @@ from agent_auth.server import (
 )
 from agent_auth.store import TokenStore
 from agent_auth.tokens import create_token_pair
-from tests._http import get, post
+from tests._http import get, get_text, post
 
 
 def _issue_health_token(server, store, scopes):
@@ -53,7 +54,8 @@ def in_process_server(tmp_dir, signing_key, encryption_key):
     store = TokenStore(config.db_path, encryption_key)
     audit = AuditLogger(config.log_path)
     approval_manager = ApprovalManager(_DenyPlugin(), store, audit)
-    server = AgentAuthServer(config, signing_key, store, audit, approval_manager)
+    registry, metrics = build_registry()
+    server = AgentAuthServer(config, signing_key, store, audit, approval_manager, registry, metrics)
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -107,6 +109,80 @@ def test_health_rejects_tokens_without_the_health_scope(in_process_server):
     status, body = get(f"{base}/agent-auth/health", _health_headers(token))
     assert status == 403
     assert body["error"] == "scope_denied"
+
+
+# -- /metrics ---------------------------------------------------------------
+_EXPECTED_METRIC_NAMES = (
+    "http_server_request_duration_seconds",
+    "http_server_active_requests",
+    "agent_auth_token_operations_total",
+    "agent_auth_validation_outcomes_total",
+    "agent_auth_approval_outcomes_total",
+)
+
+
+@pytest.mark.covers_function("Serve Metrics Endpoint")
+def test_metrics_requires_a_bearer_token(in_process_server):
+    _, base, _ = in_process_server
+    status, body = get(f"{base}/agent-auth/metrics")
+    assert status == 401
+    assert body["error"] == "missing_token"
+
+
+@pytest.mark.covers_function("Serve Metrics Endpoint")
+def test_metrics_rejects_tokens_without_the_metrics_scope(in_process_server):
+    server, base, store = in_process_server
+    token = _issue_health_token(server, store, {"things:read": "allow"})
+    status, body = get(f"{base}/agent-auth/metrics", _health_headers(token))
+    assert status == 403
+    assert body["error"] == "scope_denied"
+
+
+@pytest.mark.covers_function("Serve Metrics Endpoint")
+def test_metrics_emits_prometheus_text_with_all_declared_metric_names(in_process_server):
+    server, base, store = in_process_server
+    token = _issue_health_token(server, store, {"agent-auth:metrics": "allow"})
+    status, content_type, body = get_text(f"{base}/agent-auth/metrics", _health_headers(token))
+    assert status == 200
+    assert content_type.startswith("text/plain")
+    # Contract: every declared metric name must appear in the
+    # exposition. Names are inlined (not looped over a module
+    # constant) so the test body is what scripts/verify-standards.sh
+    # regex-matches against — a rename breaks both places at once.
+    assert "# TYPE http_server_request_duration_seconds" in body
+    assert "# TYPE http_server_active_requests" in body
+    assert "# TYPE agent_auth_token_operations_total" in body
+    assert "# TYPE agent_auth_validation_outcomes_total" in body
+    assert "# TYPE agent_auth_approval_outcomes_total" in body
+
+
+@pytest.mark.covers_function("Serve Metrics Endpoint")
+def test_metrics_record_http_duration_on_every_request(in_process_server):
+    """A scrape observes its own duration bucket — smoke test for the wrapper."""
+    server, base, store = in_process_server
+    token = _issue_health_token(server, store, {"agent-auth:metrics": "allow"})
+    # Prime with one request; the /metrics scrape itself increments too.
+    get_text(f"{base}/agent-auth/metrics", _health_headers(token))
+    status, _ct, body = get_text(f"{base}/agent-auth/metrics", _health_headers(token))
+    assert status == 200
+    # The scrape increments the bucket for its own (GET, /agent-auth/metrics)
+    # request; count must be >= 1 for the +Inf bucket.
+    assert 'route="/agent-auth/metrics"' in body
+    assert "http_server_request_duration_seconds_bucket" in body
+
+
+@pytest.mark.covers_function("Serve Metrics Endpoint")
+def test_metrics_increments_validation_denied_counter(in_process_server):
+    server, base, store = in_process_server
+    # Trigger a validation-denied outcome with an invalid token.
+    post(
+        f"{base}/agent-auth/v1/validate",
+        data={"token": "aa_fake_nope", "required_scope": "things:read"},
+    )
+    token = _issue_health_token(server, store, {"agent-auth:metrics": "allow"})
+    status, _ct, body = get_text(f"{base}/agent-auth/metrics", _health_headers(token))
+    assert status == 200
+    assert 'agent_auth_validation_outcomes_total{outcome="denied",reason="invalid_token"}' in body
 
 
 def test_unknown_get_route_returns_404(in_process_server):

--- a/tests/test_server_metrics.py
+++ b/tests/test_server_metrics.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for server_metrics primitives and Prometheus text formatter."""
+
+from __future__ import annotations
+
+import pytest
+
+from server_metrics import (
+    PROMETHEUS_CONTENT_TYPE,
+    Counter,
+    Gauge,
+    Histogram,
+    Registry,
+    render_prometheus_text,
+)
+
+
+def test_counter_increments_and_cannot_go_negative():
+    c = Counter("requests_total", "Request count.", label_names=("method",))
+    c.inc(method="GET")
+    c.inc(method="GET")
+    c.inc(method="POST", amount=3)
+    samples = dict(c.samples())
+    assert samples[("GET",)] == 2
+    assert samples[("POST",)] == 3
+    with pytest.raises(ValueError):
+        c.inc(amount=-1, method="GET")
+
+
+def test_counter_rejects_unknown_labels():
+    c = Counter("x_total", "desc", label_names=("a",))
+    with pytest.raises(ValueError):
+        c.inc(b="oops")
+
+
+def test_gauge_goes_up_and_down_and_supports_set():
+    g = Gauge("active", "Active count.", label_names=())
+    g.inc()
+    g.inc(2)
+    g.dec()
+    samples = dict(g.samples())
+    assert samples[()] == 2
+    g.set(10)
+    assert dict(g.samples())[()] == 10
+
+
+def test_histogram_buckets_are_cumulative_and_track_sum():
+    h = Histogram(
+        "latency_seconds",
+        "Latency.",
+        label_names=("route",),
+        buckets=(0.1, 0.5, 1.0),
+    )
+    for v in (0.05, 0.2, 0.8, 1.5):
+        h.observe(v, route="/foo")
+    ((labels, counts, sum_value),) = h.samples()
+    assert labels == ("/foo",)
+    # buckets: <=0.1, <=0.5, <=1.0, +Inf
+    assert counts == [1, 2, 3, 4]
+    assert sum_value == pytest.approx(0.05 + 0.2 + 0.8 + 1.5)
+
+
+def test_histogram_requires_buckets():
+    with pytest.raises(ValueError):
+        Histogram("bad", "desc", buckets=())
+
+
+def test_registry_preserves_registration_order_and_rejects_duplicates():
+    r = Registry()
+    a = Counter("a_total", "A")
+    b = Counter("b_total", "B")
+    r.register(a)
+    r.register(b)
+    assert [m.name for m in r.metrics()] == ["a_total", "b_total"]
+    with pytest.raises(ValueError):
+        r.register(Counter("a_total", "dup"))
+
+
+def test_render_emits_help_type_and_samples_in_order():
+    r = Registry()
+    c = Counter("http_requests_total", "HTTP request count.", label_names=("method",))
+    c.inc(method="GET")
+    r.register(c)
+    text = render_prometheus_text(r)
+    assert text.endswith("\n")
+    lines = text.splitlines()
+    assert lines[0] == "# HELP http_requests_total HTTP request count."
+    assert lines[1] == "# TYPE http_requests_total counter"
+    assert lines[2] == 'http_requests_total{method="GET"} 1'
+
+
+def test_render_escapes_backslash_quote_and_newline_in_label_values():
+    r = Registry()
+    c = Counter("edge_total", "edge", label_names=("path",))
+    c.inc(path='a"b\\c\nd')
+    r.register(c)
+    text = render_prometheus_text(r)
+    assert 'path="a\\"b\\\\c\\nd"' in text
+
+
+def test_render_histogram_emits_bucket_sum_and_count_lines():
+    r = Registry()
+    h = Histogram(
+        "http_duration_seconds",
+        "Request duration.",
+        label_names=("route",),
+        buckets=(0.1, 1.0),
+    )
+    h.observe(0.05, route="/x")
+    h.observe(0.5, route="/x")
+    r.register(h)
+    text = render_prometheus_text(r)
+    # Every bucket line plus +Inf, sum, count present.
+    assert 'http_duration_seconds_bucket{route="/x",le="0.1"} 1' in text
+    assert 'http_duration_seconds_bucket{route="/x",le="1"} 2' in text
+    assert 'http_duration_seconds_bucket{route="/x",le="+Inf"} 2' in text
+    assert 'http_duration_seconds_count{route="/x"} 2' in text
+    assert 'http_duration_seconds_sum{route="/x"}' in text
+
+
+def test_render_handles_zero_sample_metric():
+    r = Registry()
+    r.register(Counter("unused_total", "Never touched."))
+    text = render_prometheus_text(r)
+    lines = text.splitlines()
+    assert lines == [
+        "# HELP unused_total Never touched.",
+        "# TYPE unused_total counter",
+    ]
+
+
+def test_prometheus_content_type_matches_spec():
+    assert PROMETHEUS_CONTENT_TYPE == "text/plain; version=0.0.4; charset=utf-8"

--- a/tests/test_server_shutdown.py
+++ b/tests/test_server_shutdown.py
@@ -28,6 +28,7 @@ import pytest
 from agent_auth.approval import ApprovalManager
 from agent_auth.audit import AuditLogger
 from agent_auth.config import Config
+from agent_auth.metrics import build_registry
 from agent_auth.plugins import ApprovalResult, NotificationPlugin
 from agent_auth.server import AgentAuthHandler, AgentAuthServer, _install_shutdown_handler
 from agent_auth.store import TokenStore
@@ -149,7 +150,8 @@ def _make_server(tmp_dir, signing_key, encryption_key):
     store = TokenStore(config.db_path, encryption_key)
     audit = AuditLogger(config.log_path)
     approval_manager = ApprovalManager(_DenyPlugin(), store, audit)
-    server = AgentAuthServer(config, signing_key, store, audit, approval_manager)
+    registry, metrics = build_registry()
+    server = AgentAuthServer(config, signing_key, store, audit, approval_manager, registry, metrics)
     return config, store, server
 
 

--- a/tests/test_things_bridge_server.py
+++ b/tests/test_things_bridge_server.py
@@ -25,6 +25,7 @@ from things_bridge.errors import (
     ThingsError,
     ThingsPermissionError,
 )
+from things_bridge.metrics import build_registry as build_bridge_registry
 from things_bridge.server import ThingsBridgeServer
 from things_models.models import Area
 
@@ -100,7 +101,8 @@ def bridge():
     authz = FakeAuthz()
     store = FakeThingsStore()
     things = _InjectableThings(store)
-    server = ThingsBridgeServer(config, things, authz)
+    registry, metrics = build_bridge_registry()
+    server = ThingsBridgeServer(config, things, authz, registry, metrics)
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -134,10 +136,91 @@ def _get(url: str, token: str | None = "aa_test_token") -> tuple[int, Any]:
         return exc.code, parsed
 
 
+def _get_text(url: str, token: str | None = "aa_test_token"):
+    """GET a text/plain endpoint, returning (status, content_type, body)."""
+    req = urllib.request.Request(url)
+    if token is not None:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return (
+                resp.status,
+                resp.headers.get("Content-Type", ""),
+                resp.read().decode("utf-8"),
+            )
+    except urllib.error.HTTPError as exc:
+        return (
+            exc.code,
+            exc.headers.get("Content-Type", "") if exc.headers else "",
+            exc.read().decode("utf-8", errors="replace"),
+        )
+
+
 def test_get_todos_requires_bearer_token(bridge):
     status, data = _get(f"{bridge['url']}/things-bridge/v1/todos", token=None)
     assert status == 401
     assert data == {"error": "unauthorized"}
+
+
+# -- /metrics ---------------------------------------------------------------
+
+_EXPECTED_BRIDGE_METRIC_NAMES = (
+    "http_server_request_duration_seconds",
+    "http_server_active_requests",
+)
+
+
+def test_metrics_requires_bearer_token(bridge):
+    status, data = _get(f"{bridge['url']}/things-bridge/metrics", token=None)
+    assert status == 401
+    assert data == {"error": "unauthorized"}
+
+
+def test_metrics_rejects_tokens_without_metrics_scope(bridge):
+    bridge["authz"].raise_on_validate = AuthzScopeDeniedError("scope_denied")
+    status, data = _get(f"{bridge['url']}/things-bridge/metrics")
+    assert status == 403
+    assert data == {"error": "scope_denied"}
+
+
+def test_metrics_returns_prometheus_text_with_declared_metrics(bridge):
+    status, content_type, body = _get_text(f"{bridge['url']}/things-bridge/metrics")
+    assert status == 200
+    assert content_type.startswith("text/plain")
+    # The scrape calls authz.validate under the ``things-bridge:metrics``
+    # scope. Our FakeAuthz accepts anything that doesn't raise.
+    assert bridge["authz"].last_scope == "things-bridge:metrics"
+    # Contract: every declared metric name appears in the exposition.
+    # Names are inlined (not looped via a module constant) so
+    # scripts/verify-standards.sh can regex-match this block — a
+    # rename breaks both places at once.
+    assert "# TYPE http_server_request_duration_seconds" in body
+    assert "# TYPE http_server_active_requests" in body
+
+
+def test_metrics_authz_unavailable_maps_to_502(bridge):
+    bridge["authz"].raise_on_validate = AuthzUnavailableError("unreachable")
+    status, data = _get(f"{bridge['url']}/things-bridge/metrics")
+    assert status == 502
+    assert data["error"] == "authz_unavailable"
+
+
+def test_metrics_scrape_records_its_own_http_duration(bridge):
+    _get_text(f"{bridge['url']}/things-bridge/metrics")
+    status, _ct, body = _get_text(f"{bridge['url']}/things-bridge/metrics")
+    assert status == 200
+    assert 'route="/things-bridge/metrics"' in body
+    assert "http_server_request_duration_seconds_bucket" in body
+
+
+def test_metrics_id_carrying_route_uses_templated_label(bridge):
+    # Probe a todo-by-id path — the metric label should collapse the
+    # ``{id}`` segment so cardinality stays bounded.
+    _get(f"{bridge['url']}/things-bridge/v1/todos/t1")
+    status, _ct, body = _get_text(f"{bridge['url']}/things-bridge/metrics")
+    assert status == 200
+    assert 'route="/things-bridge/v1/todos/{id}"' in body
+    assert 'route="/things-bridge/v1/todos/t1"' not in body
 
 
 def test_get_todos_delegates_to_authz_and_returns_list(bridge):

--- a/tests/test_things_bridge_shutdown.py
+++ b/tests/test_things_bridge_shutdown.py
@@ -27,6 +27,7 @@ from tests.factories import make_area
 from tests.things_client_fake.store import FakeThingsClient, FakeThingsStore
 from things_bridge.authz import AgentAuthClient
 from things_bridge.config import Config
+from things_bridge.metrics import build_registry as build_bridge_registry
 from things_bridge.server import (
     ThingsBridgeHandler,
     ThingsBridgeServer,
@@ -137,7 +138,8 @@ def test_in_flight_bridge_request_completes_before_server_close_returns(monkeypa
     things = FakeThingsClient(store)
     authz = _AlwaysValidAuthz()
     config = Config(host="127.0.0.1", port=0)
-    server = ThingsBridgeServer(config, things, authz)
+    registry, metrics = build_bridge_registry()
+    server = ThingsBridgeServer(config, things, authz, registry, metrics)
     port = server.server_address[1]
 
     request_entered = threading.Event()


### PR DESCRIPTION
## Summary

- Both servers now expose a scoped Prometheus scrape endpoint at `/<service>/metrics`, authenticated under an `<service>:metrics` scope parallel to the existing `<service>:health` model.
- Exposition is hand-rolled in a new `src/server_metrics/` package (Counter / Gauge / Histogram / Registry + v0.0.4 text formatter) — no `prometheus_client`, no OTel SDK. ADR 0017 pinned the OTel semconv *names*, not the SDK.
- Fills in the domain-counter catalogue in `design/DESIGN.md` "Observability" that was previously deferred to #26.
- `scripts/verify-standards.sh` now gates route registration + per-metric-name test coverage.

Closes #26.

## Metrics catalogue

Agent-auth:
- `http_server_request_duration_seconds` (histogram; method/route/status_code; OTel default HTTP buckets)
- `http_server_active_requests` (gauge; method)
- `agent_auth_token_operations_total` (operation ∈ {created, refreshed, reissued, revoked, rotated})
- `agent_auth_validation_outcomes_total` (outcome, reason — reasons mirror `validation_denied` audit reasons plus `ok`)
- `agent_auth_approval_outcomes_total` (outcome ∈ {approved, denied})

Things-bridge:
- `http_server_request_duration_seconds` + `http_server_active_requests`. No domain counters — bridge has no persistent state; authz / Things failures appear on the `status_code` label.

## Route templating

For things-bridge's id-carrying paths, the handler sets `_route_template` to the templated form (e.g. `/things-bridge/v1/todos/{id}`) before the outer wrapper records the duration, so id cardinality is bounded.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration` — 389 passed, 3 skipped
- [x] `task typecheck` (mypy strict + pyright strict) clean
- [x] `task check` (lint + format) clean
- [x] `bash scripts/verify-standards.sh` passes including the new metrics gate
- [x] OpenAPI specs updated; `tests/test_openapi_spec.py` green
- [x] Error taxonomy updated + contract tests added for both `/metrics` surfaces
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)