### PR TITLE
chore: ignore .claude local state files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 # keep-sorted start
 *.egg-info/
 *.pyc
+.claude/scheduled_tasks.lock
+.claude/worktrees/
 .coverage
 .coverage.*
 .eggs/


### PR DESCRIPTION
## Summary
- Adds `.claude/scheduled_tasks.lock` and `.claude/worktrees/` to `.gitignore` so Claude Code harness local state stops showing as untracked.

## Test plan
- [x] `git status` clean after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)