### PR TITLE
ci: pin uv version and upgrade setup-uv to v7 across workflows

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -9,6 +9,9 @@ inputs:
   go-task-version:
     description: go-task version to install
     default: "3.50.0"
+  uv-version:
+    description: uv version to install (passed through to astral-sh/setup-uv)
+    default: "0.11.7"
   keep-sorted-version:
     description: keep-sorted version to install
     default: "0.8.0"
@@ -71,8 +74,9 @@ runs:
   using: composite
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
+        version: ${{ inputs.uv-version }}
         enable-cache: true
 
     - name: Install d2

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
+          version: "0.11.7"
           enable-cache: true
 
       - name: Build sdist and wheel

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,8 +20,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
+          version: "0.11.7"
           enable-cache: true
 
       - name: Run pip-audit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,8 +116,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
+          version: "0.11.7"
           enable-cache: true
 
       - name: Sync venv

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -25,6 +25,9 @@
 #   2a. Third-party GitHub Actions enumerated in PINNED_ACTIONS use the
 #      sha+trailing-comment pin form (see issue #83 and the OpenSSF
 #      Scorecard `pinned-dependencies` check).
+#   2b. Every astral-sh/setup-uv invocation passes an explicit
+#      `with.version` so the uv binary can't silently upgrade between
+#      runs (see issue #84).
 #   3. Bash gating (shellcheck, shfmt) is wired into CI, treefmt, and
 #      lefthook per .claude/instructions/bash.md.
 #   4. Markdown (mdformat) and TOML (taplo) formatters are wired into
@@ -199,6 +202,7 @@ fi
 PINNED_ACTIONS=(
   # keep-sorted start
   actions/checkout
+  astral-sh/setup-uv
   # keep-sorted end
 )
 
@@ -239,6 +243,50 @@ if [[ ${pinned_drift} -ne 0 ]]; then
 fi
 
 echo "verify-standards: third-party actions in PINNED_ACTIONS (${PINNED_ACTIONS[*]}) use sha+comment form."
+
+# ---------------------------------------------------------------------------
+# Every astral-sh/setup-uv invocation pins the uv binary version.
+# ---------------------------------------------------------------------------
+# Without an explicit `version:` input, setup-uv installs whatever
+# `uv-version` or `latest` resolves to at run time — drift we don't
+# want on a security-signing toolchain. The setup-toolchain composite
+# action exposes `uv-version` as a top-level input whose default feeds
+# `with.version`; direct workflow invocations hardcode the literal
+# until the central tool-versions manifest from #87 is available.
+uv_version_drift=0
+uv_version_matches=0
+for wf in .github/workflows/*.yml .github/actions/*/action.yml; do
+  [[ -f "${wf}" ]] || continue
+  # yq emits one document per `uses: astral-sh/setup-uv@...` step with
+  # its `with` block; absence of a `.with.version` key (or an empty
+  # string) is the drift signal.
+  while IFS=$'\t' read -r step_wf version_value; do
+    [[ -n "${step_wf}" ]] || continue
+    uv_version_matches=$((uv_version_matches + 1))
+    if [[ -z "${version_value}" || "${version_value}" == "null" ]]; then
+      echo "verify-standards: ${wf} invokes astral-sh/setup-uv without 'with.version' set." >&2
+      uv_version_drift=1
+    fi
+  done < <(
+    WF="${wf}" yq eval -o=tsv '
+      [.. | select(type == "!!map" and has("uses") and (.uses | test("^astral-sh/setup-uv@")))
+        | [(env(WF) // "wf"), (.with.version // "")]
+      ] | .[] | @tsv
+    ' "${wf}" 2>/dev/null
+  )
+done
+
+if [[ ${uv_version_drift} -ne 0 ]]; then
+  echo "  Expected: with.version: \"<pin>\" (or \${{ inputs.uv-version }} inside the composite action)." >&2
+  echo "  Rationale: pin the uv binary so CI can't silently upgrade. See issue #84." >&2
+  exit 1
+fi
+
+if [[ ${uv_version_matches} -eq 0 ]]; then
+  echo "verify-standards: no astral-sh/setup-uv invocations found — skipping uv-version pin check." >&2
+else
+  echo "verify-standards: all ${uv_version_matches} astral-sh/setup-uv invocations pin 'with.version'."
+fi
 
 # Bash tooling: shellcheck + shfmt must be wired into CI, treefmt, and
 # lefthook per .claude/instructions/bash.md. Strip comments before


### PR DESCRIPTION
## Summary

- Bump `setup-toolchain/action.yml` from `astral-sh/setup-uv@v5` (sha `d4b2f3b6...`) to `@v7` (sha `37802adc...`), matching `release-publish.yml`.
- Add a `uv-version` input to the composite action (default `0.11.7`) and pass it via `with.version` so the uv binary can't drift.
- Hardcode the same pin on the three direct invocations in `security.yml`, `test.yml`, `release-publish.yml`, and sha-pin the two bare `@v7` refs.
- Extend `scripts/verify-standards.sh`: add `astral-sh/setup-uv` to `PINNED_ACTIONS` and a new check asserting `with.version` is set everywhere `setup-uv` is used.

## Why

Before: `setup-toolchain` was on `setup-uv@v5` while every other workflow was on `@v7` — a silent version split — and none passed `with.version`, so the uv binary itself could silently upgrade between runs. Pinning the action **and** the binary closes both drift surfaces.

The issue calls out #87 (central tool-versions manifest) as the intended source of truth for `uv-version`; this PR uses a literal for the interim, which #87 will replace.

## Test plan

- [x] `bash scripts/verify-standards.sh` passes; the new check reports "all 4 astral-sh/setup-uv invocations pin 'with.version'".
- [x] Negative path: deleting `version:` from one invocation causes verify-standards to exit 1 with a targeted message.
- [x] `shellcheck scripts/verify-standards.sh` — clean.
- [x] `treefmt --ci` — clean.
- [ ] CI (setup-toolchain cycles with the new uv version; release-publish / test / security jobs use the pinned v7).

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)