### PR TITLE
ci(release): bump setup-node to 24 for semantic-release 25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
 
       - name: Install release tooling


### PR DESCRIPTION
## Summary
- semantic-release 25.0.3 (merged via #207) requires Node `^22.14.0 || >= 24.10.0`.
- The Release workflow still pinned `node-version: "20"`, so every push to `main` has been failing with `node version ... is required. Found v20.20.2.` (see run [24827239328](https://github.com/aidanns/agent-auth/actions/runs/24827239328)).
- Bumps `actions/setup-node` input to `"24"`; no other changes.

## Test plan
- [ ] Release workflow runs green on the post-merge push to `main`.
- [ ] `semantic-release` completes its dry-run / release step without the Node version error.