### PR TITLE
fix(server): drain oversize request bodies before rejecting (#144)

### DIFF
--- a/src/agent_auth/server.py
+++ b/src/agent_auth/server.py
@@ -58,6 +58,19 @@ class AgentAuthHandler(BaseHTTPRequestHandler):
         if length == 0:
             return {}
         if length > self.MAX_BODY_SIZE:
+            # Drain the announced body before sending 400. Closing the
+            # socket mid-upload surfaces a BrokenPipeError on the
+            # client's sendall() instead of a clean status response —
+            # the observed flake in #144. Read in fixed chunks rather
+            # than buffering the whole body so an oversize
+            # Content-Length header can't still exhaust memory; the
+            # bytes are discarded.
+            remaining = length
+            while remaining > 0:
+                chunk = self.rfile.read(min(remaining, 65536))
+                if not chunk:
+                    break
+                remaining -= len(chunk)
             return None
         body = self.rfile.read(length)
         try:


### PR DESCRIPTION
## Summary

- Root cause of the `test_oversize_body_returns_400` flake: `AgentAuthHandler._read_json` returned 400 on oversize `Content-Length` **without** reading the announced body. Under CI load the server closed the socket while the client was mid-`sendall` on the 1 MiB+ payload, and `urllib.request` surfaced `BrokenPipeError` instead of a clean 400 (observed in GitHub Actions run 24667015232 on PR #139).
- Fix: drain the announced body in 64 KiB chunks (bytes discarded, not buffered) before sending the 400 rejection so the client finishes its upload and reads the `malformed_request` response cleanly. Pathological `Content-Length` values can't exhaust server memory because chunks are never retained; the server is only reachable over loopback so read-to-completion doesn't open a new DoS vector.

Closes #144.

## Test plan

- [x] `tests/test_server.py::test_oversize_body_returns_400` runs cleanly 30x in a row locally (previously intermittent — observed passing on retries, failing BrokenPipeError on other runs)
- [x] Full unit suite (`uv run pytest tests/ --ignore=tests/integration`) passes — 408 passed, 3 skipped
- [x] `task check`, `task typecheck`, `task verify-standards` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)