### PR TITLE
ci(release-please): migrate from PAT to GitHub App installation token (#128)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,12 +17,23 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived installation token from the "Release Please
+      # agent-auth" GitHub App. Tags and releases created by the default
+      # GITHUB_TOKEN do not fire downstream `on: push: tags:` workflow
+      # triggers, which would silently break the chain into
+      # release-publish.yml — so we need a non-GITHUB_TOKEN credential.
+      # The App has `contents: write` + `pull-requests: write` on this
+      # repo only; the token expires on workflow completion. Setup
+      # instructions: CONTRIBUTING.md § Release process → Default path.
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
-          # RELEASE_PLEASE_TOKEN must be a PAT or GitHub App token. Tags
-          # and releases created by the default GITHUB_TOKEN do not fire
-          # downstream workflow triggers, which would silently break the
-          # release-publish chain. See CONTRIBUTING.md § Release process.
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Release Please now authenticates via a dedicated GitHub App
+  instead of a PAT.** `.github/workflows/release-please.yml` mints a
+  short-lived installation token per workflow run via
+  `actions/create-github-app-token` (pinned to `v3` commit SHA),
+  using new repository secrets `RELEASE_PLEASE_APP_ID` +
+  `RELEASE_PLEASE_APP_PRIVATE_KEY`. The "Release Please agent-auth"
+  App scopes to `aidanns/agent-auth` only with `contents: write` +
+  `pull-requests: write`, strictly narrower than a human-account
+  PAT. The legacy `RELEASE_PLEASE_TOKEN` secret is retired; setup
+  and rotation procedures are documented in `CONTRIBUTING.md` §
+  *Release process → Default path*. ADR 0016 "Consequences" and
+  "Follow-ups" updated. Closes
+  [#128](https://github.com/aidanns/agent-auth/issues/128).
+
 ### Added
 
 - **`design/SELF_ASSESSMENT.md` — CNCF TAG-Security-style security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,15 +159,64 @@ For every user-facing PR, update `CHANGELOG.md` before merging:
 
 ### Default path: Release Please
 
-One-time setup: create a **fine-grained personal access token** (or
-GitHub App installation token) with `contents: write` and
-`pull-requests: write` permission on this repository, and save it as
-the `RELEASE_PLEASE_TOKEN` repository secret. This is required
-because tags created by the default `GITHUB_TOKEN` do **not** fire
-downstream `on: push: tags:` workflows — without a PAT, the chain
-from the Release Please merge to the signed-artefact publish
-silently breaks. A GitHub App token is the lower-blast-radius option
-if you're willing to spin one up.
+One-time setup: install a **GitHub App** on this repository that the
+`Release Please` workflow uses to mint short-lived installation
+tokens via
+[`actions/create-github-app-token`](https://github.com/actions/create-github-app-token).
+A GitHub App token is required (rather than the default
+`GITHUB_TOKEN`) because tags created by `GITHUB_TOKEN` do **not**
+fire downstream `on: push: tags:` workflows — the chain from the
+Release Please merge to the signed-artefact publish would silently
+break. The App is preferred over a PAT because it scopes to a single
+repo, exposes no human credential surface, and its private key can
+be rotated without touching a personal account.
+
+#### One-time: register the "Release Please agent-auth" GitHub App
+
+1. Go to
+   [github.com/settings/apps/new](https://github.com/settings/apps/new)
+   (user-owned App) and create an App with:
+   - **App name**: `Release Please agent-auth` (any identifier
+     works; the name appears in release-PR author metadata).
+   - **Homepage URL**:
+     `https://github.com/aidanns/agent-auth`.
+   - **Webhook**: uncheck *Active* — this App does not handle
+     events.
+   - **Repository permissions**:
+     - *Contents*: **Read & write** (create tags + releases).
+     - *Pull requests*: **Read & write** (open/update the release
+       PR).
+     - All other permissions: **No access**.
+   - **Where can this GitHub App be installed?**: *Only on this
+     account*.
+2. Click **Create GitHub App**.
+3. On the App's settings page:
+   - Copy the **App ID** (numeric, shown at the top) for step 5.
+   - Under **Private keys → Generate a private key**, download
+     the `.pem` file. GitHub shows it once.
+4. Still on the App's settings page, open **Install App** and
+   install it against `aidanns/agent-auth` only — not *All
+   repositories*.
+5. In the repo's
+   [Settings → Secrets and variables → Actions](https://github.com/aidanns/agent-auth/settings/secrets/actions),
+   add:
+   - `RELEASE_PLEASE_APP_ID` — the numeric App ID from step 3.
+   - `RELEASE_PLEASE_APP_PRIVATE_KEY` — the **full contents** of
+     the `.pem` file, including the `-----BEGIN/END` markers and
+     the trailing newline.
+6. Delete the legacy `RELEASE_PLEASE_TOKEN` secret if it still
+   exists.
+
+The workflow in `.github/workflows/release-please.yml` reads these
+two secrets at run time, mints an installation token via
+`actions/create-github-app-token`, and hands the token to
+`googleapis/release-please-action`. The token is short-lived and
+is not persisted beyond the workflow run.
+
+To rotate the private key, re-run step 3 (generate a new key),
+update `RELEASE_PLEASE_APP_PRIVATE_KEY` in repo settings, and
+revoke the old key from the App settings page. No workflow change
+is required.
 
 1. Land PRs on `main` using Conventional Commits.
 2. The `Release Please` workflow opens or updates the release PR

--- a/design/decisions/0016-release-supply-chain.md
+++ b/design/decisions/0016-release-supply-chain.md
@@ -129,14 +129,22 @@ the per-file licensing convention.
 - A compromised GitHub-hosted runner could produce a signed
   malicious bundle. Residual risk accepted; Rekor transparency-log
   inclusion is the detection signal.
-- Release Please requires a PAT or GitHub App token stored as a
-  repository secret (`RELEASE_PLEASE_TOKEN`) because tags created
-  with the default `GITHUB_TOKEN` do not fire downstream workflow
-  triggers. This adds one long-lived credential to the trust root
-  — weaker than the keyless cosign posture elsewhere in this
-  pipeline. Rotation burden is on the maintainer; a GitHub App
-  installation token is the preferred mitigation if we spin one
-  up.
+- Release Please requires a non-`GITHUB_TOKEN` credential stored as
+  a repository secret because tags created with the default
+  `GITHUB_TOKEN` do not fire downstream workflow triggers. The
+  original implementation used a fine-grained PAT
+  (`RELEASE_PLEASE_TOKEN`); as of
+  [#128](https://github.com/aidanns/agent-auth/issues/128) this has
+  been replaced with a dedicated GitHub App
+  ("Release Please agent-auth") whose installation token is minted
+  per workflow run via `actions/create-github-app-token` from
+  `RELEASE_PLEASE_APP_ID` + `RELEASE_PLEASE_APP_PRIVATE_KEY`
+  secrets. The token is short-lived and the App scopes to this
+  single repo with only `contents: write` and
+  `pull-requests: write` — strictly narrower than a PAT bound to a
+  human account. The private key remains the long-lived credential
+  in the trust root; rotation procedure is documented in
+  `CONTRIBUTING.md` § *Release process → Default path*.
 - `release-type: simple` means Release Please will generate its
   own CHANGELOG section on first run, which may not match the
   existing hand-maintained Keep-a-Changelog format perfectly. We
@@ -147,17 +155,24 @@ the per-file licensing convention.
 
 ## Follow-ups
 
-- [#109](https://github.com/aidanns/agent-auth/issues/109) — add
-  SLSA build provenance attestation on top of the publish workflow.
 - [#93](https://github.com/aidanns/agent-auth/issues/93) —
   write-protect the `v*` tag namespace to CI only.
 - [#18](https://github.com/aidanns/agent-auth/issues/18) — decide
   whether to collapse `scripts/release.sh` into a smaller local
   validator once the CI path has produced a few real releases.
-- [#127](https://github.com/aidanns/agent-auth/issues/127) — pin
-  release-affecting GitHub Actions to commit SHAs.
-- [#128](https://github.com/aidanns/agent-auth/issues/128) — migrate
-  `release-please-action` from a PAT to a GitHub App installation
-  token.
+
+Resolved since this ADR landed:
+
+- [#109](https://github.com/aidanns/agent-auth/issues/109) — SLSA
+  Build L3 provenance attached to every release (see
+  [ADR 0020](0020-slsa-build-provenance.md)).
+- [#127](https://github.com/aidanns/agent-auth/issues/127) —
+  release-adjacent Actions pinned to commit SHAs; policy in
+  `.claude/instructions/tooling-and-ci.md`.
+- [#128](https://github.com/aidanns/agent-auth/issues/128) —
+  `release-please-action` migrated from a PAT to a dedicated GitHub
+  App installation token minted via
+  `actions/create-github-app-token`. Setup and rotation in
+  `CONTRIBUTING.md` § *Release process → Default path*.
 
 <!-- REUSE-IgnoreEnd -->


### PR DESCRIPTION
> ⚠ **Do not merge until the one-time GitHub App setup is complete (checklist at the bottom).** Merging before \`RELEASE_PLEASE_APP_ID\` + \`RELEASE_PLEASE_APP_PRIVATE_KEY\` are set in repo secrets will break the next Release Please run.

## Summary

- \`release-please.yml\` mints a short-lived installation token per
  run via \`actions/create-github-app-token@v3\` (SHA-pinned per the
  #127 policy) and hands it to
  \`googleapis/release-please-action\`. The App token is the
  non-\`GITHUB_TOKEN\` credential needed to push tags that fire
  downstream \`on: push: tags:\` workflows.
- New repo secrets consumed: \`RELEASE_PLEASE_APP_ID\` and
  \`RELEASE_PLEASE_APP_PRIVATE_KEY\`. The legacy
  \`RELEASE_PLEASE_TOKEN\` PAT is retired.
- \`CONTRIBUTING.md\` § *Release process → Default path* now
  documents the full App-registration walkthrough (App name,
  permissions, install-scope, secret format, rotation procedure).
- ADR 0016 "Consequences" swaps the PAT carve-out for the App
  description; "Follow-ups" moves #109, #127, and #128 to a new
  "Resolved since this ADR landed" section and cross-links to ADR
  0020 and the SHA-pin policy.

Closes #128.

## Pre-merge setup checklist (maintainer)

**Do not merge until all of these are done.** Full walkthrough in
[\`CONTRIBUTING.md\` § Release process → Default path](../blob/aidanns/issue-128-release-please-app/CONTRIBUTING.md#default-path-release-please).

- [ ] Create a **user-owned** GitHub App at
      https://github.com/settings/apps/new named
      \`Release Please agent-auth\`, with:
  - Webhook → *Active* **unchecked**
  - Repository permissions: *Contents* **Read & write**,
    *Pull requests* **Read & write**, everything else
    **No access**
  - Install scope: *Only on this account*
- [ ] Copy the numeric **App ID** from the App settings page.
- [ ] Generate a private key from the App settings page; save the
      \`.pem\` file (it's shown only once).
- [ ] Install the App on \`aidanns/agent-auth\` only (not *All
      repositories*).
- [ ] In
      [repo Settings → Secrets and variables → Actions](https://github.com/aidanns/agent-auth/settings/secrets/actions),
      add:
  - [ ] \`RELEASE_PLEASE_APP_ID\` — numeric App ID.
  - [ ] \`RELEASE_PLEASE_APP_PRIVATE_KEY\` — full \`.pem\`
        contents including \`-----BEGIN/END\` lines and trailing
        newline.
- [ ] Delete the legacy \`RELEASE_PLEASE_TOKEN\` secret from repo
      settings once the two new secrets exist.

## Post-merge verification

- [ ] Push a dummy \`chore:\` commit to \`main\` (or manually
      trigger the \`Release Please\` workflow via
      \`workflow_dispatch\`); confirm the existing release PR is
      updated by the App (the PR author / committer metadata
      should show the App's name, not a human user).
- [ ] On the next release-PR merge, confirm the \`v*\` tag push
      fires \`release-publish.yml\` — i.e. the full
      sdist/wheel/SBOM/cosign/SLSA bundle lands on the release.

## Test plan (CI-level)

- [ ] \`task format -- --check\` passes
- [ ] \`task lint\` passes
- [ ] \`task reuse-lint\` passes
- [ ] \`task verify-standards\` passes
- [ ] CI green on this PR (CI doesn't exercise
      \`release-please.yml\` on PRs — the workflow only fires on
      \`main\` push / workflow_dispatch, so the first real-world
      validation is the post-merge dry run above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)