### PR TITLE
fix(things-bridge): bound subprocess stderr capture

### DIFF
--- a/design/decisions/0003-things-client-cli-split.md
+++ b/design/decisions/0003-things-client-cli-split.md
@@ -175,13 +175,23 @@ only disambiguates success from failure when the envelope is absent.
   scrubbed from HTTP response bodies and only forwarded to the
   bridge's own stderr for operator diagnostics. The bridge never
   reads subprocess stderr into a response body.
+- **Bounded stderr capture.** Stderr is forwarded to the bridge's
+  own stderr line-by-line as the child writes it, and only a fixed
+  tail (64 KiB) is retained for the timeout-diagnostic line. A
+  misbehaving or compromised client CLI that streams multi-megabyte
+  diagnostics therefore cannot pin bridge memory across the live
+  subprocess, even under the `ThreadingHTTPServer`'s per-thread
+  request model. Stdout remains unbounded because the JSON envelope
+  must be parsed in full; envelopes are small by construction and
+  malformed/oversize bodies still fail closed through the existing
+  error-taxonomy entries.
 - **STRIDE deltas.** Spoofing / Tampering: mitigated by the bridge
   controlling the argv and validating `things_client_command` at
   config load. Repudiation: subprocess invocations are logged at
   operator-diagnostic level on stderr. Info disclosure: unchanged
   (stderr scrubbing). DoS: a hung subprocess is bounded by
-  `request_timeout_seconds`. Elevation: no privilege boundary
-  crossed.
+  `request_timeout_seconds`; stderr capture is bounded to a fixed
+  tail. Elevation: no privilege boundary crossed.
 
 ### Performance
 

--- a/src/things_bridge/things_client.py
+++ b/src/things_bridge/things_client.py
@@ -11,10 +11,12 @@ stdout. This module is the only place the bridge reasons about the
 subprocess protocol.
 """
 
+import contextlib
 import json
 import subprocess
 import sys
-from typing import Any, cast
+import threading
+from typing import IO, Any, cast
 
 from things_models.errors import (
     ThingsError,
@@ -22,6 +24,15 @@ from things_models.errors import (
     ThingsPermissionError,
 )
 from things_models.models import Area, Project, Todo
+
+STDERR_TAIL_MAX_CHARS = 64 * 1024
+"""Upper bound on the stderr tail retained for diagnostic messages.
+
+The bridge forwards client stderr to its own stderr *live* so nothing is
+buffered indefinitely in memory. The tail only exists so the timeout
+diagnostic can include a last-gasp excerpt when the child hung before
+writing a structured error.
+"""
 
 
 class ThingsSubprocessClient:
@@ -31,8 +42,9 @@ class ThingsSubprocessClient:
     or ``[sys.executable, "-m", "tests.things_client_fake", "--fixtures", P]``);
     sub-commands matching the request are appended. ``timeout_seconds`` caps
     the per-call wall clock. Subprocess stderr is forwarded to the bridge's
-    own stderr for operator diagnostics; the HTTP response body never
-    contains subprocess output.
+    own stderr line-by-line as the child writes it, so a misbehaving client
+    cannot pin bridge memory by streaming multi-megabyte diagnostics. The
+    HTTP response body never contains subprocess output.
     """
 
     def __init__(self, command: list[str], timeout_seconds: float = 35.0):
@@ -90,21 +102,42 @@ class ThingsSubprocessClient:
     def _invoke(self, argv: list[str]) -> dict[str, Any]:
         full_command = [*self._command, *argv]
         try:
-            result = subprocess.run(
+            process = subprocess.Popen(
                 full_command,
-                capture_output=True,
-                text=True,
-                timeout=self._timeout_seconds,
                 stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
             )
         except FileNotFoundError as exc:
             raise ThingsError(f"things client not found at {self._command[0]!r}") from exc
+
+        stdout_parts: list[str] = []
+        stderr_tail = _BoundedTail(STDERR_TAIL_MAX_CHARS)
+
+        stdout_thread = threading.Thread(
+            target=_drain_stdout,
+            args=(process.stdout, stdout_parts),
+            daemon=True,
+        )
+        stderr_thread = threading.Thread(
+            target=_drain_stderr_forward_and_tail,
+            args=(process.stderr, stderr_tail),
+            daemon=True,
+        )
+        stdout_thread.start()
+        stderr_thread.start()
+
+        try:
+            process.wait(timeout=self._timeout_seconds)
         except subprocess.TimeoutExpired as exc:
-            raw_stderr = exc.stderr
-            if isinstance(raw_stderr, bytes):
-                partial = raw_stderr.decode("utf-8", errors="replace").strip()
-            else:
-                partial = (raw_stderr or "").strip()
+            process.kill()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                process.wait(timeout=1.0)
+            stdout_thread.join(timeout=1.0)
+            stderr_thread.join(timeout=1.0)
+            partial = stderr_tail.text().strip()
             print(
                 f"things-bridge: things client subprocess timed out after "
                 f"{self._timeout_seconds}s: {partial or '<empty stderr>'}",
@@ -115,23 +148,73 @@ class ThingsSubprocessClient:
                 f"things client subprocess timed out after {self._timeout_seconds}s"
             ) from exc
 
-        stderr = (result.stderr or "").strip()
-        if stderr:
-            # Forward client stderr so operators see osascript diagnostics,
-            # fixture-load errors, etc. HTTP responses never include it.
-            print(stderr, file=sys.stderr, flush=True)
+        stdout_thread.join(timeout=1.0)
+        stderr_thread.join(timeout=1.0)
 
-        payload = _parse_payload(result.stdout or "", full_command, result.returncode)
+        stdout = "".join(stdout_parts)
+        payload = _parse_payload(stdout, full_command, process.returncode)
 
         if "error" in payload:
             raise _error_from_payload(payload)
 
-        if result.returncode != 0:
+        if process.returncode != 0:
             raise ThingsError(
-                f"things client exited {result.returncode} without a structured error body"
+                f"things client exited {process.returncode} without a structured error body"
             )
 
         return payload
+
+
+class _BoundedTail:
+    """Append-only tail buffer that drops oldest content past a char cap."""
+
+    def __init__(self, max_chars: int):
+        if max_chars <= 0:
+            raise ValueError("_BoundedTail: max_chars must be positive")
+        self._max = max_chars
+        self._parts: list[str] = []
+        self._size = 0
+        self._lock = threading.Lock()
+
+    def append(self, chunk: str) -> None:
+        if not chunk:
+            return
+        with self._lock:
+            if len(chunk) >= self._max:
+                self._parts = [chunk[-self._max :]]
+                self._size = len(self._parts[0])
+                return
+            self._parts.append(chunk)
+            self._size += len(chunk)
+            while self._size > self._max and self._parts:
+                dropped = self._parts.pop(0)
+                self._size -= len(dropped)
+
+    def text(self) -> str:
+        with self._lock:
+            return "".join(self._parts)
+
+
+def _drain_stdout(stream: IO[str] | None, sink: list[str]) -> None:
+    if stream is None:
+        return
+    try:
+        for chunk in iter(lambda: stream.read(4096), ""):
+            sink.append(chunk)
+    finally:
+        stream.close()
+
+
+def _drain_stderr_forward_and_tail(stream: IO[str] | None, tail: _BoundedTail) -> None:
+    if stream is None:
+        return
+    try:
+        for chunk in iter(lambda: stream.read(4096), ""):
+            sys.stderr.write(chunk)
+            sys.stderr.flush()
+            tail.append(chunk)
+    finally:
+        stream.close()
 
 
 def _parse_payload(stdout: str, command: list[str], returncode: int) -> dict[str, Any]:

--- a/tests/test_things_subprocess_client.py
+++ b/tests/test_things_subprocess_client.py
@@ -6,18 +6,20 @@
 
 Verifies the subprocess protocol the bridge speaks to any configured
 Things client CLI: argv construction, stdout envelope parsing, exit-code
-interpretation, stderr forwarding, timeout handling, and the mapping
-from error payloads to the typed :class:`ThingsError` hierarchy. The
-live-subprocess path is exercised in ``test_things_bridge_e2e.py``.
+interpretation, stderr forwarding, timeout handling, bounded stderr
+capture, and the mapping from error payloads to the typed
+:class:`ThingsError` hierarchy. The live-subprocess path is exercised in
+``test_things_bridge_e2e.py``.
 """
 
+import io
 import json
 import subprocess
-from typing import Any, cast
+from typing import Any
 
 import pytest
 
-from things_bridge.things_client import ThingsSubprocessClient
+from things_bridge.things_client import STDERR_TAIL_MAX_CHARS, ThingsSubprocessClient
 from things_models.errors import (
     ThingsError,
     ThingsNotFoundError,
@@ -25,11 +27,42 @@ from things_models.errors import (
 )
 
 
-class _FakeCompleted:
-    def __init__(self, stdout: str = "", stderr: str = "", returncode: int = 0):
-        self.stdout = stdout
-        self.stderr = stderr
-        self.returncode = returncode
+class _FakePopen:
+    """Minimal ``subprocess.Popen`` double for unit tests.
+
+    Emits ``stdout`` / ``stderr`` as text streams the client drains, and
+    surfaces ``returncode`` from :meth:`wait`. Pass ``timeout=True`` to make
+    the first :meth:`wait` raise :class:`subprocess.TimeoutExpired` so the
+    timeout branch can be exercised.
+    """
+
+    def __init__(
+        self,
+        args: list[str],
+        *,
+        stdout: str = "",
+        stderr: str = "",
+        returncode: int = 0,
+        timeout: bool = False,
+    ):
+        self.args = args
+        self.stdout = io.StringIO(stdout)
+        self.stderr = io.StringIO(stderr)
+        self._returncode = returncode
+        self._timeout = timeout
+        self._wait_calls = 0
+        self.returncode: int | None = None
+        self.killed = False
+
+    def wait(self, timeout: float | None = None) -> int:
+        self._wait_calls += 1
+        if self._timeout and self._wait_calls == 1:
+            raise subprocess.TimeoutExpired(cmd=self.args, timeout=timeout or 0.0)
+        self.returncode = self._returncode
+        return self._returncode
+
+    def kill(self) -> None:
+        self.killed = True
 
 
 @pytest.fixture
@@ -37,15 +70,15 @@ def client() -> ThingsSubprocessClient:
     return ThingsSubprocessClient(command=["fake-client"], timeout_seconds=1.0)
 
 
-def _patch_run(monkeypatch, completed: _FakeCompleted) -> list[list[str]]:
-    """Record each subprocess.run argv and return ``completed`` unchanged."""
+def _patch_popen(monkeypatch, **fake_kwargs) -> list[list[str]]:
+    """Record each ``subprocess.Popen`` argv and return a ``_FakePopen``."""
     recorded: list[list[str]] = []
 
-    def _run(argv, **kwargs):
+    def _popen(argv, **kwargs):
         recorded.append(argv)
-        return completed
+        return _FakePopen(argv, **fake_kwargs)
 
-    monkeypatch.setattr(subprocess, "run", _run)
+    monkeypatch.setattr(subprocess, "Popen", _popen)
     return recorded
 
 
@@ -57,7 +90,7 @@ def test_empty_command_rejected():
 
 @pytest.mark.covers_function("Fetch Things Data")
 def test_list_todos_sends_full_argv(monkeypatch, client):
-    recorded = _patch_run(monkeypatch, _FakeCompleted(stdout='{"todos": []}\n'))
+    recorded = _patch_popen(monkeypatch, stdout='{"todos": []}\n')
     client.list_todos(
         list_id="TMTodayListSource",
         project_id="p1",
@@ -85,7 +118,7 @@ def test_list_todos_sends_full_argv(monkeypatch, client):
 
 
 def test_list_todos_omits_unset_flags(monkeypatch, client):
-    recorded = _patch_run(monkeypatch, _FakeCompleted(stdout='{"todos": []}'))
+    recorded = _patch_popen(monkeypatch, stdout='{"todos": []}')
     client.list_todos()
     assert recorded == [["fake-client", "todos", "list"]]
 
@@ -112,7 +145,7 @@ def test_list_todos_parses_payload(monkeypatch, client):
             }
         ]
     }
-    _patch_run(monkeypatch, _FakeCompleted(stdout=json.dumps(payload)))
+    _patch_popen(monkeypatch, stdout=json.dumps(payload))
     todos = client.list_todos()
     assert [t.id for t in todos] == ["t1"]
 
@@ -137,27 +170,27 @@ def test_get_todo_argv_and_envelope(monkeypatch, client):
             "modification_date": None,
         }
     }
-    recorded = _patch_run(monkeypatch, _FakeCompleted(stdout=json.dumps(payload)))
+    recorded = _patch_popen(monkeypatch, stdout=json.dumps(payload))
     todo = client.get_todo("t2")
     assert recorded == [["fake-client", "todos", "show", "t2"]]
     assert todo.id == "t2"
 
 
 def test_list_projects_area_filter(monkeypatch, client):
-    recorded = _patch_run(monkeypatch, _FakeCompleted(stdout='{"projects": []}'))
+    recorded = _patch_popen(monkeypatch, stdout='{"projects": []}')
     client.list_projects(area_id="a1")
     assert recorded == [["fake-client", "projects", "list", "--area", "a1"]]
 
 
 def test_areas_commands(monkeypatch, client):
-    recorded = _patch_run(monkeypatch, _FakeCompleted(stdout='{"areas": []}'))
+    recorded = _patch_popen(monkeypatch, stdout='{"areas": []}')
     client.list_areas()
     assert recorded == [["fake-client", "areas", "list"]]
 
     recorded.clear()
-    _patch_run(
+    _patch_popen(
         monkeypatch,
-        _FakeCompleted(stdout='{"area": {"id": "a1", "name": "Personal", "tag_names": []}}'),
+        stdout='{"area": {"id": "a1", "name": "Personal", "tag_names": []}}',
     )
     area = client.get_area("a1")
     assert area.id == "a1"
@@ -165,30 +198,30 @@ def test_areas_commands(monkeypatch, client):
 
 @pytest.mark.covers_function("Fetch Things Data")
 def test_not_found_error_mapped(monkeypatch, client):
-    _patch_run(
+    _patch_popen(
         monkeypatch,
-        _FakeCompleted(stdout='{"error": "not_found", "detail": "todo 123 missing"}', returncode=4),
+        stdout='{"error": "not_found", "detail": "todo 123 missing"}',
+        returncode=4,
     )
     with pytest.raises(ThingsNotFoundError, match="todo 123 missing"):
         client.get_todo("123")
 
 
 def test_permission_denied_error_mapped(monkeypatch, client):
-    _patch_run(
+    _patch_popen(
         monkeypatch,
-        _FakeCompleted(
-            stdout='{"error": "things_permission_denied", "detail": "grant access"}',
-            returncode=5,
-        ),
+        stdout='{"error": "things_permission_denied", "detail": "grant access"}',
+        returncode=5,
     )
     with pytest.raises(ThingsPermissionError, match="grant access"):
         client.list_todos()
 
 
 def test_unknown_error_code_falls_back_to_things_error(monkeypatch, client):
-    _patch_run(
+    _patch_popen(
         monkeypatch,
-        _FakeCompleted(stdout='{"error": "something_else", "detail": "surprise"}', returncode=9),
+        stdout='{"error": "something_else", "detail": "surprise"}',
+        returncode=9,
     )
     with pytest.raises(ThingsError) as exc_info:
         client.list_todos()
@@ -203,28 +236,29 @@ def test_error_body_with_zero_exit_still_raises(monkeypatch, client):
     # JSON body is authoritative. An ``error`` key on stdout must raise even
     # if the CLI mistakenly reports rc=0; otherwise a buggy client could
     # return a synthetic empty envelope to the bridge without failing.
-    _patch_run(
+    _patch_popen(
         monkeypatch,
-        _FakeCompleted(stdout='{"error": "not_found", "detail": "x"}', returncode=0),
+        stdout='{"error": "not_found", "detail": "x"}',
+        returncode=0,
     )
     with pytest.raises(ThingsNotFoundError):
         client.list_todos()
 
 
 def test_non_zero_exit_without_error_body_raises_things_error(monkeypatch, client):
-    _patch_run(monkeypatch, _FakeCompleted(stdout='{"todos": []}', returncode=1))
+    _patch_popen(monkeypatch, stdout='{"todos": []}', returncode=1)
     with pytest.raises(ThingsError, match="exited 1"):
         client.list_todos()
 
 
 def test_empty_stdout_raises_things_error(monkeypatch, client):
-    _patch_run(monkeypatch, _FakeCompleted(stdout="", returncode=0))
+    _patch_popen(monkeypatch, stdout="", returncode=0)
     with pytest.raises(ThingsError, match="no JSON output"):
         client.list_todos()
 
 
 def test_non_json_stdout_raises_things_error(monkeypatch, client):
-    _patch_run(monkeypatch, _FakeCompleted(stdout="not json at all", returncode=0))
+    _patch_popen(monkeypatch, stdout="not json at all", returncode=0)
     with pytest.raises(ThingsError, match="non-JSON"):
         client.list_todos()
 
@@ -232,7 +266,7 @@ def test_non_json_stdout_raises_things_error(monkeypatch, client):
 def test_non_object_json_stdout_raises_things_error(monkeypatch, client):
     # A bare list on stdout is a protocol violation — without this guard
     # the bridge would index into a list as though it were a dict.
-    _patch_run(monkeypatch, _FakeCompleted(stdout='["oops"]', returncode=0))
+    _patch_popen(monkeypatch, stdout='["oops"]', returncode=0)
     with pytest.raises(ThingsError, match="non-object JSON"):
         client.list_todos()
 
@@ -241,7 +275,7 @@ def test_missing_binary_raises_things_error(monkeypatch, client):
     def _missing(*args, **kwargs):
         raise FileNotFoundError(2, "No such file or directory", "fake-client")
 
-    monkeypatch.setattr(subprocess, "run", _missing)
+    monkeypatch.setattr(subprocess, "Popen", _missing)
     with pytest.raises(ThingsError, match="not found"):
         client.list_todos()
 
@@ -250,14 +284,11 @@ def test_missing_binary_raises_things_error(monkeypatch, client):
 def test_timeout_surfaces_as_things_error_and_logs_partial_stderr(monkeypatch, capfd, client):
     # Operators troubleshoot stuck subprocesses from the bridge's stderr;
     # the HTTP response stays generic. Both paths are exercised here.
-    def _timeout(*args, **kwargs):
-        raise subprocess.TimeoutExpired(
-            cmd=args[0],
-            timeout=cast(float, kwargs.get("timeout")),
-            stderr="hung on automation prompt\n",
-        )
-
-    monkeypatch.setattr(subprocess, "run", _timeout)
+    _patch_popen(
+        monkeypatch,
+        stderr="hung on automation prompt\n",
+        timeout=True,
+    )
     with pytest.raises(ThingsError, match="timed out"):
         client.list_todos()
     err = capfd.readouterr().err
@@ -265,35 +296,36 @@ def test_timeout_surfaces_as_things_error_and_logs_partial_stderr(monkeypatch, c
     assert "hung on automation prompt" in err
 
 
-@pytest.mark.covers_function("Fetch Things Data")
-def test_timeout_decodes_bytes_stderr_without_b_prefix(monkeypatch, capfd, client):
-    # Regression: CPython populates ``TimeoutExpired.stderr`` as ``bytes`` even
-    # when ``subprocess.run`` was invoked with ``text=True``, so the timeout
-    # path must decode it explicitly. If the decode branch regresses, the
-    # operator-facing stderr line would show a ``b'...'`` byte-literal repr
-    # instead of the actual subprocess output.
-    def _timeout(*args, **kwargs):
-        raise subprocess.TimeoutExpired(
-            cmd=args[0],
-            timeout=cast(float, kwargs.get("timeout")),
-            stderr=b"hung on automation prompt\n",
-        )
-
-    monkeypatch.setattr(subprocess, "run", _timeout)
-    with pytest.raises(ThingsError, match="timed out"):
-        client.list_todos()
-    err = capfd.readouterr().err
-    assert "hung on automation prompt" in err
-    assert "b'hung" not in err
-
-
 def test_subprocess_stderr_is_forwarded(monkeypatch, capfd, client):
     # The bridge must surface the client's stderr unchanged — otherwise
     # osascript permission prompts, YAML-load errors, etc. are invisible
     # to operators.
-    _patch_run(
+    _patch_popen(
         monkeypatch,
-        _FakeCompleted(stdout='{"todos": []}', stderr="things-client-cli-applescript: warning\n"),
+        stdout='{"todos": []}',
+        stderr="things-client-cli-applescript: warning\n",
     )
     client.list_todos()
     assert "things-client-cli-applescript: warning" in capfd.readouterr().err
+
+
+@pytest.mark.covers_function("Fetch Things Data")
+def test_timeout_diagnostic_tail_is_bounded(monkeypatch, capfd, client):
+    # A misbehaving client that streams multi-megabyte diagnostics must
+    # not pin bridge memory. The bridge forwards stderr live and retains
+    # only a small tail for the timeout-diagnostic line. This test
+    # exercises the tail path by driving the client into the timeout
+    # branch with a stderr payload many multiples of the cap; the
+    # diagnostic excerpt must be ≤ STDERR_TAIL_MAX_CHARS.
+    flood = "x" * (STDERR_TAIL_MAX_CHARS * 4)
+    _patch_popen(monkeypatch, stderr=flood, timeout=True)
+    with pytest.raises(ThingsError, match="timed out"):
+        client.list_todos()
+    err = capfd.readouterr().err
+    diagnostic_lines = [line for line in err.splitlines() if "timed out" in line]
+    assert diagnostic_lines, "expected a timeout diagnostic line"
+    diagnostic = diagnostic_lines[-1]
+    # The diagnostic format is "...timed out after Ns: <tail excerpt>";
+    # split on ": " after the numeric timeout to isolate the excerpt.
+    excerpt = diagnostic.rsplit(": ", 1)[-1]
+    assert len(excerpt) <= STDERR_TAIL_MAX_CHARS


### PR DESCRIPTION
## Summary

- Replace `subprocess.run(capture_output=True, ...)` in `ThingsSubprocessClient._invoke` with `Popen` + drain threads so stderr is forwarded to the bridge's own stderr line-by-line as the child writes it (no unbounded in-memory buffer).
- Retain only a bounded tail (64 KiB, `STDERR_TAIL_MAX_CHARS`) for the timeout-diagnostic line; stdout is still collected in full because the JSON envelope must be parsed.
- Refresh ADR 0003 "Security" section: new "Bounded stderr capture" bullet and updated STRIDE DoS note.

Under the existing `ThreadingHTTPServer` request model, a buggy or rogue client CLI can no longer exhaust bridge memory by streaming multi-megabyte stderr diagnostics across concurrent requests.

Closes #72

## Test plan

- [x] `task test` — 471 passed, 3 skipped, coverage 76.93% (above 74% floor).
- [x] `task check` — lint, format, integration-isolation all green.
- [x] `task typecheck` — pyright clean.
- [x] `task verify-function-tests` — 60/60 leaf functions covered.
- [x] `task verify-design` — allocations clean.
- [x] `task verify-standards` — all standards green.
- [x] New test `test_timeout_diagnostic_tail_is_bounded` drives 256 KiB of stderr through the timeout path and asserts the diagnostic excerpt is ≤ `STDERR_TAIL_MAX_CHARS`.
- [x] Existing stderr-forwarding, timeout, and envelope-parsing coverage preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)