### PR TITLE
ci: macOS runner for real AppleScript client CLI tests (#69)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,39 @@ jobs:
       - name: Run things-client-applescript integration tests
         run: task test -- --integration things-client-applescript
 
+  # macOS-only job that exercises the real osascript path shipped in
+  # things-client-cli-applescript. The rest of the suite runs against a
+  # FakeRunner on Linux; this job guards against the failure modes that
+  # only show up when the emitted AppleScript is actually compiled —
+  # invalid helper syntax, osascript error-message wording that breaks
+  # our stderr parsing, subprocess-level timeout handling. A real
+  # Things 3 instance + Automation permissions are not available on
+  # GitHub's hosted macOS runners, so the few ``@_requires_things3``
+  # e2e tests auto-skip here; driving the full bridge + AppleScript CLI
+  # against a live Things database is tracked as a follow-up.
+  #
+  # Minimal toolchain: this job deliberately does NOT reuse
+  # .github/actions/setup-toolchain (which hard-codes Linux asset URLs
+  # for every release binary). The Darwin-gated suite only needs uv +
+  # the project venv + osascript (pre-installed on GitHub's macOS
+  # runner), so we bootstrap that directly.
+  macos-applescript:
+    runs-on: macos-14
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Sync venv
+        run: uv sync --extra dev
+
+      - name: Run Darwin-gated AppleScript client tests
+        run: uv run pytest tests/test_things_client_applescript_things.py --no-cov -v
+
   tests:
     runs-on: ubuntu-latest
     needs:
@@ -101,6 +134,7 @@ jobs:
       - integration-things-bridge
       - integration-things-cli
       - integration-things-client-applescript
+      - macos-applescript
     if: always()
     steps:
       - name: Aggregate test results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **macOS runner in the `Test` workflow** to exercise the real
+  osascript path shipped in `things-client-cli-applescript`. The new
+  `macos-applescript` job runs on `macos-14` (Apple Silicon) and
+  drives `tests/test_things_client_applescript_things.py` against
+  GitHub's pre-installed osascript so helper-AppleScript syntax
+  errors, osascript stderr-wording changes, and subprocess-timeout
+  handling get caught at merge time rather than on a contributor's
+  laptop during review. A real Things 3 instance + Automation
+  permissions aren't available on hosted macOS runners, so the
+  `@_requires_things3` end-to-end tests auto-skip — extending
+  coverage to a live Things database is tracked as follow-up. The
+  job deliberately does not reuse
+  `.github/actions/setup-toolchain` (Linux-asset URLs only) and
+  instead bootstraps uv + the project venv directly. The
+  aggregating `tests` job now fails on skip or failure of
+  `macos-applescript` so a silently-skipped macOS job can't sneak
+  through. Closes
+  [#69](https://github.com/aidanns/agent-auth/issues/69).
+
 ### Changed
 
 - **Release Please now authenticates via a dedicated GitHub App


### PR DESCRIPTION
## Summary

- Add a new `macos-applescript` job to `.github/workflows/test.yml` running on `macos-14`. Drives `tests/test_things_client_applescript_things.py` against GitHub's pre-installed osascript so helper-AppleScript syntax errors, osascript stderr wording changes, and subprocess-timeout handling get caught at merge time rather than on whoever's laptop reviews the PR.
- The job deliberately doesn't reuse `.github/actions/setup-toolchain` (Linux-only asset URLs) and instead bootstraps `uv` directly via `astral-sh/setup-uv@v7`. 15-minute timeout caps runtime.
- The aggregating `tests` job now lists `macos-applescript` in `needs:`, so a silent skip or failure is caught.

## Decisions (issue open questions)

- **Every PR, no path filter.** The job is narrow enough (one test file, mostly compile-time / subprocess-shape checks) that the runtime cost is small. A `paths:` filter would force the aggregating `tests` job to tolerate `skipped` — currently it deliberately fails on skip, which keeps the required-status-check story simple.
- **No live Things 3 database.** Hosted macOS runners don't have Things 3 or Automation permissions, so the handful of `@_requires_things3` tests skip automatically. The remaining Darwin-only tests (`osacompile` of the helper prelude, real osascript failure-mode diagnostics) still run — extending coverage to a live Things database is tracked as follow-up.

## Test plan

- [x] Workflow YAML is valid (`task check` passes).
- [ ] The new job runs green against `macos-14` in the PR's CI pipeline.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)