### PR TITLE
feat(store): numbered-SQL migration runner for the token store (#29)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,39 @@ immediately. Rationale in
 - **Lowering the floor** (rare): only with a commit-message
   justification; never lower silently. The floor never goes below 0.
 
+### Schema migrations
+
+The token store's SQLite schema is managed by a hand-rolled
+numbered-SQL runner in `src/agent_auth/migrations/`. Alembic /
+yoyo would be disproportionate for a single-family schema and
+would add a runtime dependency the project intentionally keeps
+out (CLAUDE.md § Conventions). Rules:
+
+- **Never modify an applied migration in place.** Each entry in
+  `src/agent_auth/migrations/_catalogue.py::CATALOGUE` is a
+  pinned version. Changes land as a new `Migration(version=N+1, …)`
+  tuple.
+- **Every migration must be reversible.** Both `up_sql` and a
+  matching `down_sql` are required. The runner refuses a partial
+  rollback that would hit an irreversible step, so a missing
+  `down_sql` blocks the whole roll-back path.
+- **No `CREATE TABLE` / `ALTER TABLE` in application code.**
+  Schema DDL lives exclusively in `_catalogue.py`;
+  `scripts/verify-standards.sh` greps `src/agent_auth/store.py`
+  to enforce this.
+- **Test up-then-down.** `tests/test_migrations.py` asserts that
+  every declared migration can be applied and rolled back cleanly.
+  New catalogue entries should be covered by an equivalent test.
+
+Adding a migration:
+
+1. Append a `Migration(version=N, name="…", up_sql="…", down_sql="…")`
+   entry to `CATALOGUE`.
+2. Add or extend a test under `tests/test_migrations.py`.
+3. `scripts/verify-standards.sh` re-runs the up/down drift check
+   against an ephemeral DB on every PR — a stale catalogue or a
+   non-reversible entry fails CI.
+
 ## Commit conventions
 
 Use [Conventional Commit](https://www.conventionalcommits.org/) messages.

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -1723,3 +1723,88 @@ if ! grep -qE "^## +Key loss and recovery\b" design/DESIGN.md; then
 fi
 
 echo "verify-standards: design/DESIGN.md documents key-loss detection and recovery."
+
+# DB schema migration system per
+# .claude/instructions/service-design.md ("DB schema migration strategy")
+# and the deterministic regression check from issue #29:
+#
+#   1. src/agent_auth/store.py contains no CREATE TABLE / ALTER TABLE —
+#      schema DDL lives exclusively in
+#      src/agent_auth/migrations/_catalogue.py and cannot drift from
+#      application code.
+#   2. At least one migration is declared in the catalogue (so the
+#      runner has something to apply) and the catalogue ships a
+#      reversible v=1 entry.
+#   3. Running the catalogue against an empty DB and then rolling back
+#      leaves the tracking table empty again ("up/down" drift check —
+#      the hand-rolled analogue of ``alembic check``).
+
+migrations_drift="$(
+  python3 - <<'PY'
+import pathlib
+import re
+import sqlite3
+import sys
+import tempfile
+
+errors: list[str] = []
+
+store_src = pathlib.Path("src/agent_auth/store.py").read_text()
+if re.search(r"\b(CREATE|ALTER)\s+TABLE\b", store_src, re.IGNORECASE):
+    errors.append(
+        "src/agent_auth/store.py contains CREATE TABLE / ALTER TABLE — "
+        "all schema DDL must live in src/agent_auth/migrations/_catalogue.py"
+    )
+
+catalogue_path = pathlib.Path("src/agent_auth/migrations/_catalogue.py")
+if not catalogue_path.is_file():
+    errors.append("src/agent_auth/migrations/_catalogue.py is missing")
+else:
+    sys.path.insert(0, "src")
+    from agent_auth.migrations import migrate_down, migrate_up
+    from agent_auth.migrations._catalogue import CATALOGUE
+
+    if not CATALOGUE:
+        errors.append(
+            "CATALOGUE in _catalogue.py is empty — declare at least the initial migration"
+        )
+    else:
+        with tempfile.TemporaryDirectory() as tmp:
+            db = pathlib.Path(tmp) / "drift.db"
+            conn = sqlite3.connect(db)
+            try:
+                conn.execute("PRAGMA foreign_keys=ON")
+                applied = migrate_up(conn)
+                if [m.version for m in applied] != [m.version for m in CATALOGUE]:
+                    errors.append(
+                        "migrate_up did not apply every declared migration against an empty DB"
+                    )
+                reverted = migrate_down(conn, to_version=0)
+                if {m.version for m in reverted} != {m.version for m in CATALOGUE}:
+                    errors.append(
+                        "migrate_down did not revert every applied migration back to version 0"
+                    )
+                remaining = conn.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='table' AND name != 'schema_migrations'"
+                ).fetchall()
+                if remaining:
+                    names = ", ".join(r[0] for r in remaining)
+                    errors.append(f"migrate_down left stray tables: {names}")
+            finally:
+                conn.close()
+
+for err in errors:
+    print(err)
+if errors:
+    sys.exit(1)
+PY
+)" || {
+  echo "verify-standards: migration system drift detected:" >&2
+  while IFS= read -r line; do
+    echo "  - ${line}" >&2
+  done <<<"${migrations_drift}"
+  exit 1
+}
+
+echo "verify-standards: schema DDL lives in migrations/_catalogue.py; up/down drift check passes."

--- a/src/agent_auth/migrations/__init__.py
+++ b/src/agent_auth/migrations/__init__.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Hand-rolled numbered-SQL migration runner for the agent-auth store.
+
+Scope: the project keeps its runtime deps minimal
+(`cryptography`, `keyring`, `pyyaml`) — adopting Alembic or yoyo for a
+single-table-family schema would be disproportionate. Instead this
+module ships a small, deterministic runner:
+
+- Migrations are Python ``Migration`` instances declared in
+  ``_MIGRATIONS`` below; each carries its ``version`` (monotonic
+  int), ``name``, ``up_sql`` and ``down_sql``.
+- ``migrate_up(conn)`` applies every migration whose version is
+  greater than the recorded current version, each in its own
+  transaction, in order.
+- ``migrate_down(conn, to_version)`` rolls back to the target
+  version inclusive-of-target, running the matching ``down_sql``
+  in reverse order.
+- Applied versions are recorded in a ``schema_migrations`` table
+  bootstrapped by the runner itself (the only DDL allowed outside
+  the migration SQL).
+
+The recorder column is deliberately an ``INTEGER PRIMARY KEY`` so a
+re-applied version raises a unique-constraint error rather than
+silently duplicating.
+"""
+
+from agent_auth.migrations.runner import (
+    Migration,
+    current_version,
+    migrate_down,
+    migrate_up,
+)
+
+__all__ = ["Migration", "current_version", "migrate_down", "migrate_up"]

--- a/src/agent_auth/migrations/_catalogue.py
+++ b/src/agent_auth/migrations/_catalogue.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Declared migrations, in version order.
+
+Every schema change to the token store lands as a new ``Migration``
+entry here. Do not modify an applied migration in place — pinning a
+prior version is the whole point of the versioned runner.
+"""
+
+from agent_auth.migrations.runner import Migration
+
+_INITIAL_UP = """
+CREATE TABLE token_families (
+    id TEXT PRIMARY KEY,
+    scopes BLOB NOT NULL,
+    created_at TEXT NOT NULL,
+    revoked INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE tokens (
+    id TEXT PRIMARY KEY,
+    hmac_signature BLOB NOT NULL,
+    family_id TEXT NOT NULL REFERENCES token_families(id),
+    type TEXT NOT NULL CHECK (type IN ('access', 'refresh')),
+    expires_at TEXT NOT NULL,
+    consumed INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_tokens_family_id ON tokens(family_id);
+"""
+
+# Drop in reverse-dependency order: the index and the referencing
+# ``tokens`` table before the referenced ``token_families``.
+_INITIAL_DOWN = """
+DROP INDEX IF EXISTS idx_tokens_family_id;
+DROP TABLE IF EXISTS tokens;
+DROP TABLE IF EXISTS token_families;
+"""
+
+CATALOGUE: tuple[Migration, ...] = (
+    Migration(
+        version=1,
+        name="initial",
+        up_sql=_INITIAL_UP,
+        down_sql=_INITIAL_DOWN,
+    ),
+)

--- a/src/agent_auth/migrations/runner.py
+++ b/src/agent_auth/migrations/runner.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Migration runner: apply / roll back versioned SQL against a sqlite3 connection."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+
+@dataclass(frozen=True)
+class Migration:
+    """A single numbered migration.
+
+    ``version`` must be unique and monotonically increasing across
+    the declared migrations; ``up_sql`` and ``down_sql`` are raw
+    SQL executed via ``conn.executescript``. Keep each migration
+    focused — one logical schema change per version — so partial
+    roll-backs stay debuggable.
+    """
+
+    version: int
+    name: str
+    up_sql: str
+    down_sql: str
+
+
+# The ``schema_migrations`` bootstrap is the only DDL the runner
+# owns directly. All other tables are expressed as migrations.
+_BOOTSTRAP_SQL = """
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    applied_at TEXT NOT NULL
+);
+"""
+
+
+def _ensure_bootstrap(conn: sqlite3.Connection) -> None:
+    conn.execute(_BOOTSTRAP_SQL)
+    conn.commit()
+
+
+def current_version(conn: sqlite3.Connection) -> int:
+    """Return the highest applied migration version, or 0 if none applied."""
+    _ensure_bootstrap(conn)
+    row = conn.execute("SELECT COALESCE(MAX(version), 0) FROM schema_migrations").fetchone()
+    return int(row[0])
+
+
+def _declared_sorted(migrations: tuple[Migration, ...]) -> tuple[Migration, ...]:
+    seen: set[int] = set()
+    for m in migrations:
+        if m.version in seen:
+            raise ValueError(f"duplicate migration version {m.version}")
+        seen.add(m.version)
+    return tuple(sorted(migrations, key=lambda m: m.version))
+
+
+def migrate_up(
+    conn: sqlite3.Connection,
+    migrations: tuple[Migration, ...] | None = None,
+) -> list[Migration]:
+    """Apply every pending migration in order; return the ones applied.
+
+    Each migration runs in its own transaction: partial schema
+    changes from a failed migration do not leak into subsequent
+    ones. The tracking row is written in the same transaction as
+    the DDL so the recorded version never drifts from the actual
+    schema state.
+    """
+    _ensure_bootstrap(conn)
+    if migrations is None:
+        from agent_auth.migrations._catalogue import CATALOGUE
+
+        migrations = CATALOGUE
+    ordered = _declared_sorted(migrations)
+    applied_rows = {
+        int(v) for (v,) in conn.execute("SELECT version FROM schema_migrations").fetchall()
+    }
+    applied: list[Migration] = []
+    for migration in ordered:
+        if migration.version in applied_rows:
+            continue
+        # Each migration is its own BEGIN/COMMIT so partial failures
+        # don't leave the DB in a half-applied state.
+        conn.execute("BEGIN")
+        try:
+            conn.executescript(migration.up_sql)
+            conn.execute(
+                "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?, ?, ?)",
+                (migration.version, migration.name, datetime.now(UTC).isoformat()),
+            )
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+        conn.execute("COMMIT")
+        applied.append(migration)
+    return applied
+
+
+def migrate_down(
+    conn: sqlite3.Connection,
+    to_version: int = 0,
+    migrations: tuple[Migration, ...] | None = None,
+) -> list[Migration]:
+    """Roll back applied migrations down to (but not through) ``to_version``.
+
+    Migrations whose version is strictly greater than
+    ``to_version`` are reverted in reverse order. A missing
+    ``down_sql`` on any selected migration raises ``ValueError``
+    before any rollback is applied — partial roll-backs with
+    irreversible steps would be the worst of both worlds.
+    """
+    _ensure_bootstrap(conn)
+    if migrations is None:
+        from agent_auth.migrations._catalogue import CATALOGUE
+
+        migrations = CATALOGUE
+    ordered = _declared_sorted(migrations)
+    applied_rows = {
+        int(v) for (v,) in conn.execute("SELECT version FROM schema_migrations").fetchall()
+    }
+    to_revert = [m for m in ordered if m.version > to_version and m.version in applied_rows]
+    to_revert.sort(key=lambda m: m.version, reverse=True)
+
+    missing_down = [m for m in to_revert if not m.down_sql.strip()]
+    if missing_down:
+        versions = ", ".join(str(m.version) for m in missing_down)
+        raise ValueError(f"refusing partial rollback: migrations {versions} have no down_sql")
+
+    reverted: list[Migration] = []
+    for migration in to_revert:
+        conn.execute("BEGIN")
+        try:
+            conn.executescript(migration.down_sql)
+            conn.execute("DELETE FROM schema_migrations WHERE version = ?", (migration.version,))
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+        conn.execute("COMMIT")
+        reverted.append(migration)
+    return reverted

--- a/src/agent_auth/store.py
+++ b/src/agent_auth/store.py
@@ -15,6 +15,7 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 from agent_auth.crypto import Ciphertext, decrypt_field, encrypt_field
 from agent_auth.keys import EncryptionKey
+from agent_auth.migrations import migrate_up
 
 
 class TokenStore:
@@ -26,7 +27,7 @@ class TokenStore:
         self._aesgcm = AESGCM(encryption_key)
         self._local = threading.local()
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._init_schema()
+        self._run_migrations()
 
     def _get_conn(self) -> sqlite3.Connection:
         if not hasattr(self._local, "conn"):
@@ -37,27 +38,16 @@ class TokenStore:
             self._local.conn = conn
         return cast(sqlite3.Connection, self._local.conn)
 
-    def _init_schema(self) -> None:
-        conn = self._get_conn()
-        conn.executescript("""
-            CREATE TABLE IF NOT EXISTS token_families (
-                id TEXT PRIMARY KEY,
-                scopes BLOB NOT NULL,
-                created_at TEXT NOT NULL,
-                revoked INTEGER NOT NULL DEFAULT 0
-            );
+    def _run_migrations(self) -> None:
+        """Apply any pending schema migrations.
 
-            CREATE TABLE IF NOT EXISTS tokens (
-                id TEXT PRIMARY KEY,
-                hmac_signature BLOB NOT NULL,
-                family_id TEXT NOT NULL REFERENCES token_families(id),
-                type TEXT NOT NULL CHECK (type IN ('access', 'refresh')),
-                expires_at TEXT NOT NULL,
-                consumed INTEGER NOT NULL DEFAULT 0
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_tokens_family_id ON tokens(family_id);
-        """)
+        Schema DDL lives exclusively in
+        ``src/agent_auth/migrations/_catalogue.py``. Application code
+        here must not issue schema-modifying SQL directly; the
+        ``no-ddl-in-application-code`` rule is enforced by
+        ``scripts/verify-standards.sh``.
+        """
+        migrate_up(self._get_conn())
 
     def _encrypt(self, plaintext: str) -> Ciphertext:
         return encrypt_field(plaintext.encode("utf-8"), self._encryption_key, self._aesgcm)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for the numbered-SQL migration runner."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from agent_auth.migrations import (
+    Migration,
+    current_version,
+    migrate_down,
+    migrate_up,
+)
+from agent_auth.migrations._catalogue import CATALOGUE
+
+
+def _table_names(conn: sqlite3.Connection) -> set[str]:
+    return {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    }
+
+
+def _index_names(conn: sqlite3.Connection) -> set[str]:
+    return {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'"
+        ).fetchall()
+    }
+
+
+@pytest.fixture
+def conn(tmp_path):
+    """In-memory-backed SQLite connection shared by a test."""
+    path = tmp_path / "mig.db"
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA foreign_keys=ON")
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def test_current_version_is_zero_on_empty_db(conn):
+    assert current_version(conn) == 0
+
+
+def test_current_version_creates_tracking_table(conn):
+    current_version(conn)
+    assert "schema_migrations" in _table_names(conn)
+
+
+def test_migrate_up_applies_initial_migration(conn):
+    applied = migrate_up(conn)
+    assert [m.version for m in applied] == [1]
+    tables = _table_names(conn)
+    assert "token_families" in tables
+    assert "tokens" in tables
+    assert "idx_tokens_family_id" in _index_names(conn)
+    assert current_version(conn) == 1
+
+
+def test_migrate_up_is_idempotent(conn):
+    migrate_up(conn)
+    second = migrate_up(conn)
+    # No pending migrations on the second pass.
+    assert second == []
+
+
+def test_migrate_down_removes_initial_schema(conn):
+    migrate_up(conn)
+    reverted = migrate_down(conn, to_version=0)
+    assert [m.version for m in reverted] == [1]
+    # Down returns to the pre-migration state: tracking table stays
+    # (so a future up can find v=0), every declared table is gone.
+    tables = _table_names(conn)
+    assert tables == {"schema_migrations"}
+    assert current_version(conn) == 0
+
+
+def test_up_down_up_cycles_cleanly(conn):
+    migrate_up(conn)
+    migrate_down(conn, to_version=0)
+    applied = migrate_up(conn)
+    # Second up replays the same migration against a cleared tracker.
+    assert [m.version for m in applied] == [1]
+    assert "token_families" in _table_names(conn)
+
+
+def test_migrate_up_rejects_duplicate_versions(conn):
+    dup = (
+        Migration(version=1, name="a", up_sql="", down_sql=""),
+        Migration(version=1, name="b", up_sql="", down_sql=""),
+    )
+    with pytest.raises(ValueError, match="duplicate migration version"):
+        migrate_up(conn, migrations=dup)
+
+
+def test_partial_rollback_with_missing_down_raises_before_touching_db(conn):
+    migrations = (
+        Migration(
+            version=1,
+            name="has_down",
+            up_sql="CREATE TABLE one (id INTEGER);",
+            down_sql="DROP TABLE one;",
+        ),
+        Migration(
+            version=2,
+            name="no_down",
+            up_sql="CREATE TABLE two (id INTEGER);",
+            down_sql="",  # irreversible
+        ),
+    )
+    migrate_up(conn, migrations=migrations)
+    with pytest.raises(ValueError, match="refusing partial rollback"):
+        migrate_down(conn, to_version=0, migrations=migrations)
+    # Nothing was reverted — both tables are still there and the
+    # tracker still reflects both versions.
+    tables = _table_names(conn)
+    assert "one" in tables
+    assert "two" in tables
+
+
+def test_catalogue_versions_are_monotonic_and_unique():
+    versions = [m.version for m in CATALOGUE]
+    assert versions == sorted(set(versions))
+    assert all(m.version > 0 for m in CATALOGUE)
+
+
+def test_catalogue_initial_migration_is_reversible():
+    initial = next(m for m in CATALOGUE if m.version == 1)
+    # A stray empty down_sql here would let a "rollback then re-apply"
+    # workflow silently fail to clean up — the runner would refuse
+    # the partial rollback at runtime, but asserting it at the catalogue
+    # level gives a nicer failure message during development.
+    assert initial.down_sql.strip(), "initial migration must declare a non-empty down_sql"


### PR DESCRIPTION
## Summary

- Replaces `TokenStore._init_schema`'s inline `CREATE TABLE IF NOT EXISTS` bootstrap with a hand-rolled numbered-SQL migration runner under `src/agent_auth/migrations/`.
- Initial schema is captured as `Migration(version=1, name="initial", …)` with a matching reversible `down_sql`.
- 10 new tests cover up/down/idempotent/partial-rollback invariants and catalogue-level assertions.
- `scripts/verify-standards.sh` gates three things: no schema-modifying SQL in application code, a non-empty catalogue, and an ephemeral up-then-down cycle that leaves only `schema_migrations` behind (the hand-rolled analogue of `alembic check`).
- `CONTRIBUTING.md` § "Schema migrations" documents the never-modify-in-place / reversibility / add-a-migration procedure.

Closes #29.

## Why a hand-rolled runner

Alembic and yoyo are both disproportionate for a single-family schema and would add a runtime dependency the project intentionally keeps out (CLAUDE.md § Conventions: "Python 3.11+, no external dependencies for core functionality"). The runner is ~80 LOC and ships with the same standards rigor the project applies everywhere else.

## Test plan

- [x] `uv run pytest tests/test_migrations.py tests/test_store.py tests/test_server.py` — 70 passed.
- [x] `uv run pytest tests/` — 439 passed, 3 skipped.
- [x] `task check` clean.
- [x] `bash scripts/verify-standards.sh` green on the new drift check.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)