### PR TITLE
ci: sha-pin actions/checkout across all workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup-toolchain
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
         language: [python, actions]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialise CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -29,7 +29,7 @@ jobs:
     name: DCO sign-off check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # Need full PR history so `git rev-list base..head` resolves.
           fetch-depth: 0

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -24,7 +24,7 @@ jobs:
     # gets cut off cleanly rather than burning compute minutes.
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup-toolchain
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -53,7 +53,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -90,7 +90,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,7 +17,7 @@ jobs:
   pip-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup-toolchain
         with:
@@ -32,7 +32,7 @@ jobs:
   integration-agent-auth:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup-toolchain
         with:
@@ -48,7 +48,7 @@ jobs:
   integration-things-bridge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup-toolchain
         with:
@@ -64,7 +64,7 @@ jobs:
   integration-things-cli:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup-toolchain
         with:
@@ -80,7 +80,7 @@ jobs:
   integration-things-client-applescript:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup-toolchain
         with:
@@ -113,7 +113,7 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -14,7 +14,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup-toolchain
         with:

--- a/.github/workflows/verify-design.yml
+++ b/.github/workflows/verify-design.yml
@@ -14,7 +14,7 @@ jobs:
   verify-design:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup-toolchain
         with:

--- a/.github/workflows/verify-function-tests.yml
+++ b/.github/workflows/verify-function-tests.yml
@@ -14,7 +14,7 @@ jobs:
   verify-function-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup-toolchain
         with:

--- a/.github/workflows/verify-standards.yml
+++ b/.github/workflows/verify-standards.yml
@@ -14,7 +14,7 @@ jobs:
   verify-standards:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup-toolchain
         with:

--- a/.github/workflows/verify-token-cli-http-parity.yml
+++ b/.github/workflows/verify-token-cli-http-parity.yml
@@ -14,7 +14,7 @@ jobs:
   verify-token-cli-http-parity:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup-toolchain
         with:

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -22,6 +22,9 @@
 #      tooling-and-ci.md Security). An ecosystem is "in use" when its
 #      manifest files are present; ecosystems without manifests are
 #      skipped rather than required.
+#   2a. Third-party GitHub Actions enumerated in PINNED_ACTIONS use the
+#      sha+trailing-comment pin form (see issue #83 and the OpenSSF
+#      Scorecard `pinned-dependencies` check).
 #   3. Bash gating (shellcheck, shfmt) is wired into CI, treefmt, and
 #      lefthook per .claude/instructions/bash.md.
 #   4. Markdown (mdformat) and TOML (taplo) formatters are wired into
@@ -177,6 +180,65 @@ else
 
   echo "verify-standards: dependabot.yml covers detected ecosystems (${required_ecosystems[*]}) with minor/patch grouping."
 fi
+
+# ---------------------------------------------------------------------------
+# Third-party actions are sha-pinned with a trailing ` # <tag>` comment.
+# ---------------------------------------------------------------------------
+# A bare `uses: owner/action@v6` satisfies no supply-chain control: the
+# tag can be force-moved upstream without touching this repo. The
+# project standard is `uses: owner/action@<sha> # v6` — the sha locks
+# the ref and the trailing comment documents the human-readable version
+# that Dependabot / Renovate bump together.
+#
+# PINNED_ACTIONS lists the third-party action prefixes that must be
+# sha-pinned. Add new actions here as follow-up PRs convert them to the
+# pinned form (see issue #83). Entries match against the full
+# `uses: <owner>/<action>` path — trailing slashes are stripped before
+# comparison so `github/codeql-action` can be added to catch any of its
+# sub-actions (analyze, init, upload-sarif).
+PINNED_ACTIONS=(
+  # keep-sorted start
+  actions/checkout
+  # keep-sorted end
+)
+
+pinned_drift=0
+for wf in .github/workflows/*.yml .github/actions/*/action.yml; do
+  [[ -f "${wf}" ]] || continue
+  while IFS= read -r line; do
+    # Capture the `uses: owner/name[/sub]@ref[ # tag]` tail after stripping
+    # leading whitespace and the optional `- ` list marker. Lines without
+    # `uses:` are already excluded by the grep filter below.
+    stripped="${line#"${line%%[![:space:]]*}"}" # ltrim
+    stripped="${stripped#- }"
+    stripped="${stripped#uses:}"
+    stripped="${stripped#"${stripped%%[![:space:]]*}"}" # ltrim again
+    # stripped is now e.g. "actions/checkout@v6" or
+    # "actions/checkout@<sha> # v6".
+    action_path="${stripped%@*}"
+    ref_and_comment="${stripped#*@}"
+    for pinned in "${PINNED_ACTIONS[@]}"; do
+      # Match on exact repo path or a `/`-prefixed sub-action (so
+      # "github/codeql-action" covers "github/codeql-action/analyze").
+      if [[ "${action_path}" == "${pinned}" ]] \
+        || [[ "${action_path}" == "${pinned}/"* ]]; then
+        if [[ ! "${ref_and_comment}" =~ ^[0-9a-f]{40}[[:space:]]+#[[:space:]]+.+$ ]]; then
+          echo "verify-standards: ${wf} has '${pinned}' reference not in sha+comment form: ${stripped}" >&2
+          pinned_drift=1
+        fi
+        break
+      fi
+    done
+  done < <(grep -nE "^\s*-?\s*uses:\s" "${wf}" | cut -d: -f2-)
+done
+
+if [[ ${pinned_drift} -ne 0 ]]; then
+  echo "  Expected: uses: <owner>/<action>@<40-char-sha> # <tag>" >&2
+  echo "  Rationale: a bare tag can be force-moved upstream without changing this repo. See issue #83." >&2
+  exit 1
+fi
+
+echo "verify-standards: third-party actions in PINNED_ACTIONS (${PINNED_ACTIONS[*]}) use sha+comment form."
 
 # Bash tooling: shellcheck + shfmt must be wired into CI, treefmt, and
 # lefthook per .claude/instructions/bash.md. Strip comments before


### PR DESCRIPTION
## Summary

- Standardise every `actions/checkout@v6` reference on the `@<sha> # v6` form already used in `reuse.yml`, `release.yml`, and `release-publish.yml` (18 bare refs across 12 workflows → sha-pinned).
- Add a `PINNED_ACTIONS` check to `scripts/verify-standards.sh` that enforces the sha+comment form for every listed action prefix. Starts with `actions/checkout`; follow-up PRs grow the list to cover other third-party actions (`astral-sh/setup-uv`, `arduino/setup-task`, `github/codeql-action`, ...) and align with the OpenSSF Scorecard `pinned-dependencies` check.

## Why

A bare `@v6` tag satisfies no supply-chain control — upstream can force-move the tag without the ref in this repo changing. The sha pins it; the trailing `# v6` comment documents the human-readable version that Dependabot/Renovate bump alongside the sha.

## Test plan

- [x] `bash scripts/verify-standards.sh` passes.
- [x] Negative-path check: temporarily reverted one `actions/checkout` to `@v6` — script exits 1 with a clear message pointing at the offending file.
- [x] `shellcheck scripts/verify-standards.sh` — clean.
- [x] `treefmt --ci` — clean.
- [ ] CI (check / test / scorecard / verify-standards) — green.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)