### PR TITLE
ci(scorecard): move SCORECARD_MIN_SCORE to step-level env (#231)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,14 +31,6 @@ on:
 
 permissions: read-all
 
-env:
-  # Initial floor of 0.0 so the first scheduled run establishes a
-  # baseline without red-lighting CI before we know the observed score.
-  # Raise to `observed_score - 0.5` after the first publication and
-  # ratchet upward as supply-chain hardening lands (pinned deps, token
-  # permissions, signed releases, fuzzing, ...).
-  SCORECARD_MIN_SCORE: "0.0"
-
 jobs:
   analysis:
     name: Scorecard analysis
@@ -88,6 +80,18 @@ jobs:
           publish_results: false
 
       - name: Gate on aggregate score
+        # Kept at step-level rather than workflow-level: scorecard-action's
+        # publish_results endpoint rejects workflows that declare a top-level
+        # `env:` or `defaults:` block (see ossf/scorecard-action workflow
+        # restrictions), and losing publication would break the README badge
+        # and the SELF_ASSESSMENT publication claim.
+        env:
+          # Initial floor of 0.0 so the first scheduled run establishes a
+          # baseline without red-lighting CI before we know the observed score.
+          # Raise to `observed_score - 0.5` after the first publication and
+          # ratchet upward as supply-chain hardening lands (pinned deps, token
+          # permissions, signed releases, fuzzing, ...).
+          SCORECARD_MIN_SCORE: "0.0"
         run: |
           set -euo pipefail
           score=$(jq -r '.score' results.json)


### PR DESCRIPTION
## Summary
- Every push to `main` has been failing the `Run Scorecard (SARIF)` step with HTTP 400 (`workflow contains global env vars or defaults`) because `scorecard-action`'s publication endpoint rejects any workflow declaring a top-level `env:` or `defaults:` block — and we were declaring one to hold `SCORECARD_MIN_SCORE`.
- Move `SCORECARD_MIN_SCORE` onto the only step that reads it (`Gate on aggregate score`), carrying the ratcheting-floor comment with it.
- Add a step-level comment recording *why* the variable can't be hoisted back to workflow level, so the next reader doesn't undo this.

Closes #231.

## Test plan
- [x] `task lint`
- [x] `task format -- --check`
- [x] `task reuse-lint`
- [x] `task verify-standards`
- [ ] After merge: confirm the next push to `main` runs `Scorecard` to completion and `api.scorecard.dev` advances to the new commit SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)