### PR TITLE
feat(audit): attach OTel service.name/service.version to every audit entry (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Audit log entries now carry OTel resource attributes
+  (`service.name`, `service.version`) on every line.** Consolidates
+  the audit envelope across the system: SIEM consumers joining
+  archived or multi-service trails can filter by emitter from the
+  entry itself instead of inferring from the file path. The fields
+  are constant today (`service.name = "agent-auth"`) because
+  things-bridge is intentionally audit-free — every bridge
+  authorization trace comes via agent-auth's `/validate` — but the
+  envelope now matches what a second emitter would need, future-
+  proofing multi-service consumers. Contract tests
+  (`tests/test_audit_schema.py`) assert the resource attributes on
+  every documented event kind so a rename fails CI. `schema_version`
+  stays at `1` (new optional field per the stability policy).
+  `design/DESIGN.md` §Audit log fields reframes the HTTP-attribute
+  table as *reserved for future events*, aligning docs with what the
+  code actually emits. Rationale in
+  [ADR 0024](design/decisions/0024-audit-log-shared-envelope.md).
+  Closes
+  [#100](https://github.com/aidanns/agent-auth/issues/100).
+
 - **`GET /things-bridge/health` now fails closed when the configured
   Things-client binary is missing.** The handler previously returned
   `200 {"status":"ok"}` unconditionally once the probe token

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -869,7 +869,12 @@ them would break downstream expectations:
 
 things-bridge emits no dedicated audit log — every request it
 handles traces back to agent-auth's audit trail via the delegated
-validation call, so audit coverage is single-sourced there.
+validation call, so audit coverage is single-sourced there. The
+audit envelope (OTel `service.name` / `service.version` resource
+attributes alongside `schema_version` / `timestamp` / `event`) is
+nonetheless shaped to work across services so any future emitter
+ships with the same wire format; today that envelope carries a
+constant `service.name = "agent-auth"`.
 
 ### Log levels
 
@@ -988,13 +993,25 @@ Contract tests in `tests/test_audit_schema.py` pin every documented
 event kind and fail if a field is renamed, removed, or re-typed
 without a version bump.
 
-Fields fall into two groups:
+Fields fall into three groups:
 
-**HTTP request attributes (OTel HTTP semconv keys)** — populated on
-events that originated from an HTTP request. Names and types follow
-the semconv HTTP conventions:
+**Resource attributes (OTel resource semconv keys)** — identify the
+emitter itself, not the request. Included on every entry so audit
+trails can be joined across services or retained through a file move:
 
-| Field                       | Type   | Source                                                                                                     |
+| Field             | Type   | Value                                                                                                                                                             |
+| ----------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `service.name`    | string | `agent-auth`. Constant today — things-bridge has no dedicated audit log (see §Log streams). The field is retained in the envelope for future audit emitters.      |
+| `service.version` | string | PEP 440 release version, read from `agent_auth.__version__` (i.e. `importlib.metadata.version("agent-auth")`). `0.0.0+unknown` when the package is not installed. |
+
+**HTTP request attributes (OTel HTTP semconv keys)** — *reserved for
+future events that originate from an HTTP request.* Not emitted today;
+authorization decisions currently carry only domain fields plus the
+resource envelope. Names and types below are the reservation; when
+events begin populating them, they will follow the semconv HTTP
+conventions verbatim:
+
+| Field                       | Type   | Source (when emitted)                                                                                      |
 | --------------------------- | ------ | ---------------------------------------------------------------------------------------------------------- |
 | `http.request.method`       | string | e.g. `POST`                                                                                                |
 | `http.route`                | string | templated path, e.g. `/agent-auth/token/modify` (metrics-safe, low cardinality)                            |
@@ -1006,15 +1023,6 @@ the semconv HTTP conventions:
 | `network.protocol.version`  | string | e.g. `1.1` or `2`; lets audits distinguish HTTP/1.1 from HTTP/2 sessions                                   |
 | `server.address`            | string | local bind address                                                                                         |
 | `server.port`               | int    | local bind port                                                                                            |
-
-**Resource attributes (OTel resource semconv keys)** — identify the
-emitter itself, not the request. Included on every line so audit
-trails can be joined across services:
-
-| Field             | Type   | Source                          |
-| ----------------- | ------ | ------------------------------- |
-| `service.name`    | string | `agent-auth` or `things-bridge` |
-| `service.version` | string | PEP 440 release version         |
 
 **Domain fields (project-namespaced)** — describe authorization
 state, not HTTP mechanics. No OTel equivalent exists; these keep

--- a/design/decisions/0024-audit-log-shared-envelope.md
+++ b/design/decisions/0024-audit-log-shared-envelope.md
@@ -1,0 +1,153 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# ADR 0024 — Single-source audit trail at agent-auth with a cross-service resource envelope
+
+## Status
+
+Accepted — 2026-04-22.
+
+## Context
+
+Issue [#100](https://github.com/aidanns/agent-auth/issues/100) asks for
+a consolidated, structured audit-log schema across every service so a
+SIEM can ingest the whole system with a single parser.
+
+The current state on main:
+
+- `agent_auth.audit.AuditLogger` already writes JSON-lines with a
+  pinned `schema_version`, a discriminator `event`, and an ISO 8601
+  `timestamp` (`src/agent_auth/audit.py`).
+- `tests/test_audit_schema.py` contract-tests every documented event
+  kind; `scripts/verify-standards.sh` gates presence of that test file.
+- things-bridge emits **no audit log at all**. ADR 0017 and
+  `design/DESIGN.md` §Log streams commit to routing every bridge
+  request's authorization trace through agent-auth's `POST /validate`,
+  which agent-auth audits.
+
+Two gaps remain against #100's acceptance:
+
+1. **No emitter identity on entries.** `design/DESIGN.md` claims
+   `service.name` / `service.version` are included on every line, but
+   the code never emits them. A consumer joining multiple audit
+   sources (current log + a retained archive from a renamed file)
+   has to infer the emitter from path conventions.
+2. **Drifted HTTP-attribute documentation.** The same DESIGN.md
+   section lists OTel HTTP request attributes
+   (`http.request.method`, `http.route`, `url.path`, …) as "populated
+   on events that originated from an HTTP request", but the code never
+   attaches them to any entry today.
+
+## Considered alternatives
+
+### Add a parallel audit log to things-bridge
+
+Stand up a second `AuditLogger` inside things-bridge (its own
+`audit.log` path, its own events) and emit the same schema.
+
+**Rejected** because:
+
+- Every authorization decision a bridge request triggers is already
+  captured by agent-auth as a `validation_allowed` /
+  `validation_denied` entry. A bridge-side emit would be a strict
+  duplicate with a small time skew.
+- Two audit writers means two schema-emit contracts, two retention
+  paths, and two sources that must be kept in sync when the schema
+  evolves. That's exactly the thing SIEMs find hard to ingest — which
+  is the problem #100 set out to fix.
+- There is no bridge-only event today that isn't expressible through
+  `things-bridge:*` scope checks on agent-auth.
+
+### Drop the HTTP-attribute table from DESIGN.md entirely
+
+Remove the HTTP-attribute table on the grounds that it documents
+fields the code doesn't emit.
+
+**Rejected** because:
+
+- ADR 0017 (OTel semconv adoption) explicitly names those attribute
+  keys as the canonical naming source for when they are emitted.
+  Dropping the table deletes the naming contract and invites future
+  contributors to reinvent names inconsistently.
+- A "reserved / not emitted today" label costs little and keeps
+  future work anchored to semconv.
+
+### Emit HTTP attributes now as part of this ADR
+
+Thread an HTTP request context through every `audit.log_*` call site
+so authorization-decision entries carry the full semconv HTTP
+attribute set.
+
+**Rejected** because:
+
+- `AuditLogger` currently has no request context; every call site
+  would need to pass one, and CLI-triggered token operations
+  (`agent-auth token revoke`) have no HTTP context at all, so the
+  code would need to carry a nullable context type everywhere.
+- That's a larger surface-area change than #100 targets — and it
+  touches the audit emit sites mutation-tested under the security
+  ratchet (ADR 0021), expanding review blast radius.
+- The naming contract is already pinned (see previous alternative),
+  so a later issue can add emission without renegotiating keys.
+
+## Decision
+
+1. **Keep the audit trail single-sourced at agent-auth.**
+   things-bridge continues to emit no audit log. Document the
+   rationale in `design/DESIGN.md` §Log streams.
+2. **Extend `AuditLogger` to emit OTel resource attributes on every
+   entry.** Add `service.name = "agent-auth"` (constant today) and
+   `service.version = agent_auth.__version__` to the fixed envelope
+   in `AuditLogger.log()`. This is a non-breaking schema addition
+   per the stability policy ("adding a new optional field is
+   non-breaking; version stays the same"), so `SCHEMA_VERSION` stays
+   at `1`.
+3. **Pin the resource fields as part of the contract.** Every test
+   in `tests/test_audit_schema.py` already asserts base fields via
+   `_assert_base_fields`; extend that helper to assert `service.name`
+   is `"agent-auth"` and `service.version` is a non-empty string on
+   every entry. Add a dedicated regression test that writes two
+   different kinds of event and asserts the resource envelope is
+   present on both.
+4. **Mark HTTP attributes as reserved.** Relabel the DESIGN.md HTTP
+   attribute table as *"Reserved for future events that originate
+   from an HTTP request. Not emitted today."* A future issue may
+   promote individual fields to emitted status, case by case, without
+   needing to rename them.
+
+## Consequences
+
+**Positive**:
+
+- SIEM filter expressions can rely on `service.name` being present
+  with exactly that dotted key on every line — no need to special-case
+  the emitter or infer it from the file path.
+- The envelope is future-proof: a second audit emitter in the
+  project would slot in under the same contract with zero schema
+  churn.
+- DESIGN.md now matches the code — no more drift between a documented
+  attribute table and its emission status.
+
+**Negative / accepted trade-offs**:
+
+- `service.name` is redundant today (only one emitter). That's the
+  cost of reserving the envelope shape before it's strictly needed.
+- The `service.version` value depends on package metadata. In a
+  source-checkout execution (rare outside tests), it falls back to
+  `0.0.0+unknown` — acceptable because such runs are not operator-
+  facing.
+
+## Follow-ups
+
+- **HTTP-attribute emission** — no issue filed yet; track under a
+  new issue only if SIEM requirements demand the per-request HTTP
+  context on authorization-decision entries. Naming is pre-pinned
+  via ADR 0017 and the DESIGN.md reservation, so emission can land
+  without a renaming negotiation.
+- Dead `log_path` field in `things_bridge/config.py` (never read by
+  the bridge) predates the single-source audit decision; cleanup is
+  out of scope here but worth a follow-up if the config surface is
+  refactored.

--- a/design/decisions/README.md
+++ b/design/decisions/README.md
@@ -67,3 +67,5 @@ is linked from this index.
   — 1.0 ships without per-IP / per-token buckets; the loopback bind, 1 MiB body cap, and `ApprovalManager` serialisation cover the threat model until the trust boundary extends beyond localhost.
 - [ADR 0023 — Deepen `/things-bridge/health` to verify the Things-client binary is resolvable](0023-things-bridge-health-depth.md)
   — /health now returns 503 `{"status":"unhealthy"}` when `things_client_command[0]` fails PATH resolution; cached for 30s to keep the probe cheap. agent-auth reachability is covered implicitly by the probe-authorization call.
+- [ADR 0024 — Single-source audit trail at agent-auth with a cross-service resource envelope](0024-audit-log-shared-envelope.md)
+  — keep things-bridge audit-free (authz traces come via agent-auth); add OTel `service.name` / `service.version` to every audit entry so a future second emitter drops in with no schema churn; mark HTTP-attribute fields as reserved until emission lands.

--- a/src/agent_auth/audit.py
+++ b/src/agent_auth/audit.py
@@ -10,6 +10,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from agent_auth import __version__ as _agent_auth_version
+
 # Audit log schema version. Emitted on every entry so downstream consumers
 # (SIEM, compliance, forensics) can detect the schema at parse time.
 #
@@ -20,14 +22,26 @@ from typing import Any
 #     change; bump SCHEMA_VERSION and announce in CHANGELOG.md.
 SCHEMA_VERSION = 1
 
+# OTel resource attributes attached to every emitted entry. Allow audit
+# consumers joining trails across services (SIEM, forensics) to filter
+# by emitter without inferring it from the file path. things-bridge does
+# not emit its own audit log (see design/DESIGN.md §Log streams — all
+# bridge authorization traces come through agent-auth's validate
+# endpoint), so ``service.name`` is a constant here. The field exists
+# in the envelope so any future audit emitter in this project ships with
+# a consistent shape from day one.
+_SERVICE_NAME = "agent-auth"
+
 
 class AuditLogger:
     """Writes JSON-lines audit log entries to a file.
 
     The on-disk format is part of the project's public surface: one JSON
     object per line with at minimum ``timestamp`` (ISO 8601 UTC),
-    ``schema_version`` (int), and ``event`` keys, plus any event-specific
-    fields. See ``tests/test_audit_schema.py`` for the contract.
+    ``schema_version`` (int), ``service.name`` (string),
+    ``service.version`` (string), and ``event`` (string) keys, plus any
+    event-specific fields. See ``tests/test_audit_schema.py`` for the
+    contract.
     """
 
     def __init__(self, log_path: str):
@@ -40,6 +54,8 @@ class AuditLogger:
         entry = {
             "timestamp": datetime.now(UTC).isoformat(),
             "schema_version": SCHEMA_VERSION,
+            "service.name": _SERVICE_NAME,
+            "service.version": _agent_auth_version,
             "event": event,
             **details,
         }

--- a/tests/test_audit_schema.py
+++ b/tests/test_audit_schema.py
@@ -52,6 +52,23 @@ def test_schema_version_value(tmp_path):
     assert entry["schema_version"] == SCHEMA_VERSION
 
 
+def test_service_resource_attributes_on_every_entry(tmp_path):
+    # Pin the OTel resource envelope: downstream audit consumers rely
+    # on ``service.name`` / ``service.version`` being present with
+    # exactly those keys (dotted semconv names, not ``service_name``
+    # etc.) on every entry regardless of event kind. A rename breaks
+    # SIEM filter expressions.
+    logger = AuditLogger(_log_path(tmp_path))
+    logger.log_token_operation("token_created", family_id="fam-1")
+    logger.log_authorization_decision("validation_allowed", scope="x", tier="allow")
+    with open(_log_path(tmp_path)) as f:
+        lines = [json.loads(line) for line in f if line.strip()]
+    assert len(lines) == 2
+    for entry in lines:
+        assert entry["service.name"] == "agent-auth"
+        assert isinstance(entry["service.version"], str) and entry["service.version"]
+
+
 def _assert_base_fields(entry: dict[str, Any]) -> None:
     assert "timestamp" in entry
     assert "event" in entry
@@ -63,6 +80,15 @@ def _assert_base_fields(entry: dict[str, Any]) -> None:
     assert ts.endswith("+00:00") or ts.endswith("Z"), f"timestamp not UTC: {ts!r}"
     # Must parse as a datetime
     datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    # OTel resource attributes: every entry identifies its emitter so
+    # SIEMs joining multi-service audit trails don't need to infer
+    # service from the log path. ``service.name`` is constant today
+    # (agent-auth is the only emitter by design — see DESIGN.md §Log
+    # streams), but the schema reserves the field so a future emitter
+    # ships with a consistent envelope.
+    assert entry["service.name"] == "agent-auth"
+    assert isinstance(entry["service.version"], str)
+    assert entry["service.version"]  # non-empty
 
 
 # -- token operation events --


### PR DESCRIPTION
## Summary

- `AuditLogger.log` now emits `service.name` (constant `"agent-auth"`) and `service.version` (from `agent_auth.__version__`) on every entry. `schema_version` stays at `1` (new optional field per the stability policy).
- `tests/test_audit_schema.py` asserts both resource fields on every documented event kind plus a dedicated regression covering two event kinds in one file.
- `design/DESIGN.md` §Audit log fields reframes the HTTP-attribute table as *reserved for future events* (it was documented as emitted but the code never attached those attributes); §Log streams now notes the envelope is cross-service even with a single emitter today.
- ADR 0024 records the decision to keep the audit trail single-sourced at agent-auth rather than adding a parallel log to things-bridge.

Closes #100.

## Test plan

- [x] `pytest tests/test_audit_schema.py` — 16 passed (new service-resource assertion exercised on every event).
- [x] Full unit suite (`pytest tests/ --ignore=tests/integration --no-cov`) — 414 passed, 3 skipped.
- [x] `task check` + `task typecheck` + `task verify-standards` — all pass.
- [ ] Full Docker integration suite — runs in CI; not available locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)