### PR TITLE
test: restore authz-unavailable integration test for things-bridge (#90)

### DIFF
--- a/tests/integration/things_bridge/conftest.py
+++ b/tests/integration/things_bridge/conftest.py
@@ -21,6 +21,7 @@ shared compose file used by every per-service fixture in this tree).
 from __future__ import annotations
 
 import os
+import subprocess
 import uuid
 from collections.abc import Callable, Generator
 from dataclasses import dataclass
@@ -80,6 +81,24 @@ class ThingsBridgeStack:
         path = self.fixtures_dir / "things.yaml"
         path.write_text(yaml.safe_dump(fixture))
         os.chmod(path, 0o644)
+
+    def stop_agent_auth(self) -> None:
+        """Stop the sibling ``agent-auth`` container without tearing down the bridge.
+
+        Used to exercise the ``authz_unavailable`` path end-to-end: the
+        bridge stays up and keeps serving requests, but its in-network
+        upstream is gone so ``AgentAuthClient.validate`` surfaces a real
+        connection error from the container runtime rather than a mock.
+        The shared fixture teardown then runs ``compose down`` against
+        the whole project, which is a no-op for already-stopped
+        containers.
+        """
+        subprocess.run(
+            ["docker", "compose", "-f", self.compose_file, "stop", "agent-auth"],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
 
 
 def _write_agent_auth_config(

--- a/tests/integration/things_bridge/test_bridge.py
+++ b/tests/integration/things_bridge/test_bridge.py
@@ -216,6 +216,18 @@ def test_expired_access_token_returns_401_token_expired(
 
 
 @pytest.mark.covers_function("Delegate Token Validation")
+def test_list_todos_authz_unavailable_returns_502(stack):
+    # Stop the in-network agent-auth service mid-test so the bridge's
+    # ``authz.validate`` call surfaces a real connection error, not a
+    # mocked one. The 502 ``authz_unavailable`` discriminator is what
+    # clients rely on to distinguish upstream outage from bad tokens.
+    stack["stack"].stop_agent_auth()
+    status, data = _get(stack["stack"].url("todos"), stack["token"])
+    assert status == 502
+    assert data == {"error": "authz_unavailable"}
+
+
+@pytest.mark.covers_function("Delegate Token Validation")
 def test_health_endpoint_requires_token(things_bridge_stack):
     # Regression guard: dropping the bearer check would let any caller
     # probe service-internal state without authorization.


### PR DESCRIPTION
## Summary

- Restores the end-to-end "agent-auth gone, bridge surfaces 502 authz_unavailable" coverage dropped by #89 during the Docker migration. The error-mapping path was only pinned at the unit layer; real HTTP coverage is back.
- Adds `ThingsBridgeStack.stop_agent_auth()` which runs `docker compose -f <rendered> stop agent-auth` against the per-test Compose project so the bridge container keeps serving requests while its in-network upstream is gone — surfaces a real connection error, not a mocked one.
- New `test_list_todos_authz_unavailable_returns_502` in `tests/integration/things_bridge/test_bridge.py` drives a real bridge request with a real bearer token after the upstream is killed, asserting `502 {"error": "authz_unavailable"}`.

Closes #90.

## Test plan

- [x] `task check` (lint / format / integration-isolation) passes
- [x] `task typecheck` (mypy + pyright) passes
- [x] `uv run pytest tests/ --ignore=tests/integration` (unit suite, 408 passed) passes
- [x] `task verify-design`, `task verify-function-tests`, `task verify-standards`, `task reuse-lint` pass
- [ ] `task test -- --integration things-bridge` (exercised in CI — Docker unavailable locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)