### PR TITLE
docs(security): defer application-layer rate limiting with ADR 0022 (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   still catching a regression that would add a per-request tax on
   every downstream bridge call. Closes
   [#41](https://github.com/aidanns/agent-auth/issues/41).
+- Rate-limiting / DoS posture decision recorded in
+  [ADR 0022](design/decisions/0022-rate-limiting-posture.md):
+  1.0 defers application-layer rate limiting and relies on the
+  loopback-only bind, the 1 MiB body cap, the 128-byte id-segment
+  cap on the bridge, and `ApprovalManager`'s implicit per-family
+  serialisation. `design/DESIGN.md` gains a new
+  "Rate limiting and request budgets" section enumerating the
+  expected steady / ceiling rate per endpoint.
+  `scripts/verify-standards.sh` gates that some ADR carries
+  "rate limit" / "DoS posture" / "denial of service" in its title
+  so a future deletion fails CI
+  ([#30](https://github.com/aidanns/agent-auth/issues/30)).
 - Fault-injection test layer under `tests/fault/` exercising each
   documented failure mode: SQLite write errors / closed connection,
   audit-log disk-full / read-only filesystem, keyring backend

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -1036,6 +1036,38 @@ their existing names:
 Log-level policy, log location, rotation, and retention are
 documented in the subsections above.
 
+## Rate limiting and request budgets
+
+Both services run loopback-only by default (`127.0.0.1`) and are
+single-user on a host. `design/decisions/0022-rate-limiting-posture.md`
+records the decision to **defer application-layer rate limiting**
+for 1.0; the guards that remain are the 1 MiB request-body cap
+(`AgentAuthHandler.MAX_BODY_SIZE`), the 128-byte id-segment cap
+(`ThingsBridgeHandler._safe_id`), and `ApprovalManager`'s implicit
+per-family serialisation of JIT approvals via the notification
+plugin's blocking contract.
+
+Expected request rate and ceiling per endpoint on a typical
+single-operator deployment:
+
+| Endpoint                                                  | Expected rate (steady)      | Ceiling (short burst) | Notes                                                                    |
+| --------------------------------------------------------- | --------------------------- | --------------------- | ------------------------------------------------------------------------ |
+| `POST /agent-auth/v1/validate`                            | ≲ 10 / min per active agent | 60 / min              | One call per Things-bridge request; scripted agents are the main source. |
+| `POST /agent-auth/v1/token/refresh`                       | ≲ 4 / hour per family       | 20 / hour             | Access tokens default to 15 min TTL, so 4/hour is the natural ceiling.   |
+| `POST /agent-auth/v1/token/reissue`                       | ≲ 1 / day per family        | 5 / day               | Gated by JIT approval; burst unlikely given human-in-the-loop.           |
+| `POST /agent-auth/v1/token/{create,modify,revoke,rotate}` | ≲ 1 / day                   | 50 / day              | Operator-driven management.                                              |
+| `GET /agent-auth/v1/token/{list,status}`                  | ≲ 10 / min                  | 120 / min             | Operator-driven; management UIs may poll.                                |
+| `GET /agent-auth/health`                                  | 1 / 10 s (probe)            | 1 / s                 | Liveness probes.                                                         |
+| `GET /agent-auth/metrics`                                 | 1 / 15–60 s (scrape)        | 1 / 5 s               | Prometheus scrape.                                                       |
+| `GET /things-bridge/v1/*` (read)                          | ≲ 10 / min per active agent | 60 / min              | AppleScript subprocess is the bottleneck, not the bridge.                |
+| `GET /things-bridge/health`, `/things-bridge/metrics`     | 1 / 10–60 s                 | 1 / s                 | Same probe / scrape budget as agent-auth.                                |
+
+"Ceiling" is an observational target (what we expect to *see* in
+normal operation) rather than an enforced limit. Exceeding it
+during production use is a signal to investigate — a looping
+agent, a runaway polling loop, or a legitimate workflow change —
+not a condition to refuse.
+
 ## Security Considerations
 
 - The signing key is stored in the system keyring (macOS Keychain or libsecret/gnome-keyring), never as a plaintext file. Only agent-auth reads it.

--- a/design/decisions/0022-rate-limiting-posture.md
+++ b/design/decisions/0022-rate-limiting-posture.md
@@ -1,0 +1,161 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+SPDX-License-Identifier: MIT
+-->
+
+# ADR 0022 — Defer application-layer rate limiting; rely on loopback-only bind and bounded request bodies
+
+## Status
+
+Accepted — 2026-04-21.
+
+## Context
+
+Issue [#30](https://github.com/aidanns/agent-auth/issues/30).
+`.claude/instructions/service-design.md` calls for an expected
+request-rate budget per endpoint and either an implemented rate
+limit or a documented rationale for deferring it. Today neither
+server applies application-layer rate limiting; the only DoS guard
+on the request path is the 1 MiB body cap enforced in
+`AgentAuthHandler._read_json` (and the read path is GET-only on
+things-bridge, which trivially bounds body size).
+
+The services' trust boundary is a single host: both bind to
+`127.0.0.1` by default, accept traffic only from local processes,
+and the `agent-auth:manage` surface requires a bearer token issued
+and stored in the system keyring on the same machine. There is no
+public-network deployment model and no multi-tenant posture — the
+threat model in `SECURITY.md` names the user themselves as the
+single principal.
+
+Under those constraints, rate limiting protects the service from
+two realistic adversaries:
+
+- **Buggy local agent.** A looping caller could burn CPU and flood
+  the audit log. The typical symptom is a validation-storm on
+  `POST /agent-auth/v1/validate` from a runaway automation script.
+- **Compromised local process.** A process that has already
+  escalated on the host could amplify its blast radius by
+  exhausting the approval-prompt queue for a sensitive scope. This
+  matters more for the things-bridge surface (Things AppleScript
+  is user-visible and throttled by the OS automation pipeline
+  anyway) than for agent-auth itself.
+
+It is *not* plausibly useful against:
+
+- Remote network floods — the loopback bind excludes them entirely.
+- Credential stuffing — tokens are HMAC-signed opaque identifiers;
+  an attacker without the signing key cannot mint valid tokens no
+  matter the request rate.
+
+## Considered alternatives
+
+### Per-IP / per-token token-bucket on every endpoint
+
+Standard web-app rate limit — N requests per token-bucket refill
+per peer identity (IP, or bearer token id).
+
+**Rejected** because:
+
+- Peer identity at `127.0.0.1` is effectively one value. Per-IP
+  limits do not distinguish concurrent agents on the same host;
+  per-token limits bucket the management path and the agent-
+  validation path against each other, which is the opposite of
+  what the threat model asks for.
+- The buggy-agent case is better solved by the audit log and
+  metrics: `agent_auth_validation_outcomes_total{outcome="denied"}`
+  spikes on a loop and the operator notices. A hard cap adds a new
+  failure mode (legitimate burst > cap → refusal) without
+  preventing the observable loop.
+- Every token family would need a bucket state. Sizing and
+  persisting that state is new complexity on the storage tier,
+  which agent-auth keeps deliberately tight.
+
+### JIT-approval concurrency limit only
+
+Narrower variant: cap the number of in-flight `prompt`-tier
+approvals per family so a compromised caller cannot queue an
+unbounded number of system-modal dialogs.
+
+**Rejected for this ADR** because the existing `ApprovalManager`
+already serialises approval requests per family through the
+notification plugin's own blocking semantics (the plugin returns
+before the next request is dispatched), which bounds the queue
+depth to effectively 1 per family. A separate counter is redundant
+here. If a future plugin implementation runs approvals concurrently
+across families, we will revisit.
+
+### Reverse-proxy rate limit
+
+Run `agent-auth` and `things-bridge` behind a local reverse proxy
+(nginx, envoy, caddy) with rate-limit directives.
+
+**Rejected** because it adds an operator-visible component for a
+single-user deployment and cannot see past the 127.0.0.1 bind —
+every request would hit it from `localhost` so it would only
+provide global, not per-caller, limits. Moving that cap into the
+service itself is cheaper if we later decide it is needed.
+
+## Decision
+
+**Defer application-layer rate limiting.** The 1.0 release ships
+without per-IP or per-token buckets.
+
+Keep these guards instead:
+
+- Loopback-only bind (`127.0.0.1`) remains the default in
+  `Config.host` on both services. Remote-binding is deliberately
+  an operator opt-in, not a packaging default.
+- `AgentAuthHandler.MAX_BODY_SIZE = 1 MiB` bounds the validation
+  and token-management request bodies. A caller cannot blow RAM
+  by sending a huge JSON payload.
+- `ThingsBridgeHandler._safe_id` caps path-segment length at
+  128 bytes, so id-carrying paths cannot defeat metric-label
+  templating.
+- `ApprovalManager` serialises JIT approvals per family — if a
+  plugin blocks on the user, the family cannot enqueue a second
+  prompt until the first resolves.
+- `agent_auth_validation_outcomes_total` on `/metrics` gives the
+  operator a runaway-loop signal without forcing refusal.
+
+Document the decision and the expected-rate ceiling in
+`design/DESIGN.md` "Rate limiting and request budgets" so a
+future threat-model refresh can recheck the assumption.
+
+## Consequences
+
+Positive:
+
+- No new state on the storage tier. Token-store schema stays at
+  the shape pinned by #20 + the migration story in #29.
+- No rejection path for legitimate bursts. A script driving the
+  CLI at normal agent pace will never trip an artificial cap.
+- Metric signal (`agent_auth_validation_outcomes_total`) and the
+  audit log together cover the diagnostic need rate limits are
+  usually built to serve.
+
+Negative / accepted risks:
+
+- A buggy local agent can still produce a tight validation loop.
+  The operator diagnoses via `/metrics` + audit log and kills the
+  agent; the service does not throttle automatically.
+- If a future deployment exposes either server beyond `127.0.0.1`
+  (reverse proxy, devcontainer port-forward, remote operator
+  tooling), the decision recorded here no longer applies and must
+  be revisited. The follow-up trigger is "trust boundary moves
+  off-host", not "more requests per second".
+- JIT-approval storms from a compromised peer rely on the
+  notification plugin being slow-serial; moving to a batched or
+  concurrent plugin will require reopening this ADR.
+
+## Follow-ups
+
+- If/when the trust boundary extends beyond localhost (e.g.
+  devcontainer port-forward surfaces a user-visible listener),
+  reopen this ADR and implement per-peer token-bucket limiting
+  with a corresponding `agent_auth_requests_throttled_total`
+  counter.
+- Reopen this ADR when the notification plugin migrates to the
+  out-of-process HTTP model in issue #6 — the per-family
+  concurrency bound rests on the current in-process plugin
+  contract.

--- a/design/decisions/README.md
+++ b/design/decisions/README.md
@@ -63,3 +63,5 @@ is linked from this index.
   — tag-triggered `release-publish.yml` attaches `multiple.intoto.jsonl` in-toto attestations to every release; verification via `slsa-verifier verify-artifact`.
 - [ADR 0021 — Mutation testing on security-critical modules](0021-mutation-testing-security-critical.md)
   — nightly mutmut pass on tokens/crypto/keys/scopes/store gated by a ratcheting score floor; `scripts/verify-standards.sh` enforces `[tool.mutmut]` config and scheduled workflow stay present.
+- [ADR 0022 — Defer application-layer rate limiting; rely on loopback-only bind and bounded request bodies](0022-rate-limiting-posture.md)
+  — 1.0 ships without per-IP / per-token buckets; the loopback bind, 1 MiB body cap, and `ApprovalManager` serialisation cover the threat model until the trust boundary extends beyond localhost.

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -1568,3 +1568,38 @@ if ! grep -r -l -E "@pytest\\.mark\\.perf_budget\\b" tests/ >/dev/null 2>&1; the
 fi
 
 echo "verify-standards: ${design_file} documents a performance budget and at least one test carries the perf_budget marker."
+
+# Rate-limiting / DoS posture per
+# .claude/instructions/service-design.md ("Rate limiting / DoS posture")
+# and the deterministic regression check from issue #30:
+#
+#   - design/decisions/ contains an ADR addressing rate limiting / DoS.
+#     The gate matches on ADR titles or body copy that carry the
+#     "rate limit" keyword so a rename of the current ADR filename
+#     still satisfies the check as long as the rationale keeps
+#     living in an ADR.
+
+rate_limit_adr_found=0
+# Match the ADR title (first ``# ADR`` line), not body-copy mentions —
+# ASVS and other cross-cutting ADRs list "rate limiting" in their
+# follow-ups without actually carrying the posture decision. Requiring
+# the keyword in the title keeps the gate pointed at the dedicated ADR.
+for adr in design/decisions/*.md; do
+  [[ -f "${adr}" ]] || continue
+  base="$(basename "${adr}")"
+  [[ "${base}" == "README.md" || "${base}" == "TEMPLATE.md" ]] && continue
+  if grep -m1 "^# ADR" "${adr}" \
+    | grep -qiE "rate[[:space:]]?limit|DoS posture|denial[- ]of[- ]service"; then
+    rate_limit_adr_found=1
+    rate_limit_adr="${adr}"
+    break
+  fi
+done
+
+if [[ ${rate_limit_adr_found} -eq 0 ]]; then
+  echo "verify-standards: no ADR under design/decisions/ addresses rate limiting / DoS posture." >&2
+  echo "  Add an ADR with the decision (implement with thresholds, or defer with rationale)." >&2
+  exit 1
+fi
+
+echo "verify-standards: rate-limiting / DoS posture is recorded in ${rate_limit_adr}."


### PR DESCRIPTION
## Summary

- Adds `design/decisions/0022-rate-limiting-posture.md` — defers application-layer rate limiting for 1.0. The loopback-only bind, 1 MiB body cap, 128-byte id-segment cap on the bridge, and `ApprovalManager`'s implicit per-family serialisation cover the threat model until the trust boundary moves off-host.
- Adds a "Rate limiting and request budgets" section to `design/DESIGN.md` with expected steady and ceiling request rates per endpoint.
- `scripts/verify-standards.sh` grows a regression gate that asserts some ADR in `design/decisions/` carries the rate-limit / DoS keyword **in its title** (not body copy — ASVS and other cross-cutting ADRs mention rate limiting in follow-ups without being the decision).

Closes #30.

## Follow-up triggers (recorded in the ADR)

- Trust boundary extends beyond `127.0.0.1` (devcontainer port-forward, remote operator tooling).
- Notification plugin migrates to the out-of-process HTTP model (#6) — per-family concurrency currently rests on the blocking plugin contract.

## Test plan

- [x] `bash scripts/verify-standards.sh` passes; the new gate points at ADR 0022.
- [x] `task check` clean after treefmt pass on the new docs.
- [x] `shellcheck` + `shfmt` clean on the modified script.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)