### PR TITLE
feat(keys): detect keyring wipe against a non-empty token store (#31)

### DIFF
--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -1076,6 +1076,84 @@ during production use is a signal to investigate — a looping
 agent, a runaway polling loop, or a legitimate workflow change —
 not a condition to refuse.
 
+## Key loss and recovery
+
+The signing and encryption keys are stored only in the system
+keyring. If that keyring is wiped or inaccessible (fresh OS
+install, keychain reset, new host, corrupted macOS Keychain entry)
+while the token store on disk persists, silently regenerating a
+new key pair would strand every live token and render encrypted
+columns unreadable — and the operator would have no signal that
+anything had changed until the next call failed.
+
+### Detection
+
+`agent_auth.keys.check_key_integrity(db_path, key_manager)` runs
+before any `get_or_create_*` call in `agent-auth`'s CLI
+entrypoint (`_init_services`). It opens the token-store DB
+read-only (no encryption key required — `token_families` is not
+a field-encrypted column) and raises `KeyLossError` when:
+
+- the DB file exists, and
+- the `token_families` table has at least one row, and
+- either the signing or the encryption key is absent from the
+  keyring.
+
+The DB-absent and DB-empty paths are the legitimate first-install
+and clean-start cases; the check stays silent and startup
+proceeds to `get_or_create_*`.
+
+### Operator-facing error
+
+`KeyLossError`'s message names the missing key(s), the DB path,
+and the two recovery options:
+
+- **Restore the keyring entry.** If the operator has a backup of
+  the `agent-auth` service entry (for example, via macOS Time
+  Machine restore of `~/Library/Keychains`), reinstalling it
+  brings the existing tokens back to life. No tooling is shipped
+  for this — it is operator-driven.
+- **Delete the token store.** Remove `tokens.db` and its
+  `-wal` / `-shm` siblings under `$XDG_DATA_HOME/agent-auth/`.
+  The next launch generates a fresh key pair and a fresh DB,
+  which invalidates every previously issued access and refresh
+  token. Clients must be reissued from scratch.
+
+The CLI catches `KeyLossError` at `main()` and prints the message
+verbatim to stderr with exit status 2 — Python tracebacks would
+bury the recovery instructions.
+
+### No backup tool in 1.0
+
+agent-auth deliberately does **not** ship a backup or export tool
+for the keys. Any first-party backup path would:
+
+- introduce a secondary store for 32-byte secrets, widening the
+  attack surface; and
+- need its own tamper-evidence, key-wrapping, and restore-
+  verification story that the QM/SIL declaration in
+  `design/ASSURANCE.md` does not cover.
+
+For a personal-use deployment the system keyring's own backup
+story (macOS Time Machine of `~/Library/Keychains`; `seahorse`
+export on Linux) is the intended path. This is revisitable if a
+future multi-user or remote-operator posture makes a first-party
+backup tool necessary.
+
+### Known gaps
+
+- Byte-for-byte corruption of the keyring entry (not absence) is
+  not detected: `check_key_integrity` verifies presence, not
+  validity. A corrupted entry surfaces later as a signature-
+  verification failure (`TokenInvalidError`) or an `AESGCM`
+  decryption `InvalidTag` error on the first authenticated
+  request. The operator-visible symptom is the same — every
+  live token suddenly looks invalid — and so is the mitigation
+  path (restore or wipe).
+- The check runs exactly once at startup. Key rotation while the
+  server is running is out of scope (`agent-auth` does not
+  implement key rotation in 1.0).
+
 ## Security Considerations
 
 - The signing key is stored in the system keyring (macOS Keychain or libsecret/gnome-keyring), never as a plaintext file. Only agent-auth reads it.

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -1705,3 +1705,21 @@ if [[ ${rate_limit_adr_found} -eq 0 ]]; then
 fi
 
 echo "verify-standards: rate-limiting / DoS posture is recorded in ${rate_limit_adr}."
+
+# Key-loss / recovery design per
+# .claude/instructions/service-design.md ("Key recovery and loss
+# scenarios") and the deterministic regression check from issue #31:
+#
+#   - design/DESIGN.md contains a documented "Key loss and recovery"
+#     section. A missing section would silently leave the project
+#     without a documented behaviour for the keyring-wiped-but-DB-
+#     persists scenario.
+
+if ! grep -qE "^## +Key loss and recovery\b" design/DESIGN.md; then
+  echo "verify-standards: design/DESIGN.md is missing a '## Key loss and recovery' section." >&2
+  echo "  Document detection, user warning, and recovery behaviour per" >&2
+  echo "  .claude/instructions/service-design.md § Key recovery and loss scenarios." >&2
+  exit 1
+fi
+
+echo "verify-standards: design/DESIGN.md documents key-loss detection and recovery."

--- a/src/agent_auth/cli.py
+++ b/src/agent_auth/cli.py
@@ -10,8 +10,8 @@ import sys
 
 from agent_auth.audit import AuditLogger
 from agent_auth.config import Config, load_config
-from agent_auth.errors import KeyringError
-from agent_auth.keys import KeyManager, SigningKey
+from agent_auth.errors import KeyLossError, KeyringError
+from agent_auth.keys import KeyManager, SigningKey, check_key_integrity
 from agent_auth.scopes import parse_scope_arg
 from agent_auth.store import TokenStore
 from agent_auth.tokens import create_token_pair, generate_token_id
@@ -22,6 +22,11 @@ def _init_services(
 ) -> tuple[Config, SigningKey, TokenStore, AuditLogger, KeyManager]:
     config = load_config(config_dir)
     key_manager = KeyManager()
+    # Refuse to regenerate keys when an existing DB would be orphaned
+    # by a fresh key pair (see design/DESIGN.md "Key loss and recovery").
+    # The check runs before ``get_or_create_*`` so that first-time
+    # installs — DB absent, keyring absent — proceed normally.
+    check_key_integrity(config.db_path, key_manager)
     signing_key = key_manager.get_or_create_signing_key()
     encryption_key = key_manager.get_or_create_encryption_key()
     store = TokenStore(config.db_path, encryption_key)
@@ -337,7 +342,13 @@ def main() -> None:
         parser.print_help()
         sys.exit(1)
 
-    config, signing_key, store, audit, key_manager = _init_services(args.config_dir)
+    try:
+        config, signing_key, store, audit, key_manager = _init_services(args.config_dir)
+    except KeyLossError as exc:
+        # Surface the operator-facing message without a Python traceback —
+        # the recovery instructions are in the message itself.
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(2)
 
     if args.command == "serve":
         handle_serve(args, config, signing_key, store, audit, key_manager)

--- a/src/agent_auth/errors.py
+++ b/src/agent_auth/errors.py
@@ -39,3 +39,17 @@ class ApprovalDeniedError(AgentAuthError):
 
 class KeyringError(AgentAuthError):
     """Failed to access the system keyring."""
+
+
+class KeyLossError(AgentAuthError):
+    """Token store exists but the signing / encryption key is missing.
+
+    Raised at startup when ``$XDG_DATA_HOME/agent-auth/tokens.db`` contains
+    any token families but the system keyring no longer holds the matching
+    signing or encryption key (keychain wipe, new host, fresh OS install).
+    The server refuses to auto-regenerate: a fresh key would silently
+    invalidate every live token and render encrypted columns unreadable,
+    while the DB would claim the old state. The operator must delete the
+    DB to accept the reset, or restore the keyring to resume with live
+    tokens. See ``design/DESIGN.md`` "Key loss and recovery".
+    """

--- a/src/agent_auth/keys.py
+++ b/src/agent_auth/keys.py
@@ -6,11 +6,13 @@
 
 import base64
 import os
+import sqlite3
+from pathlib import Path
 from typing import NewType
 
 import keyring
 
-from agent_auth.errors import KeyringError
+from agent_auth.errors import KeyLossError, KeyringError
 
 SERVICE_NAME = "agent-auth"
 # These are the "username" parameter of the system keyring API, but semantically
@@ -34,23 +36,45 @@ class KeyManager:
     def __init__(self, service_name: str = SERVICE_NAME):
         self._service = service_name
 
-    def _get_or_create_key(self, key_name: str) -> bytes:
+    def _read_key(self, key_name: str) -> bytes | None:
+        """Return the key bytes if present in the keyring, else ``None``.
+
+        Split from ``_get_or_create_key`` so startup can detect key loss
+        (keyring empty while the token store holds state) without
+        silently regenerating.
+        """
         try:
             stored = keyring.get_password(self._service, key_name)
         except Exception as e:
             raise KeyringError(f"Failed to read key '{key_name}' from keyring: {e}") from e
+        if stored is None:
+            return None
+        return base64.b64decode(stored)
 
-        if stored is not None:
-            return base64.b64decode(stored)
-
-        key = os.urandom(KEY_SIZE_BYTES)
+    def _write_key(self, key_name: str, key: bytes) -> None:
         encoded = base64.b64encode(key).decode("ascii")
         try:
             keyring.set_password(self._service, key_name, encoded)
         except Exception as e:
             raise KeyringError(f"Failed to store key '{key_name}' in keyring: {e}") from e
 
+    def _get_or_create_key(self, key_name: str) -> bytes:
+        existing = self._read_key(key_name)
+        if existing is not None:
+            return existing
+        key = os.urandom(KEY_SIZE_BYTES)
+        self._write_key(key_name, key)
         return key
+
+    def get_signing_key(self) -> SigningKey | None:
+        """Return the HMAC signing key, or ``None`` if not yet provisioned."""
+        raw = self._read_key(SIGNING_KEY_NAME)
+        return None if raw is None else SigningKey(raw)
+
+    def get_encryption_key(self) -> EncryptionKey | None:
+        """Return the AES-256-GCM encryption key, or ``None`` if not yet provisioned."""
+        raw = self._read_key(ENCRYPTION_KEY_NAME)
+        return None if raw is None else EncryptionKey(raw)
 
     def get_or_create_signing_key(self) -> SigningKey:
         """Return the HMAC signing key, generating it on first use."""
@@ -73,3 +97,63 @@ class KeyManager:
             keyring.set_password(self._service, MANAGEMENT_REFRESH_TOKEN_NAME, token)
         except Exception as e:
             raise KeyringError(f"Failed to store management refresh token in keyring: {e}") from e
+
+
+def _db_has_token_families(db_path: str) -> bool:
+    """Return True iff the token-store DB at ``db_path`` has any rows.
+
+    Opens a read-only SQLite connection so we don't need the encryption
+    key (the encryption is field-level, not database-level). A missing
+    file or an empty schema both count as "no rows" — the legitimate
+    first-run case.
+    """
+    if not Path(db_path).is_file():
+        return False
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    except sqlite3.DatabaseError:
+        return False
+    try:
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='token_families'"
+        )
+        if cursor.fetchone() is None:
+            return False
+        cursor = conn.execute("SELECT 1 FROM token_families LIMIT 1")
+        return cursor.fetchone() is not None
+    finally:
+        conn.close()
+
+
+def check_key_integrity(db_path: str, key_manager: "KeyManager") -> None:
+    """Raise ``KeyLossError`` when the DB holds state but the keyring is empty.
+
+    The check runs before any call to ``get_or_create_*``: if the token
+    store already has families, silently regenerating a fresh signing or
+    encryption key would invalidate every live token and render the
+    encrypted columns unreadable. Refusing to start and surfacing a
+    clear operator error is the safer failure mode — the operator can
+    either restore their keyring entry or delete the DB to accept a
+    fresh install.
+    """
+    if not _db_has_token_families(db_path):
+        return
+    signing = key_manager.get_signing_key()
+    encryption = key_manager.get_encryption_key()
+    missing: list[str] = []
+    if signing is None:
+        missing.append("signing key")
+    if encryption is None:
+        missing.append("encryption key")
+    if not missing:
+        return
+    raise KeyLossError(
+        f"Token store at {db_path} contains families but the keyring is "
+        f"missing the {' and '.join(missing)}. agent-auth refuses to "
+        "auto-regenerate these keys — a fresh key would silently "
+        "invalidate every live token and render encrypted columns "
+        "unreadable. Either restore the keyring entry for the "
+        "'agent-auth' service, or delete the token store "
+        f"({db_path}) and any Write-Ahead Log siblings to accept a "
+        "fresh install. See design/DESIGN.md 'Key loss and recovery'."
+    )

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -4,9 +4,13 @@
 
 """Tests for keyring key management."""
 
+import os
+
 import pytest
 
-from agent_auth.keys import KeyManager
+from agent_auth.errors import KeyLossError
+from agent_auth.keys import KeyManager, check_key_integrity
+from agent_auth.store import TokenStore
 
 
 @pytest.mark.covers_function("Generate Signing Key")
@@ -40,3 +44,90 @@ def test_signing_and_encryption_keys_differ(mock_keyring):
     encryption = km.get_or_create_encryption_key()
     # NewType distinguishes them statically; at runtime both are bytes.
     assert bytes(signing) != bytes(encryption)
+
+
+# -- key loss detection --
+
+
+@pytest.mark.covers_function("Load Signing Key")
+def test_get_signing_key_returns_none_when_keyring_empty(mock_keyring):
+    km = KeyManager()
+    assert km.get_signing_key() is None
+
+
+@pytest.mark.covers_function("Load Encryption Key")
+def test_get_encryption_key_returns_none_when_keyring_empty(mock_keyring):
+    km = KeyManager()
+    assert km.get_encryption_key() is None
+
+
+@pytest.mark.covers_function("Load Signing Key")
+def test_check_key_integrity_passes_on_fresh_install(mock_keyring, tmp_dir):
+    """DB absent + keyring empty = first-time install; no error."""
+    db_path = os.path.join(tmp_dir, "tokens.db")
+    km = KeyManager()
+    # Expected: no raise.
+    check_key_integrity(db_path, km)
+
+
+@pytest.mark.covers_function("Load Signing Key")
+def test_check_key_integrity_passes_when_db_empty(mock_keyring, tmp_dir):
+    """Empty schema + no keys is still the first-time path."""
+    db_path = os.path.join(tmp_dir, "tokens.db")
+    # Build an empty store (schema only, no families) — this uses
+    # get_or_create_encryption_key, so clear the keyring afterwards to
+    # simulate a later wipe.
+    km = KeyManager()
+    encryption_key = km.get_or_create_encryption_key()
+    TokenStore(db_path, encryption_key).close()
+    mock_keyring.clear()
+
+    # Even though the DB file exists, token_families is empty, so the
+    # check must pass — recreating keys on first launch is expected.
+    check_key_integrity(db_path, KeyManager())
+
+
+@pytest.mark.covers_function("Load Signing Key")
+def test_check_key_integrity_raises_when_db_has_families_but_keys_missing(mock_keyring, tmp_dir):
+    db_path = os.path.join(tmp_dir, "tokens.db")
+    km = KeyManager()
+    encryption_key = km.get_or_create_encryption_key()
+    _signing = km.get_or_create_signing_key()
+    store = TokenStore(db_path, encryption_key)
+    store.create_family("fam-keyloss-test", {"agent-auth:health": "allow"})
+    store.close()
+
+    # Simulate a wiped keyring (user moved hosts, lost keychain, etc.).
+    mock_keyring.clear()
+
+    with pytest.raises(KeyLossError) as excinfo:
+        check_key_integrity(db_path, KeyManager())
+    message = str(excinfo.value)
+    # The error names both missing keys and the recovery path so an
+    # operator reading only the message can act on it.
+    assert "signing key" in message
+    assert "encryption key" in message
+    assert "delete the token store" in message
+    assert db_path in message
+
+
+@pytest.mark.covers_function("Load Signing Key")
+def test_check_key_integrity_raises_when_only_signing_key_missing(mock_keyring, tmp_dir):
+    """Partial loss (one of the two keys) still fails startup."""
+    db_path = os.path.join(tmp_dir, "tokens.db")
+    km = KeyManager()
+    encryption_key = km.get_or_create_encryption_key()
+    _signing = km.get_or_create_signing_key()
+    store = TokenStore(db_path, encryption_key)
+    store.create_family("fam-partial-loss", {"agent-auth:health": "allow"})
+    store.close()
+
+    # Selectively delete only the signing key from the mock keyring.
+    mock_keyring.pop(("agent-auth", "signing-key"), None)
+
+    with pytest.raises(KeyLossError) as excinfo:
+        check_key_integrity(db_path, KeyManager())
+    message = str(excinfo.value)
+    assert "signing key" in message
+    # Encryption key is still present, so it should not be named as missing.
+    assert "encryption key" not in message


### PR DESCRIPTION
## Summary

- Refuses to auto-regenerate keys when `tokens.db` holds families but the keyring is missing the signing or encryption key. Without this, a wiped keychain / new host / OS reinstall silently strands every live token.
- New `KeyLossError`, `check_key_integrity()` helper, non-creating `KeyManager.get_signing_key()` / `get_encryption_key()` accessors, and CLI-level error surfacing (stderr + exit 2, no traceback).
- `design/DESIGN.md` gains a "Key loss and recovery" section (detection, operator-facing error, no-backup-tool stance for 1.0, known gaps).
- `scripts/verify-standards.sh` gates the section.
- Six unit tests cover first-install, empty-schema, full loss, and partial (signing-only) loss.

Closes #31.

## Design trade-offs

- **No first-party backup tool in 1.0.** Documented in the ADR-adjacent prose in the new section. The rationale: any backup store widens the attack surface for 32-byte secrets without the tamper-evidence / key-wrapping story that QM/SIL in `design/ASSURANCE.md` currently covers. System keyring backup (macOS Time Machine, `seahorse` export) is the intended recovery path.
- **Presence only, not validity.** Byte-for-byte corruption of a keyring entry surfaces later as `TokenInvalidError` / `InvalidTag`. Operator symptom is identical and so is the recovery path.

## Test plan

- [x] `uv run pytest tests/test_keys.py tests/test_server.py tests/test_error_taxonomy.py` — 100 passed.
- [x] `task check` clean (lint, format, typecheck).
- [x] `bash scripts/verify-standards.sh` passes with the new DESIGN-section gate.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)