### PR TITLE
test(perf): performance budget for validate hot path (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Performance budget** for the agent hot path
+  (`POST /agent-auth/v1/validate`) documented in `design/DESIGN.md`
+  § Performance budget along with budgets for
+  `/v1/token/refresh` and `/v1/token/create`. A new perf-assertion
+  test (`tests/test_perf_budget.py`) drives the validate endpoint
+  against an in-process `AgentAuthServer` with N=100 sequential
+  requests and fails CI if the measured median or p95 exceeds the
+  budget. The test is discoverable as a group via
+  `pytest -m perf_budget`; the marker is registered in
+  `[tool.pytest.ini_options].markers`. `scripts/verify-standards.sh`
+  asserts both pieces are present (the DESIGN.md heading, the
+  marker registration, and at least one `@pytest.mark.perf_budget`
+  test). Local baseline is p50=0.62ms / p95=1.00ms against budgets
+  of 10ms / 50ms — the headroom absorbs CI-runner noise while
+  still catching a regression that would add a per-request tax on
+  every downstream bridge call. Closes
+  [#41](https://github.com/aidanns/agent-auth/issues/41).
 - Fault-injection test layer under `tests/fault/` exercising each
   documented failure mode: SQLite write errors / closed connection,
   audit-log disk-full / read-only filesystem, keyring backend

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -794,6 +794,40 @@ Run modes:
   Docker.
 - `scripts/test.sh --all` — both layers.
 
+## Performance budget
+
+`.claude/instructions/testing-standards.md` § Performance requires a
+documented latency target for critical operations plus at least one
+test that asserts the budget. This section pins the targets; the
+assertion lives in `tests/test_perf_budget.py` behind a
+`@pytest.mark.perf_budget` marker so the gate is discoverable by tag
+and independently runnable (`pytest -m perf_budget`).
+
+The agent hot path — the one every third-party request passes through
+— is `POST /agent-auth/v1/validate`. A slow validate becomes a
+per-request tax on every downstream bridge, so it carries the tightest
+budget:
+
+| Endpoint                            | Median (p50) | p95    | Rationale                                                                                                                                                                                                                                                                       |
+| ----------------------------------- | ------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST /agent-auth/v1/validate`      | 10 ms        | 50 ms  | HMAC verify + indexed SQLite read + audit-log append. Headroom over the measured local baseline so GitHub Actions / macOS CI noise does not flake. Budget is *allow-tier only*; prompt-tier latency is dominated by the notification plugin and is not a library-level concern. |
+| `POST /agent-auth/v1/token/refresh` | 20 ms        | 100 ms | Mark-consumed + new-token-pair write under a transaction; inherently hotter than validate because it writes, not reads.                                                                                                                                                         |
+| `POST /agent-auth/v1/token/create`  | 30 ms        | 150 ms | Management-side, low volume; budgeted generously because it also holds an encrypted scope write.                                                                                                                                                                                |
+
+Measurement protocol: the perf-budget test drives the listed endpoint
+against a throwaway in-process `AgentAuthServer` bound to `127.0.0.1:0`
+(same fixture pattern the other handler-edge tests use), issues N=100
+sequential requests, and asserts the median and p95 of the per-request
+wall-clock duration do not exceed the numbers above. The budget is
+deliberately sequential — concurrency-level throughput is out of scope
+for a single-instance, single-user deployment.
+
+The floor is a *never-loosen* signal, not a benchmark — it ratchets
+**downward** as the implementation improves, never upward, per the
+same policy as the coverage and mutation-score thresholds. Any commit
+that raises it must include the measurement and an explicit
+justification in the commit message body.
+
 ## Observability
 
 The project follows the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ ignore-vuln = []
 pythonpath = ["src"]
 markers = [
     "covers_function(*names): declare which functional-decomposition leaf functions a test exercises (read by `systems-engineering function verify`)",
+    "perf_budget: asserts a latency budget documented in design/DESIGN.md § Performance budget. Discoverable as a group via `pytest -m perf_budget`.",
 ]
 # Coverage is gated at a ratcheting floor per
 # .claude/instructions/testing-standards.md. --cov-fail-under is the

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -61,6 +61,10 @@
 #      timeout/exception, agent-auth unreachable, Things AppleScript
 #      failures), per .claude/instructions/testing-standards.md
 #      "Chaos and fault-injection tests".
+#  14. design/DESIGN.md documents a latency budget for critical
+#      operations AND at least one test carries the perf_budget
+#      pytest marker, per .claude/instructions/testing-standards.md
+#      "Performance budget".
 
 set -euo pipefail
 
@@ -1456,3 +1460,49 @@ if [[ ${fault_missing} -ne 0 ]]; then
 fi
 
 echo "verify-standards: ${fault_dir}/ covers all required fault-injection scenarios."
+
+# ---------------------------------------------------------------------------
+# Performance budget.
+# ---------------------------------------------------------------------------
+# .claude/instructions/testing-standards.md (Performance — "Performance
+# budget") requires BOTH a documented latency target for critical
+# operations in the design docs AND at least one test asserting that
+# budget. The deterministic check asserts:
+#
+#   1. design/DESIGN.md contains a "Performance budget" heading.
+#   2. pyproject.toml registers the `perf_budget` pytest marker.
+#   3. At least one test file applies `@pytest.mark.perf_budget`.
+design_file="design/DESIGN.md"
+if [[ ! -f "${design_file}" ]]; then
+  echo "verify-standards: ${design_file} is missing." >&2
+  exit 1
+fi
+
+if ! grep -qE "^## +Performance budget\b" "${design_file}"; then
+  echo "verify-standards: ${design_file} is missing a '## Performance budget' section." >&2
+  echo "  Document a latency target per .claude/instructions/testing-standards.md § Performance." >&2
+  exit 1
+fi
+
+if ! python3 -c "
+import sys, tomllib
+from pathlib import Path
+pyproject = tomllib.loads(Path('pyproject.toml').read_text())
+markers = pyproject.get('tool', {}).get('pytest', {}).get('ini_options', {}).get('markers', [])
+if not any(str(m).startswith('perf_budget') for m in markers):
+    sys.exit('perf_budget marker not registered in [tool.pytest.ini_options].markers')
+" 2>/tmp/verify-standards-perf.err; then
+  echo "verify-standards: pyproject.toml does not register the perf_budget pytest marker:" >&2
+  cat /tmp/verify-standards-perf.err >&2
+  rm -f /tmp/verify-standards-perf.err
+  exit 1
+fi
+rm -f /tmp/verify-standards-perf.err
+
+if ! grep -r -l -E "@pytest\\.mark\\.perf_budget\\b" tests/ >/dev/null 2>&1; then
+  echo "verify-standards: no test under tests/ applies @pytest.mark.perf_budget." >&2
+  echo "  Add a perf-budget-assertion test referencing ${design_file} § Performance budget." >&2
+  exit 1
+fi
+
+echo "verify-standards: ${design_file} documents a performance budget and at least one test carries the perf_budget marker."

--- a/tests/test_perf_budget.py
+++ b/tests/test_perf_budget.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Performance-budget assertion for the agent hot path.
+
+``design/DESIGN.md`` § Performance budget documents the latency target
+for the critical operations; this test materialises that target into a
+deterministic gate so a regression (an unindexed query, a new
+per-request allocation, a stray ``time.sleep``) fails CI rather than
+surfacing in production.
+
+The test is sequential and in-process: concurrency-level throughput
+is out of scope for a single-user deployment, and running against a
+throwaway ``AgentAuthServer`` on ``127.0.0.1:0`` keeps the budget
+insulated from external services. Budgets include enough headroom
+over the local baseline to absorb GitHub Actions / macOS CI noise
+without flaking; see the DESIGN.md section for rationale.
+"""
+
+import os
+import threading
+import time
+
+import pytest
+
+from agent_auth.approval import ApprovalManager
+from agent_auth.audit import AuditLogger
+from agent_auth.config import Config
+from agent_auth.metrics import build_registry
+from agent_auth.plugins import ApprovalResult, NotificationPlugin
+from agent_auth.server import AgentAuthServer
+from agent_auth.store import TokenStore
+from agent_auth.tokens import create_token_pair
+from tests._http import post
+
+# Budgets below match design/DESIGN.md § Performance budget verbatim.
+# Update both together — the DESIGN.md table is the source of truth.
+VALIDATE_P50_BUDGET_MS = 10.0
+VALIDATE_P95_BUDGET_MS = 50.0
+SAMPLES = 100
+
+
+class _DenyPlugin(NotificationPlugin):
+    def request_approval(self, scope, description, family_id):
+        return ApprovalResult(approved=False)
+
+
+@pytest.fixture
+def perf_server(tmp_path, signing_key, encryption_key):
+    config = Config(
+        db_path=os.path.join(tmp_path, "tokens.db"),
+        log_path=os.path.join(tmp_path, "audit.log"),
+        host="127.0.0.1",
+        port=0,
+    )
+    store = TokenStore(config.db_path, encryption_key)
+    audit = AuditLogger(config.log_path)
+    approval_manager = ApprovalManager(_DenyPlugin(), store, audit)
+    registry, metrics = build_registry()
+    server = AgentAuthServer(config, signing_key, store, audit, approval_manager, registry, metrics)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server, f"http://127.0.0.1:{port}", store
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Nearest-rank percentile (matches Prometheus / Grafana default)."""
+    ordered = sorted(values)
+    index = max(0, min(len(ordered) - 1, int(round(pct / 100.0 * len(ordered))) - 1))
+    return ordered[index]
+
+
+@pytest.mark.perf_budget
+def test_validate_allow_tier_latency_budget(perf_server):
+    """Allow-tier validate p50/p95 latency fits the DESIGN.md budget.
+
+    Warms the connection pool and SQLite page cache once, then times
+    ``SAMPLES`` sequential validates of a known-good access token with
+    an allow-tier scope — the single path that every downstream
+    bridge/CLI request goes through.
+    """
+    server, base, store = perf_server
+    family_id = "fam-perf"
+    store.create_family(family_id, {"things:read": "allow"})
+    access_token, _ = create_token_pair(server.signing_key, store, family_id, server.config)
+
+    payload = {"token": access_token, "required_scope": "things:read"}
+
+    # Warm-up: prime the keep-alive connection, SQLite page cache, and
+    # audit-log file handle so the timed loop measures steady-state
+    # latency rather than cold start.
+    for _ in range(5):
+        status, body = post(f"{base}/agent-auth/v1/validate", data=payload)
+        assert status == 200 and body.get("valid") is True
+
+    durations_ms: list[float] = []
+    for _ in range(SAMPLES):
+        start = time.perf_counter()
+        status, body = post(f"{base}/agent-auth/v1/validate", data=payload)
+        durations_ms.append((time.perf_counter() - start) * 1000)
+        assert status == 200 and body.get("valid") is True
+
+    p50 = _percentile(durations_ms, 50)
+    p95 = _percentile(durations_ms, 95)
+
+    # Print the measurement on every run so a ratchet-down PR can read
+    # it out of the CI log without re-running the test locally.
+    print(
+        f"\nvalidate latency (n={SAMPLES}): "
+        f"p50={p50:.2f}ms (budget {VALIDATE_P50_BUDGET_MS}ms), "
+        f"p95={p95:.2f}ms (budget {VALIDATE_P95_BUDGET_MS}ms)"
+    )
+
+    assert p50 <= VALIDATE_P50_BUDGET_MS, (
+        f"validate p50 {p50:.2f}ms exceeds budget {VALIDATE_P50_BUDGET_MS}ms — "
+        "see design/DESIGN.md § Performance budget."
+    )
+    assert p95 <= VALIDATE_P95_BUDGET_MS, (
+        f"validate p95 {p95:.2f}ms exceeds budget {VALIDATE_P95_BUDGET_MS}ms — "
+        "see design/DESIGN.md § Performance budget."
+    )


### PR DESCRIPTION
## Summary

- Document a latency budget for the agent hot path (\`POST /agent-auth/v1/validate\`, p50 ≤ 10ms / p95 ≤ 50ms) in \`design/DESIGN.md\` § Performance budget, plus budgets for \`/v1/token/refresh\` and \`/v1/token/create\`.
- Add \`tests/test_perf_budget.py\`: materialises the budget into a deterministic gate with N=100 sequential validates against an in-process \`AgentAuthServer\`. Uses the nearest-rank percentile method.
- Register the \`perf_budget\` pytest marker so \`pytest -m perf_budget\` selects the group.
- \`scripts/verify-standards.sh\` asserts (a) the DESIGN.md heading exists, (b) the marker is registered, (c) at least one \`@pytest.mark.perf_budget\` test exists — so a rename or drop of any of the three fails CI.
- Budgets are *ratchet-downward-only* (never looser), same policy as the coverage and mutation-score thresholds.

## Baseline

Local measurement: p50 = 0.62 ms, p95 = 1.00 ms — well below the 10 ms / 50 ms budget. Headroom absorbs CI / macOS runner noise.

## Test plan

- [x] \`uv run pytest tests/test_perf_budget.py -s --no-cov\` — passes, prints the measured latencies.
- [x] \`task verify-standards\` — passes including the new assertion.
- [x] \`task verify-function-tests\` — 57/57 covered.
- [x] \`task typecheck\` — 0 errors.
- [x] \`task check\` — lint + format + integration isolation all green.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)