### PR TITLE
ci(scorecard): split publish and gate jobs

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,6 +18,14 @@ name: Scorecard
 # unnoticed. The floor is deliberately set to the current observed
 # score so future changes ratchet rather than regress.
 #
+# Split into two jobs because scorecard-action's publish endpoint
+# rejects any publishing job that contains a non-`uses:` step (see
+# https://github.com/ossf/scorecard-action#workflow-restrictions).
+# `publish` holds only `uses:` steps so the signed publication to
+# api.securityscorecards.dev succeeds; `gate` re-runs scorecard-action
+# without publication so it can pair the JSON output with a `run:`
+# threshold check.
+#
 # See also:
 #   - design/SELF_ASSESSMENT.md → "OpenSSF Scorecard" for the target
 #     and publication policy.
@@ -32,8 +40,8 @@ on:
 permissions: read-all
 
 jobs:
-  analysis:
-    name: Scorecard analysis
+  publish:
+    name: Scorecard analysis (publish)
     runs-on: ubuntu-latest
     permissions:
       # For uploading SARIF to the GitHub Security tab.
@@ -71,20 +79,30 @@ jobs:
         with:
           sarif_file: results.sarif
 
-      - name: Run Scorecard (JSON) for threshold gate
+  gate:
+    name: Scorecard threshold gate
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      # scorecard-action reads workflow runs for the Token-Permissions check
+      # even when publish_results is false.
+      actions: read
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard (JSON)
         uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.json
           results_format: json
-          # Gate-only run; do not re-publish.
+          # Gate-only run; publication happens in the `publish` job.
           publish_results: false
 
       - name: Gate on aggregate score
-        # Kept at step-level rather than workflow-level: scorecard-action's
-        # publish_results endpoint rejects workflows that declare a top-level
-        # `env:` or `defaults:` block (see ossf/scorecard-action workflow
-        # restrictions), and losing publication would break the README badge
-        # and the SELF_ASSESSMENT publication claim.
         env:
           # Initial floor of 0.0 so the first scheduled run establishes a
           # baseline without red-lighting CI before we know the observed score.


### PR DESCRIPTION
## Summary
- `Scorecard` workflow has been failing on every push to `main` — the aggregate score (6.1) is computed fine, but `scorecard-action`'s publish endpoint rejects the run with HTTP 400 (`scorecard job must only have steps with 'uses'`).
- #232 addressed a sibling restriction (no top-level `env:` / `defaults:`). This PR addresses the remaining restriction: the publishing job also cannot contain any `run:` step. Our `Gate on aggregate score` step is a `run:` step, so publication keeps failing.
- Split the workflow into `publish` (uses-only: checkout + `scorecard-action` SARIF with `publish_results: true` + upload artefact + upload SARIF to Security tab) and `gate` (depends on `publish`, re-runs `scorecard-action` with `publish_results: false` and runs the `awk` threshold check). The restriction only applies to the publishing job, so `gate` can carry the `run:` step freely.

Closes #234.

## Test plan
- [x] `task lint`
- [x] `task format -- --check`
- [x] `task reuse-lint`
- [x] `task verify-standards`
- [ ] After merge: `Scorecard` goes green on `main`, the SARIF artefact still lands, and `api.securityscorecards.dev` advances to the new commit SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)