### PR TITLE
feat(benchmark): pytest-benchmark suite with scheduled CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,7 +28,7 @@ jobs:
     # run-away test.
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup-toolchain
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+name: Benchmark
+
+# Benchmarks are too noisy on shared GitHub runners to gate every PR
+# (see ADR 0029 and benchmarks/README.md for the threshold rationale).
+# Run on a weekly schedule so regressions surface within a week of
+# landing, and expose workflow_dispatch so a reviewer can trigger a
+# run on-demand when refreshing the baseline.
+#
+# Schedule is offset from the Mutation workflow (Mon 04:00 UTC) to
+# avoid sharing a runner window on a single queue day. Sunday 05:00
+# UTC means the results land early in the week when they're most
+# likely to be noticed.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 0" # 05:00 UTC every Sunday
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    # Hard cap below the default 6h runner limit. A clean benchmark
+    # run is well under a minute; 30min gives head-room for runner
+    # warm-up and repeated rounds without burning compute on a
+    # run-away test.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare compare flags
+        id: compare
+        # The committed baseline is optional: on the first run after
+        # this workflow is added, the file will not yet exist. Only
+        # wire --benchmark-compare / --benchmark-compare-fail when
+        # the baseline is present so the initial run can land the
+        # results JSON as an artifact without failing.
+        run: |
+          baseline="benchmarks/baselines/ci-linux-x86_64.json"
+          if [[ -f "${baseline}" ]]; then
+            echo "flags=--benchmark-compare=ci-linux-x86_64 --benchmark-compare-fail=mean:25%" >> "${GITHUB_OUTPUT}"
+            echo "Baseline found at ${baseline} — gating on 25% mean regression."
+          else
+            echo "flags=" >> "${GITHUB_OUTPUT}"
+            echo "No baseline at ${baseline} — running in reporting-only mode." \
+                 "See benchmarks/README.md § 'Baseline refresh procedure'."
+          fi
+
+      - name: Run benchmark suite
+        run: |
+          task benchmark -- \
+            --benchmark-json=benchmarks/results.json \
+            ${{ steps.compare.outputs.flags }}
+
+      - name: Upload results artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-results
+          path: benchmarks/results.json
+          if-no-files-found: warn

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,7 @@ Every repeatable operation is exposed through the task runner. Run
 | Task                                       | Description                                                                                                                                               |
 | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `task test`                                | Run the pytest suite with coverage (unit by default; pass `-- --fast`, `-- --integration`, or `-- --all`). Fails below the `--cov-fail-under` floor.      |
+| `task benchmark`                           | Run the pytest-benchmark suite under `benchmarks/` (scheduled weekly in CI; see `benchmarks/README.md`).                                                  |
 | `task lint`                                | Run all configured linters (shellcheck, ruff check, keep-sorted).                                                                                         |
 | `task format`                              | Run all configured formatters (shfmt, ruff format, mdformat, taplo). Pass `-- --check` for diff-only mode (CI uses this).                                 |
 | `task typecheck`                           | Run mypy + pyright (strict) on `src/` and `tests/`.                                                                                                       |
@@ -135,6 +136,18 @@ immediately. Rationale in
   below the new score (so fluctuation doesn't flake CI).
 - **Lowering the floor** (rare): only with a commit-message
   justification; never lower silently. The floor never goes below 0.
+
+### Benchmarks
+
+`task benchmark` runs the pytest-benchmark suite under `benchmarks/`
+covering the token hot path (`parse_token`, `sign_token`,
+`verify_token`, `create_token_pair`) and the SQLite store
+(`get_family` for a family with 200 scopes, `get_token`,
+`create_token`). The suite is scheduled weekly via
+`.github/workflows/benchmark.yml` — too noisy on shared runners to
+gate every PR. Rationale and baseline-refresh procedure in
+[`benchmarks/README.md`](benchmarks/README.md) and
+[ADR 0029](design/decisions/0029-benchmark-suite.md).
 
 ### Schema migrations
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,6 +12,11 @@ tasks:
     cmds:
       - scripts/test.sh {{.CLI_ARGS}}
 
+  benchmark:
+    desc: Run the pytest-benchmark suite under benchmarks/. See benchmarks/README.md for the regression threshold and baseline refresh procedure.
+    cmds:
+      - scripts/benchmark.sh {{.CLI_ARGS}}
+
   lint:
     desc: Run all configured linters.
     cmds:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,103 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# Benchmarks
+
+Performance benchmarks for the token hot path and SQLite store, run
+on a schedule in CI to catch regressions. Originating standard:
+`.claude/instructions/testing-standards.md` § Performance —
+"Benchmark suite". See [ADR 0029](../design/decisions/0029-benchmark-suite.md)
+for the decision record.
+
+## Scope
+
+Each benchmark file covers one layer of the stack:
+
+- `test_tokens_benchmark.py` — `parse_token`, `sign_token`,
+  `verify_token` (the per-request hot path), and `create_token_pair`
+  (which underpins both token creation and refresh).
+- `test_store_benchmark.py` — `TokenStore.get_family` for a family
+  with 200 scopes (the "DB read of a family with many scopes" case
+  from issue #40), plus `get_token` and `create_token` for
+  steady-state DB numbers.
+
+Benchmarks live in a sibling `benchmarks/` tree — not inside
+`tests/` — because the project-wide `[tool.pytest.ini_options].addopts`
+wires the coverage floor (`--cov=src --cov-fail-under=74`). Coverage
+against the benchmark suite alone would always fail. The
+`scripts/benchmark.sh` wrapper overrides `addopts` when running the
+benchmarks.
+
+## Running locally
+
+```bash
+task benchmark
+```
+
+Pass-through arguments are forwarded to `pytest`:
+
+```bash
+# Narrow to a single benchmark
+task benchmark -- -k verify_token
+
+# Save a local baseline
+task benchmark -- --benchmark-save=local
+
+# Compare against a saved baseline
+task benchmark -- --benchmark-compare=ci-linux-x86_64
+```
+
+Baselines are stored under `benchmarks/baselines/` — that directory
+is the configured `--benchmark-storage` root.
+
+## Regression threshold
+
+The documented threshold is **25 % mean runtime** (i.e. a benchmark
+whose mean runtime increases by more than 25 % vs the most recent
+committed baseline fails the scheduled CI job).
+
+The threshold is deliberately loose. It balances:
+
+- GitHub-hosted runner variance (second-by-second noise can reach
+  10-15 % for nanosecond-scale benchmarks like `parse_token`);
+- initial signal — we would rather catch a catastrophic 2× regression
+  than flake on normal noise;
+- a tightening path — once the suite has run for a few weeks and the
+  baseline stabilises, the threshold can be lowered in a follow-up.
+
+The gate applies only when `benchmarks/baselines/ci-linux-x86_64.json`
+exists. If the baseline file is absent the scheduled job runs the
+benchmarks, prints the table, and uploads the JSON artifact without
+failing — see `Baseline refresh procedure` below.
+
+## Baseline refresh procedure
+
+Baselines are CI-generated rather than author-generated so the numbers
+match the runner that will later be compared against.
+
+1. Trigger the benchmark workflow manually
+   (`gh workflow run benchmark.yml`).
+2. Download the artifact produced by the run: the JSON report lands
+   at `benchmarks/results.json`.
+3. Rename it to `benchmarks/baselines/ci-linux-x86_64.json`
+   (or whatever target runner it is for).
+4. Commit under a `chore(benchmark):` prefix and open a PR. Include
+   a brief note on what prompted the refresh (e.g. "after #123
+   intentionally traded 10 % on get_family for DB correctness").
+
+First baseline: the initial scheduled run after this PR merges is
+what seeds `ci-linux-x86_64.json`. The threshold gate is inactive
+until that baseline is committed.
+
+## What this is _not_
+
+Benchmarks measure; they do not assert a service-level budget. The
+per-request latency budget is documented in
+`design/DESIGN.md` § Performance budget and enforced by tests
+carrying the `perf_budget` pytest marker. If the two disagree
+(benchmarks regressed but the budget test still passes), the
+benchmark is the leading indicator — the budget is a ceiling, not a
+target.

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Shared fixtures for the agent-auth benchmark suite.
+
+The benchmark tree deliberately sits alongside ``tests/`` rather than
+inside it so the coverage gate in ``pyproject.toml`` (which runs on
+every ``pytest`` invocation against ``tests/``) does not apply to
+benchmarks. See ``benchmarks/README.md``.
+"""
+
+import os
+import tempfile
+from collections.abc import Iterator
+
+import pytest
+
+from agent_auth.config import Config
+from agent_auth.keys import EncryptionKey, SigningKey
+from agent_auth.store import TokenStore
+from agent_auth.tokens import create_token_pair
+
+LARGE_FAMILY_SCOPE_COUNT = 200
+
+
+@pytest.fixture
+def tmp_dir() -> Iterator[str]:
+    with tempfile.TemporaryDirectory() as d:
+        yield d
+
+
+@pytest.fixture
+def signing_key() -> SigningKey:
+    return SigningKey(os.urandom(32))
+
+
+@pytest.fixture
+def encryption_key() -> EncryptionKey:
+    return EncryptionKey(os.urandom(32))
+
+
+@pytest.fixture
+def config(tmp_dir: str) -> Config:
+    return Config(
+        db_path=os.path.join(tmp_dir, "tokens.db"),
+        log_path=os.path.join(tmp_dir, "audit.log"),
+    )
+
+
+@pytest.fixture
+def store(config: Config, encryption_key: EncryptionKey) -> TokenStore:
+    return TokenStore(config.db_path, encryption_key)
+
+
+@pytest.fixture
+def family_with_many_scopes(store: TokenStore) -> str:
+    """A token family pre-populated with a large scope map.
+
+    Models the "DB read of a family with many scopes" case named in
+    issue #40: encrypted JSON blob decrypt cost scales with scope
+    count, so ``get_family`` is the DB-side hot path we want a
+    baseline for.
+    """
+    family_id = "fam_large"
+    scopes = {f"scope_{i}": "allow" for i in range(LARGE_FAMILY_SCOPE_COUNT)}
+    store.create_family(family_id, scopes)
+    return family_id
+
+
+@pytest.fixture
+def family_with_one_scope(store: TokenStore) -> str:
+    """A token family with a single scope, for steady-state benchmarks."""
+    family_id = "fam_small"
+    store.create_family(family_id, {"things:read": "allow"})
+    return family_id
+
+
+@pytest.fixture
+def issued_token_pair(
+    store: TokenStore,
+    signing_key: SigningKey,
+    config: Config,
+    family_with_one_scope: str,
+) -> tuple[str, str]:
+    """An (access_token, refresh_token) pair already persisted in the store."""
+    return create_token_pair(signing_key, store, family_with_one_scope, config)

--- a/benchmarks/test_store_benchmark.py
+++ b/benchmarks/test_store_benchmark.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Benchmarks for the SQLite TokenStore hot path."""
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from agent_auth.store import TokenStore
+
+
+def test_get_family_with_many_scopes_benchmark(
+    benchmark: BenchmarkFixture,
+    store: TokenStore,
+    family_with_many_scopes: str,
+) -> None:
+    """The 'DB read of a family with many scopes' case named in issue #40.
+
+    ``get_family`` decrypts a JSON blob whose size scales with scope
+    count, so the cost is dominated by AES-GCM decrypt + json.loads.
+    """
+    benchmark(store.get_family, family_with_many_scopes)
+
+
+def test_get_token_benchmark(
+    benchmark: BenchmarkFixture,
+    store: TokenStore,
+    issued_token_pair: tuple[str, str],
+) -> None:
+    access_token, _ = issued_token_pair
+    from agent_auth.tokens import parse_token
+
+    _, token_id, _ = parse_token(access_token)
+    benchmark(store.get_token, token_id)
+
+
+def test_create_token_benchmark(
+    benchmark: BenchmarkFixture,
+    store: TokenStore,
+    family_with_one_scope: str,
+) -> None:
+    """Steady-state token insert (no signing cost — isolates the DB write)."""
+    from itertools import count
+
+    from agent_auth.tokens import generate_token_id
+
+    counter = count()
+
+    def _insert() -> None:
+        token_id = generate_token_id()
+        # Per-iteration unique token_id so the PRIMARY KEY constraint
+        # never fires; the ``counter`` is only here to guard against
+        # pytest-benchmark potentially reusing IDs if generate_token_id
+        # ever switched to a deterministic generator.
+        next(counter)
+        store.create_token(
+            token_id=token_id,
+            hmac_signature="0" * 64,
+            family_id=family_with_one_scope,
+            token_type="access",
+            expires_at="2099-01-01T00:00:00+00:00",
+        )
+
+    benchmark(_insert)

--- a/benchmarks/test_tokens_benchmark.py
+++ b/benchmarks/test_tokens_benchmark.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Benchmarks for the token hot path: parse, sign, verify, and pair creation."""
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from agent_auth.config import Config
+from agent_auth.keys import SigningKey
+from agent_auth.store import TokenStore
+from agent_auth.tokens import (
+    PREFIX_ACCESS,
+    create_token_pair,
+    generate_token_id,
+    parse_token,
+    sign_token,
+    verify_token,
+)
+
+
+def test_parse_token_benchmark(benchmark: BenchmarkFixture, signing_key: SigningKey) -> None:
+    token = sign_token(generate_token_id(), PREFIX_ACCESS, signing_key)
+    benchmark(parse_token, token)
+
+
+def test_sign_token_benchmark(benchmark: BenchmarkFixture, signing_key: SigningKey) -> None:
+    token_id = generate_token_id()
+    benchmark(sign_token, token_id, PREFIX_ACCESS, signing_key)
+
+
+def test_verify_token_benchmark(benchmark: BenchmarkFixture, signing_key: SigningKey) -> None:
+    """Verify-token is the hot path named in issue #40 — called on every authed request."""
+    token = sign_token(generate_token_id(), PREFIX_ACCESS, signing_key)
+    benchmark(verify_token, token, signing_key)
+
+
+def test_create_token_pair_benchmark(
+    benchmark: BenchmarkFixture,
+    store: TokenStore,
+    signing_key: SigningKey,
+    config: Config,
+    family_with_one_scope: str,
+) -> None:
+    """Covers both 'token create' and 'refresh' from the issue — a refresh is a new pair."""
+    benchmark(create_token_pair, signing_key, store, family_with_one_scope, config)

--- a/design/decisions/0029-benchmark-suite.md
+++ b/design/decisions/0029-benchmark-suite.md
@@ -1,0 +1,122 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# ADR 0029 — Benchmark suite with pytest-benchmark
+
+## Status
+
+Accepted — 2026-04-23.
+
+## Context
+
+`.claude/instructions/testing-standards.md` § Performance mandates a
+maintained benchmark suite that runs in CI on a schedule to catch
+regressions. Before this ADR no benchmark suite existed; the per-
+request latency budget documented in `design/DESIGN.md` § Performance
+budget was enforced only by unit tests carrying the `perf_budget`
+pytest marker — useful for asserting a ceiling, but not for seeing
+*trends* in the cost of the hot path.
+
+Issue #40 names four benchmark targets: token validation (the hot
+path), token create, refresh, and DB read of a family with many
+scopes. The decision below picks a tool, a layout, and a regression
+gate compatible with the existing CI topology.
+
+## Considered alternatives
+
+### Airspeed Velocity (`asv`)
+
+Purpose-built for tracking benchmark time series across commits with
+a hosted HTML dashboard.
+
+**Rejected** because:
+
+- Requires a persistent storage location (git branch, S3 bucket, or
+  GitHub Pages deployment) for the historical database, which this
+  project does not otherwise operate.
+- Adds a second test runner alongside pytest for a benefit we do not
+  need here — the hot-path surface is small enough that a pytest
+  table in a CI log is enough signal.
+
+### Hand-rolled `time.perf_counter` loop
+
+Zero new dependencies.
+
+**Rejected** because:
+
+- No statistical rigour out of the box (warm-up, min-rounds,
+  calibration, outlier handling). pytest-benchmark gives these
+  defaults tuned for noisy CI runners.
+- Re-solving a solved problem goes against the `.claude/instructions`
+  bias toward off-the-shelf standard tooling where reasonable.
+
+### Benchmarks interleaved with unit tests (under `tests/`)
+
+Shorter import path and fewer directories.
+
+**Rejected** because:
+
+- `[tool.pytest.ini_options].addopts` already wires the coverage
+  floor (`--cov=src --cov-fail-under=74`) for every pytest run. A
+  benchmark-only pytest invocation would need to override the flag,
+  and routine `task test` runs would pick up the benchmarks as
+  regular tests and slow the suite.
+- Separate tree aligns with `.claude/instructions/testing-standards.md`
+  which discusses benchmarks independently from the unit and chaos
+  layers.
+
+## Decision
+
+1. **Tool**: `pytest-benchmark` 5.x, added to
+   `[project.optional-dependencies].dev` so developers get it on
+   `uv sync --extra dev` and CI gets it via the same path.
+2. **Layout**: sibling `benchmarks/` tree with its own `conftest.py`.
+   A thin `scripts/benchmark.sh` wrapper overrides the project
+   pytest `addopts` so coverage does not run against benchmarks.
+3. **Coverage**: the four targets named in issue #40 —
+   `verify_token`, `create_token_pair`, `TokenStore.get_family`
+   (large scope count), plus adjacent steady-state points
+   (`parse_token`, `sign_token`, `get_token`, `create_token`).
+4. **Schedule**: Sunday 05:00 UTC weekly, offset from the Mutation
+   workflow (Monday 04:00 UTC) so the two long-running scheduled
+   workflows do not queue for the same runner window.
+5. **Regression gate**: 25 % mean runtime, evaluated via
+   `--benchmark-compare-fail=mean:25%` against a committed baseline
+   at `benchmarks/baselines/ci-linux-x86_64.json`. The gate is
+   skipped when the baseline is absent so the first scheduled run
+   can capture a baseline without failing.
+6. **Baseline refresh**: CI-generated, human-committed. The
+   procedure lives in `benchmarks/README.md` — operator downloads
+   the JSON artifact from a scheduled run, renames, commits.
+7. **Standards gate**: `scripts/verify-standards.sh` asserts the
+   `benchmarks/` directory contains at least one `test_*.py` and
+   the `benchmark.yml` workflow exists and triggers on `schedule:`,
+   so later drift (someone deleting the benchmarks while leaving
+   the workflow, or vice versa) fails verify-standards.
+
+## Consequences
+
+- Developers get a `task benchmark` command that produces a stable
+  per-run report table, without touching the unit-test workflow.
+- The regression gate is loose (25 %) on initial adoption and will
+  flake less than a tighter gate would on GitHub-hosted runner
+  variance. Tightening happens once the baseline stabilises; that
+  is tracked inline in `benchmarks/README.md` rather than as a
+  separate issue.
+- Baselines live in-repo under `benchmarks/baselines/`. This
+  couples the repo to a Linux-on-x86_64 runner assumption; a future
+  macOS benchmark workflow would need its own baseline file
+  (`ci-darwin-<arch>.json`). Out-of-scope today.
+- The benchmark suite is distinct from the perf-budget tests: the
+  budget tests assert a ceiling per request; the benchmarks expose
+  trends. Both remain required by `testing-standards.md`.
+
+## Follow-ups
+
+- First scheduled run after merge produces the initial baseline
+  artifact; a follow-up PR commits it. No separate issue — tracked
+  inline in `benchmarks/README.md` § "Baseline refresh procedure".
+- Tightening the 25 % threshold once we have 4+ weeks of runs.

--- a/design/decisions/README.md
+++ b/design/decisions/README.md
@@ -77,3 +77,5 @@ is linked from this index.
   — supersedes ADR 0022. Every authenticated endpoint consumes from a token-bucket keyed on `family_id`; 429 `{"error":"rate_limited"}` with `Retry-After` on exhaustion. Default 600 req/min; set `rate_limit_per_minute: 0` to opt back into ADR 0022's deferral.
 - [ADR 0028 — HMAC-chained audit log for tamper-evident integrity](0028-audit-log-hmac-chain.md)
   — closes AU-9. Every audit entry carries a `chain_hmac = HMAC-SHA256(audit_chain_key, prev_hmac || canonical(entry))`; `agent-auth verify-audit` detects modify / delete / insert. `SCHEMA_VERSION` bumps 1→2; v1 logs are rolled over to `<path>.pre-chain-v2-*` on upgrade.
+- [ADR 0029 — Benchmark suite with pytest-benchmark](0029-benchmark-suite.md)
+  — weekly `benchmark.yml` workflow runs a `benchmarks/` pytest tree against a committed `ci-linux-x86_64.json` baseline with a 25 % mean-runtime regression gate; `scripts/verify-standards.sh` enforces the suite + workflow stay present.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
     "openapi-spec-validator>=0.7",
     "pip-audit>=2.7",
     "pyright>=1.1.408",
+    "pytest-benchmark>=5.0",
     "pytest-cov>=5.0",
     "pytest>=8.0",
     "reuse>=4.0",
@@ -136,8 +137,8 @@ select = ["E", "F", "I", "UP", "B", "SIM", "RUF"]
 [tool.mypy]
 python_version = "3.11"
 strict = true
-# Point mypy at both trees. CLI invocation stays `mypy src tests`.
-files = ["src", "tests"]
+# Point mypy at the three trees. CLI invocation stays `mypy`.
+files = ["src", "tests", "benchmarks"]
 
 # Third-party imports without type stubs. These are separately
 # addressed by pulling in types-* packages as they become available;

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -34,22 +34,6 @@
       "reportMissingTypeStubs": "none"
     },
     {
-      "root": "benchmarks",
-      "reportUnknownParameterType": "none",
-      "reportUnknownVariableType": "none",
-      "reportUnknownMemberType": "none",
-      "reportUnknownArgumentType": "none",
-      "reportUnknownLambdaType": "none",
-      "reportMissingParameterType": "none",
-      "reportMissingTypeArgument": "none",
-      "reportPrivateUsage": "none",
-      "reportUnusedImport": "none",
-      "reportUnusedFunction": "none",
-      "reportUnnecessaryCast": "none",
-      "reportUnnecessaryComparison": "none",
-      "reportMissingTypeStubs": "none"
-    },
-    {
       "root": "src/tests_support",
       "reportUnknownParameterType": "none",
       "reportUnknownVariableType": "none",

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,7 +1,8 @@
 {
   "include": [
     "src",
-    "tests"
+    "tests",
+    "benchmarks"
   ],
   "exclude": [
     ".venv",
@@ -18,6 +19,22 @@
   "executionEnvironments": [
     {
       "root": "tests",
+      "reportUnknownParameterType": "none",
+      "reportUnknownVariableType": "none",
+      "reportUnknownMemberType": "none",
+      "reportUnknownArgumentType": "none",
+      "reportUnknownLambdaType": "none",
+      "reportMissingParameterType": "none",
+      "reportMissingTypeArgument": "none",
+      "reportPrivateUsage": "none",
+      "reportUnusedImport": "none",
+      "reportUnusedFunction": "none",
+      "reportUnnecessaryCast": "none",
+      "reportUnnecessaryComparison": "none",
+      "reportMissingTypeStubs": "none"
+    },
+    {
+      "root": "benchmarks",
       "reportUnknownParameterType": "none",
       "reportUnknownVariableType": "none",
       "reportUnknownMemberType": "none",

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Run the pytest-benchmark suite under benchmarks/ inside the project
+# virtualenv. Override the pyproject.toml addopts (which wire
+# --cov=src --cov-fail-under=74 for the test suite) so coverage does
+# not run against the benchmark tree — benchmarks measure performance
+# and exercise only a thin slice of src/, so the unit-test coverage
+# floor would always fail.
+#
+# Arguments after the script name are forwarded to pytest, e.g.
+#   scripts/benchmark.sh --benchmark-save=ci-linux-x86_64
+#   scripts/benchmark.sh --benchmark-json=benchmarks/results.json
+#   scripts/benchmark.sh -k verify_token
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_bootstrap_venv.sh
+source "${SCRIPT_DIR}/_bootstrap_venv.sh"
+
+# ``--override-ini=addopts=`` clears the coverage + fail-under flags
+# configured in pyproject.toml [tool.pytest.ini_options]. Columns are
+# pinned so the CI log is stable and readable across runs.
+exec uv run --no-sync pytest \
+  --override-ini="addopts=" \
+  --benchmark-columns=min,mean,median,stddev,ops,rounds \
+  --benchmark-sort=mean \
+  --benchmark-storage=benchmarks/baselines \
+  benchmarks/ \
+  "$@"

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -65,6 +65,10 @@
 #      operations AND at least one test carries the perf_budget
 #      pytest marker, per .claude/instructions/testing-standards.md
 #      "Performance budget".
+#  15. A benchmarks/ directory contains at least one test_*.py file
+#      AND a scheduled CI workflow (.github/workflows/benchmark.yml)
+#      invokes it on `on: schedule:`, per
+#      .claude/instructions/testing-standards.md "Benchmark suite".
 
 set -euo pipefail
 
@@ -1911,3 +1915,82 @@ if [[ ${notifier_drift} -ne 0 ]]; then
 fi
 
 echo "verify-standards: notification plugin is URL-based (out-of-process); no importlib.import_module in server.py."
+
+# ---------------------------------------------------------------------------
+# Benchmark suite with scheduled CI workflow.
+# ---------------------------------------------------------------------------
+# .claude/instructions/testing-standards.md (Performance — "Benchmark
+# suite") requires a maintained benchmark suite that runs in CI on a
+# schedule. The deterministic regression check asserts both sides
+# cannot silently drift apart:
+#
+#   1. benchmarks/ exists and contains at least one test_*.py file,
+#      so deleting the benchmarks but leaving the workflow behind
+#      fails the gate.
+#   2. .github/workflows/benchmark.yml exists, has an `on:` block
+#      containing a `schedule:` trigger, and its steps invoke either
+#      `task benchmark` or a direct pytest run against benchmarks/,
+#      so deleting the workflow (or accidentally narrowing it to
+#      workflow_dispatch-only) fails the gate.
+
+benchmark_missing=0
+
+fail_benchmark_check() {
+  echo "verify-standards: $1" >&2
+  echo "  $2" >&2
+  benchmark_missing=1
+}
+
+benchmarks_dir="benchmarks"
+if [[ ! -d "${benchmarks_dir}" ]]; then
+  fail_benchmark_check \
+    "${benchmarks_dir}/ directory is missing." \
+    "Add a pytest-benchmark suite per .claude/instructions/testing-standards.md § Performance."
+else
+  # Accept any test_*.py under benchmarks/ so authors are free to
+  # split the suite across files. compgen keeps the shell-glob match
+  # compatible with `set -u`.
+  if ! compgen -G "${benchmarks_dir}/test_*.py" >/dev/null; then
+    fail_benchmark_check \
+      "${benchmarks_dir}/ contains no test_*.py benchmark files." \
+      "Add at least one pytest-benchmark test file (see benchmarks/README.md)."
+  fi
+fi
+
+benchmark_workflow=".github/workflows/benchmark.yml"
+if [[ ! -f "${benchmark_workflow}" ]]; then
+  fail_benchmark_check \
+    "${benchmark_workflow} is missing." \
+    "Add a scheduled GitHub Actions workflow that runs the benchmark suite."
+else
+  # Match ``on:`` and ``schedule:`` inside it. Allow either the
+  # short form (``on: [schedule]``) or the mapping form
+  # (``on:\n  schedule:``). Strip comments so a disabled sample
+  # does not satisfy the gate.
+  workflow_stripped="$(sed -E 's/(^|[[:space:]])#.*$//' "${benchmark_workflow}")"
+  if ! grep -qE "^on:" <<<"${workflow_stripped}"; then
+    fail_benchmark_check \
+      "${benchmark_workflow} has no 'on:' trigger block." \
+      "Add 'on:' with a 'schedule:' entry."
+  elif ! grep -qE "^[[:space:]]*schedule:" <<<"${workflow_stripped}"; then
+    fail_benchmark_check \
+      "${benchmark_workflow} does not trigger on 'schedule:'." \
+      "Add a 'schedule:' cron entry inside the 'on:' block."
+  fi
+
+  # The workflow must actually invoke the benchmark suite — accept
+  # either the ``task benchmark`` wrapper or a raw ``pytest
+  # benchmarks/`` invocation, so the gate does not mandate the
+  # Taskfile indirection specifically.
+  if ! grep -qE "task[[:space:]]+benchmark\b|pytest[[:space:]].*benchmarks/" <<<"${workflow_stripped}"; then
+    fail_benchmark_check \
+      "${benchmark_workflow} does not invoke the benchmark suite." \
+      "Call 'task benchmark' or run pytest against 'benchmarks/' in the workflow steps."
+  fi
+fi
+
+if [[ ${benchmark_missing} -ne 0 ]]; then
+  exit 1
+fi
+
+echo "verify-standards: benchmark suite exists under ${benchmarks_dir}/ and ${benchmark_workflow} runs it on a schedule."

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,7 @@ dev = [
     { name = "pip-audit" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "reuse" },
     { name = "testcontainers" },
@@ -43,6 +44,7 @@ requires-dist = [
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.408" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "reuse", marker = "extra == 'dev'", specifier = ">=4.0" },
@@ -532,7 +534,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1276,6 +1278,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "py-serializable"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1481,6 +1492,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `benchmarks/` tree with `pytest-benchmark` coverage for the token hot path (`parse_token`, `sign_token`, `verify_token`, `create_token_pair`) and the SQLite `TokenStore` read/write surface (incl. the 200-scope family read named in #40).
- Introduces `.github/workflows/benchmark.yml` on a weekly schedule (Sunday 05:00 UTC, offset from the mutation workflow). The job gates on 25 % mean-runtime regression once a baseline is committed at `benchmarks/baselines/ci-linux-x86_64.json`; runs in reporting-only mode until then (see `benchmarks/README.md` § _Baseline refresh procedure_).
- `scripts/verify-standards.sh` gains a new gate (item 15) asserting the `benchmarks/` tree and the scheduled workflow stay present and coupled — deleting either fails `task verify-standards`.
- `task benchmark` wraps the suite, overriding the project-wide `addopts` so coverage does not run against benchmarks.
- Documents the decision in [ADR 0029](design/decisions/0029-benchmark-suite.md) and adds a CONTRIBUTING section pointing at the benchmark README.

Closes #40.

## Test plan

- [x] `task verify-standards` — new gate passes; fails cleanly when `benchmarks/` is removed (confirmed locally).
- [x] `task benchmark` — 7 benchmarks run in <5s with a stable report table.
- [x] `task test` — 471 passed, 3 skipped; coverage 76.89 % (unchanged floor 74 %).
- [x] `task lint`, `task format -- --check`, `task typecheck`, `task reuse-lint` — all green.
- [x] `task verify-design`, `task verify-function-tests` — unchanged (benchmarks aren't tests for allocation).
- [ ] First scheduled run after merge establishes the baseline artifact; follow-up PR commits it.