### PR TITLE
docs(contributing): forbid issue numbers in commit subjects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,12 @@ simplifying for "personal project" scope.
   `ci:`. Breaking changes (`!` on the type — `feat!:` — or a
   `BREAKING CHANGE:` footer) are demoted to a minor bump while in
   0.x. `.releaserc.mjs` `releaseRules` is the source of truth.
+- Commit subjects must not include the linked issue number
+  (no `(#<issue>)` suffix). GitHub's squash-merge appends the PR
+  number, which the `conventionalcommits` preset auto-links; adding
+  an issue number by hand produces a duplicate parenthesized link in
+  `CHANGELOG.md`. Link the issue with a `Closes #N` footer instead.
+  See `CONTRIBUTING.md` § *Writing release-worthy commits*.
 
 ## Project-specific notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,8 +248,18 @@ bodies, not hand-edited. To get a rich CHANGELOG entry:
   notes) in the commit **body**, not a separate CHANGELOG edit. The
   body surfaces in the GitHub release notes even when the CHANGELOG
   keeps only the subject.
-- Reference the closing issue with `Closes #N` in the footer so the
-  generated section links back.
+- Do **not** append the linked issue number to the subject (no
+  `(#<issue>)` suffix). GitHub's squash-merge auto-appends the PR
+  number, and the `conventionalcommits` preset auto-links it in
+  `CHANGELOG.md` — a hand-typed issue number would render a second,
+  redundant link beside it. Link the issue via the `Closes #N` footer
+  below instead.
+- Reference the closing issue with `Closes #N` in the footer so
+  GitHub closes the issue when the PR merges and the PR page lists
+  the linkage. `CHANGELOG.md` intentionally does **not** render the
+  closed-issue link — see
+  [PR #220](https://github.com/aidanns/agent-auth/pull/220) for the
+  rationale.
 - Mark breaking changes with a `!` after the type (`feat!:`) or a
   `BREAKING CHANGE:` footer. Pre-1.0, these demote to a minor bump
   (see [ADR 0026](design/decisions/0026-semantic-release-autorelease.md)


### PR DESCRIPTION
## Summary

- Drop the `(#<issue>)` suffix from commit subjects. GitHub's
  squash-merge still appends `(#<pr>)`, so the `conventionalcommits`
  preset renders a single PR link in `CHANGELOG.md` instead of two
  parenthesised links side-by-side.
- Document the rule in `CONTRIBUTING.md` § *Writing release-worthy
  commits* and echo a one-liner in `CLAUDE.md` § Conventions so the
  convention is visible without digging. `Closes #N` in the footer
  remains the canonical issue ↔ PR linkage mechanism.

No `.releaserc.mjs` change — the preset already produces the desired
output once subjects stop carrying `(#<issue>)`.

## Test plan

- [x] Updated `CONTRIBUTING.md` (§ *Writing release-worthy commits*) and `CLAUDE.md` (§ Conventions) to state subjects must not include `(#<issue>)`; issue linkage is via `Closes #N` footer only.
- [x] Grepped repo for `(#<issue>)` / `#<pr>` / commit-subject-shaped examples — no stale references to update.
- [x] Synthesized a representative commit under the new convention (`fix(example): sample release-triggering commit under new convention (#999)`) and rendered the CHANGELOG entry through the configured preset + `commitPartial` — single PR link: `* **example:** sample release-triggering commit under new convention ([#999](https://github.com/aidanns/agent-auth/issues/999))`.

Closes #233