### PR TITLE
fix(release): repair github plugin options and anchor CHANGELOG title

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -32,15 +32,14 @@
     [
       "@semantic-release/changelog",
       {
-        "changelogFile": "CHANGELOG.md"
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Changelog"
       }
     ],
     [
       "@semantic-release/github",
       {
-        "successComment": true,
-        "failComment": false,
-        "releasedLabels": true
+        "failComment": false
       }
     ],
     [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
-
-SPDX-License-Identifier: MIT
--->
-
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -32,6 +32,15 @@ path = [
 SPDX-FileCopyrightText = "2026 Aidan Nagorcka-Smith"
 SPDX-License-Identifier = "MIT"
 
+# CHANGELOG.md is managed by @semantic-release/changelog, which anchors new
+# release sections to a `# Changelog` title at the top of the file. An inline
+# HTML SPDX comment would push the title off the first line and break that
+# anchor, so the header is declared here instead.
+[[annotations]]
+path = "CHANGELOG.md"
+SPDX-FileCopyrightText = "2026 Aidan Nagorcka-Smith"
+SPDX-License-Identifier = "MIT"
+
 [[annotations]]
 path = "uv.lock"
 SPDX-FileCopyrightText = "2026 Aidan Nagorcka-Smith"


### PR DESCRIPTION
## Summary

Post-merge hotfix for the semantic-release migration landed in #204.
The first release run on the merge commit failed at `verifyConditions`
so no `v0.x` tag was cut from `main`. Two corrections:

1. **`@semantic-release/github` options** — `successComment: true` and
   `releasedLabels: true` are both invalid: the plugin accepts only
   *omission* (plugin defaults apply), a non-empty string / string-array,
   or `false`. Failed with `EINVALIDSUCCESSCOMMENT` +
   `EINVALIDRELEASEDLABELS`. Drop both keys so the defaults apply — the
   plugin comments on resolved PRs/issues and labels them `released`.
   Behaviour matches ADR 0026; the explicit `true` values were a
   mis-translation at config time.

2. **`@semantic-release/changelog` title anchor** — the plugin checks
   `file.startsWith(changelogTitle)` to decide where to insert new
   release notes. Pre-fix `CHANGELOG.md` started with an HTML SPDX
   comment, so any new section would prepend *above* the Keep-a-Changelog
   preamble. Moves the SPDX header into `REUSE.toml` and sets
   `changelogTitle: "# Changelog"` so release notes land below the
   title.

Both fixes are config-only. Existing ADR 0026 + `CONTRIBUTING.md` copy
on App permissions still reads true — the plugin defaults still post
comments and apply labels, so the Issues / Pull requests R/W permissions
remain load-bearing.

> [!NOTE]
> This commit is **unsigned** — the configured GPG key was unavailable
> in the worktree environment, same situation as #204. Author-authorised
> as an exception; the squash-merge commit itself will be signed by
> GitHub.

## Test plan

- [x] `jq . .releaserc.json` — JSON still parses.
- [x] `npx semantic-release --dry-run --no-ci` — all 11 plugin lifecycle
      hooks load cleanly (previously failed at `verifyConditions` on
      `@semantic-release/github`).
- [x] `scripts/reuse-lint.sh` — 272/272 files REUSE 3.3 compliant after
      the SPDX header moved into `REUSE.toml`.
- [x] `scripts/verify-standards.sh` — all checks green.
- [ ] Post-merge: confirm the `Release` workflow on the merge commit
      reaches the `analyzeCommits` phase, cuts a release based on the
      `feat(release):` + `fix(release):` commits since `v0.1.0`, writes
      the new CHANGELOG section below `# Changelog`, pushes the
      `chore(release):` commit + `vX.Y.Z` tag, and the tag triggers
      `release-publish.yml` (SLSA + cosign + SBOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)