### PR TITLE
docs(claude): note DCO sign-off requirement in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,12 @@ simplifying for "personal project" scope.
   `ci:`. Breaking changes (`!` on the type — `feat!:` — or a
   `BREAKING CHANGE:` footer) are demoted to a minor bump while in
   0.x. `.releaserc.mjs` `releaseRules` is the source of truth.
+- Every PR commit needs a DCO `Signed-off-by:` trailer — use
+  `git commit -s` (or `git config --local format.signoff true` once).
+  Enforced by `.github/workflows/dco.yml`; forgetting it makes the
+  `DCO sign-off check` fail and the remedy is
+  `git rebase origin/main --signoff && git push --force-with-lease`.
+  See `CONTRIBUTING.md` → "DCO sign-off".
 
 ## Project-specific notes
 


### PR DESCRIPTION
## Summary
- Add a Conventions bullet in `CLAUDE.md` pointing out the DCO `Signed-off-by:` trailer requirement, the `-s` / `format.signoff` setup, the `.github/workflows/dco.yml` enforcement, and the rebase-with-signoff remedy. Prompted by #236 failing `DCO sign-off check` on first push — this steers future commits to get it right the first time and points at `CONTRIBUTING.md` for the full rationale.

## Test plan
- [x] `task lint` (no code changed; docs-only)
- [ ] `DCO sign-off check` passes on this PR (this commit is itself signed off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)