### PR TITLE
ci: centralise pinned tool versions in .github/tool-versions.yaml

### DIFF
--- a/.claude/instructions/tooling-and-ci.md
+++ b/.claude/instructions/tooling-and-ci.md
@@ -57,6 +57,20 @@ language: `python.md`, `bash.md`.
 - **Wire all check scripts into CI** — every repeatable check script must
   have a CI workflow.
 
+- **Central tool-versions manifest** — pinned CLI tool versions live in a
+  single YAML file at `.github/tool-versions.yaml`. Both the CI composite
+  action (`.github/actions/setup-toolchain/action.yml`) and the local
+  preflight (`scripts/verify-dependencies.sh`) read this file; neither
+  consumer may hard-code a version literal that also lives in the
+  manifest. `scripts/verify-standards.sh` enforces that canary.
+
+  CI installs the exact manifest version for reproducibility.
+  `verify-dependencies.sh` enforces the pin as a **minimum within the
+  same major** — local dev environments (brew, apt, asdf) frequently
+  ship ahead of CI, so `>= manifest_version` passes, an older version
+  or a different major fails. Renovate custom managers target the
+  manifest so a single bump propagates to both environments.
+
 - **Pin sha256 for tool binary downloads** — any CI step that downloads a
   CLI binary directly (curl/wget from a release CDN) must verify the
   artefact against a sha256 pinned in the repository before extracting or

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -6,66 +6,6 @@ name: Setup Toolchain
 description: Install all CI tooling and verify dependencies
 
 inputs:
-  go-task-version:
-    description: go-task version to install
-    default: "3.50.0"
-  uv-version:
-    description: uv version to install (passed through to astral-sh/setup-uv)
-    default: "0.11.7"
-  keep-sorted-version:
-    description: keep-sorted version to install
-    default: "0.8.0"
-  keep-sorted-sha256:
-    description: sha256 of the keep-sorted linux x86_64 binary
-    default: "0d9801785ac354232ea754bbfd8cc204a5e255905e14bcbff5fe8733e4dbd85c"
-  mdformat-version:
-    description: mdformat version to install
-    default: "0.7.22"
-  mdformat-gfm-version:
-    description: mdformat-gfm version to install
-    default: "1.0.0"
-  mdformat-tables-version:
-    description: mdformat-tables version to install
-    default: "1.0.0"
-  shellcheck-version:
-    description: shellcheck version to install
-    default: "0.10.0"
-  shellcheck-sha256:
-    description: sha256 of the shellcheck linux x86_64 tarball
-    default: "6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87"
-  ripsecrets-version:
-    description: ripsecrets version to install
-    default: "0.1.11"
-  ripsecrets-sha256:
-    description: sha256 of the ripsecrets linux x86_64 tarball
-    default: "9daf017dfdea242a58f672450a2526f0406211afe9e872c740adc49b42feccf5"
-  ruff-version:
-    description: ruff version to install
-    default: "0.6.9"
-  ruff-sha256:
-    description: sha256 of the ruff linux x86_64 tarball
-    default: "ed8ba4cac0c6dfc1c0e9c6c720daa5ea404a3bff0497a95d6e25293a7910e903"
-  shfmt-version:
-    description: shfmt version to install
-    default: "3.8.0"
-  shfmt-sha256:
-    description: sha256 of the shfmt linux x86_64 binary
-    default: "27b3c6f9d9592fc5b4856c341d1ff2c88856709b9e76469313642a1d7b558fe0"
-  taplo-version:
-    description: taplo version to install
-    default: "0.10.0"
-  taplo-sha256:
-    description: sha256 of the taplo linux x86_64 gzipped binary
-    default: "8fe196b894ccf9072f98d4e1013a180306e17d244830b03986ee5e8eabeb6156"
-  treefmt-version:
-    description: treefmt version to install
-    default: "2.5.0"
-  treefmt-sha256:
-    description: sha256 of the treefmt linux x86_64 tarball
-    default: "95f707bf9666d08b50888b116768fd77f042ad5af92aa3b795f063160e72758f"
-  systems-engineering-ref:
-    description: Commit SHA or ref of aidanns/systems-engineering to install
-    default: "d8e664a5ad20c071d4ec1cd62377597f9404b6e9"
   github-token:
     description: GitHub token used for authenticated downloads during toolchain install (avoids per-IP rate limits on raw.githubusercontent.com and the release-asset endpoint)
     required: true
@@ -73,10 +13,53 @@ inputs:
 runs:
   using: composite
   steps:
+    # Single source of truth for every pinned tool version lives in
+    # .github/tool-versions.yaml. Emit one step output per value this
+    # composite action consumes so downstream install steps reference
+    # the manifest rather than duplicating literals. yq is pre-installed
+    # on GitHub-hosted runner images.
+    - name: Read tool-versions manifest
+      id: versions
+      shell: bash
+      env:
+        MANIFEST: .github/tool-versions.yaml
+      run: |
+        set -euo pipefail
+        emit() {
+          local name="$1" path="$2"
+          local value
+          value="$(yq -r "${path}" "${MANIFEST}")"
+          if [[ -z "${value}" || "${value}" == "null" ]]; then
+            echo "setup-toolchain: ${MANIFEST} missing ${path}" >&2
+            exit 1
+          fi
+          echo "${name}=${value}" >> "$GITHUB_OUTPUT"
+        }
+        emit go-task-version            '.["go-task"].version'
+        emit uv-version                 '.uv.version'
+        emit keep-sorted-version        '.["keep-sorted"].version'
+        emit keep-sorted-sha256         '.["keep-sorted"].sha256_linux_x86_64'
+        emit mdformat-version           '.mdformat.version'
+        emit mdformat-gfm-version       '.["mdformat-gfm"].version'
+        emit mdformat-tables-version    '.["mdformat-tables"].version'
+        emit shellcheck-version         '.shellcheck.version'
+        emit shellcheck-sha256          '.shellcheck.sha256_linux_x86_64'
+        emit ripsecrets-version         '.ripsecrets.version'
+        emit ripsecrets-sha256          '.ripsecrets.sha256_linux_x86_64'
+        emit ruff-version               '.ruff.version'
+        emit ruff-sha256                '.ruff.sha256_linux_x86_64'
+        emit shfmt-version              '.shfmt.version'
+        emit shfmt-sha256               '.shfmt.sha256_linux_x86_64'
+        emit taplo-version              '.taplo.version'
+        emit taplo-sha256               '.taplo.sha256_linux_x86_64'
+        emit treefmt-version            '.treefmt.version'
+        emit treefmt-sha256             '.treefmt.sha256_linux_x86_64'
+        emit systems-engineering-ref    '.["systems-engineering"].ref'
+
     - name: Install uv
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
-        version: ${{ inputs.uv-version }}
+        version: ${{ steps.versions.outputs.uv-version }}
         enable-cache: true
 
     - name: Install d2
@@ -86,7 +69,7 @@ runs:
     - name: Install systems-engineering
       shell: bash
       env:
-        SYSTEMS_ENGINEERING_REF: ${{ inputs.systems-engineering-ref }}
+        SYSTEMS_ENGINEERING_REF: ${{ steps.versions.outputs.systems-engineering-ref }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         # Stays inline (not via scripts/ci/fetch-release-asset.sh) because
@@ -105,15 +88,15 @@ runs:
     - name: Install go-task
       uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
       with:
-        version: ${{ inputs.go-task-version }}
+        version: ${{ steps.versions.outputs.go-task-version }}
         repo-token: ${{ inputs.github-token }}
 
     - name: Install mdformat
       shell: bash
       env:
-        MDFORMAT_VERSION: ${{ inputs.mdformat-version }}
-        MDFORMAT_GFM_VERSION: ${{ inputs.mdformat-gfm-version }}
-        MDFORMAT_TABLES_VERSION: ${{ inputs.mdformat-tables-version }}
+        MDFORMAT_VERSION: ${{ steps.versions.outputs.mdformat-version }}
+        MDFORMAT_GFM_VERSION: ${{ steps.versions.outputs.mdformat-gfm-version }}
+        MDFORMAT_TABLES_VERSION: ${{ steps.versions.outputs.mdformat-tables-version }}
       run: |
         uv tool install \
           "mdformat==${MDFORMAT_VERSION}" \
@@ -124,20 +107,20 @@ runs:
     - name: Install release binaries
       shell: bash
       env:
-        KEEP_SORTED_VERSION: ${{ inputs.keep-sorted-version }}
-        KEEP_SORTED_SHA256: ${{ inputs.keep-sorted-sha256 }}
-        RIPSECRETS_VERSION: ${{ inputs.ripsecrets-version }}
-        RIPSECRETS_SHA256: ${{ inputs.ripsecrets-sha256 }}
-        RUFF_VERSION: ${{ inputs.ruff-version }}
-        RUFF_SHA256: ${{ inputs.ruff-sha256 }}
-        SHELLCHECK_VERSION: ${{ inputs.shellcheck-version }}
-        SHELLCHECK_SHA256: ${{ inputs.shellcheck-sha256 }}
-        SHFMT_VERSION: ${{ inputs.shfmt-version }}
-        SHFMT_SHA256: ${{ inputs.shfmt-sha256 }}
-        TAPLO_VERSION: ${{ inputs.taplo-version }}
-        TAPLO_SHA256: ${{ inputs.taplo-sha256 }}
-        TREEFMT_VERSION: ${{ inputs.treefmt-version }}
-        TREEFMT_SHA256: ${{ inputs.treefmt-sha256 }}
+        KEEP_SORTED_VERSION: ${{ steps.versions.outputs.keep-sorted-version }}
+        KEEP_SORTED_SHA256: ${{ steps.versions.outputs.keep-sorted-sha256 }}
+        RIPSECRETS_VERSION: ${{ steps.versions.outputs.ripsecrets-version }}
+        RIPSECRETS_SHA256: ${{ steps.versions.outputs.ripsecrets-sha256 }}
+        RUFF_VERSION: ${{ steps.versions.outputs.ruff-version }}
+        RUFF_SHA256: ${{ steps.versions.outputs.ruff-sha256 }}
+        SHELLCHECK_VERSION: ${{ steps.versions.outputs.shellcheck-version }}
+        SHELLCHECK_SHA256: ${{ steps.versions.outputs.shellcheck-sha256 }}
+        SHFMT_VERSION: ${{ steps.versions.outputs.shfmt-version }}
+        SHFMT_SHA256: ${{ steps.versions.outputs.shfmt-sha256 }}
+        TAPLO_VERSION: ${{ steps.versions.outputs.taplo-version }}
+        TAPLO_SHA256: ${{ steps.versions.outputs.taplo-sha256 }}
+        TREEFMT_VERSION: ${{ steps.versions.outputs.treefmt-version }}
+        TREEFMT_SHA256: ${{ steps.versions.outputs.treefmt-sha256 }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         set -euo pipefail

--- a/.github/tool-versions.yaml
+++ b/.github/tool-versions.yaml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Central tool-version manifest — single source of truth consumed by
+# both .github/actions/setup-toolchain (CI) and
+# scripts/verify-dependencies.sh (local). Each tool entry carries the
+# pinned version and, for tools installed directly from GitHub Release
+# assets, the sha256 of the linux x86_64 binary/archive.
+#
+# CI consumes the pinned version exactly. verify-dependencies.sh treats
+# the pinned version as a minimum within the same major — local installs
+# that ship newer (brew, apt, asdf) pass as long as the major matches.
+#
+# Renovate custom managers (#205) target this file so bumps propagate to
+# both local and CI environments in one change.
+#
+# See .claude/instructions/tooling-and-ci.md § Central tool-version
+# manifest.
+
+go-task:
+  version: "3.50.0"
+
+uv:
+  version: "0.11.7"
+
+keep-sorted:
+  version: "0.8.0"
+  sha256_linux_x86_64: "0d9801785ac354232ea754bbfd8cc204a5e255905e14bcbff5fe8733e4dbd85c"
+
+mdformat:
+  version: "0.7.22"
+
+mdformat-gfm:
+  version: "1.0.0"
+
+mdformat-tables:
+  version: "1.0.0"
+
+shellcheck:
+  version: "0.10.0"
+  sha256_linux_x86_64: "6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87"
+
+ripsecrets:
+  version: "0.1.11"
+  sha256_linux_x86_64: "9daf017dfdea242a58f672450a2526f0406211afe9e872c740adc49b42feccf5"
+
+ruff:
+  version: "0.6.9"
+  sha256_linux_x86_64: "ed8ba4cac0c6dfc1c0e9c6c720daa5ea404a3bff0497a95d6e25293a7910e903"
+
+shfmt:
+  version: "3.8.0"
+  sha256_linux_x86_64: "27b3c6f9d9592fc5b4856c341d1ff2c88856709b9e76469313642a1d7b558fe0"
+
+taplo:
+  version: "0.10.0"
+  sha256_linux_x86_64: "8fe196b894ccf9072f98d4e1013a180306e17d244830b03986ee5e8eabeb6156"
+
+treefmt:
+  version: "2.5.0"
+  sha256_linux_x86_64: "95f707bf9666d08b50888b116768fd77f042ad5af92aa3b795f063160e72758f"
+
+systems-engineering:
+  ref: "d8e664a5ad20c071d4ec1cd62377597f9404b6e9"

--- a/scripts/verify-dependencies.sh
+++ b/scripts/verify-dependencies.sh
@@ -5,42 +5,145 @@
 # SPDX-License-Identifier: MIT
 
 # Verify that the external CLI tools required to run this project's
-# Taskfile targets are available on PATH. Intended as a pre-flight check
-# — run it locally before `task test`, `task verify-standards`, etc. to
-# get an actionable list of anything missing.
+# Taskfile targets are available on PATH and meet the minimum versions
+# pinned in .github/tool-versions.yaml. Intended as a pre-flight check
+# — run it locally before `task test`, `task verify-standards`, etc.
+#
+# Version policy: the manifest pin is a MINIMUM within the same major.
+# Local dev environments (brew, apt, asdf) frequently ship ahead of the
+# CI-pinned version; blocking on e.g. `yq 4.52` when CI is on `4.44` is
+# friction without benefit. CI itself installs the exact manifest
+# version via .github/actions/setup-toolchain, so its runs remain
+# reproducible. Tools with a different major than the manifest (or
+# older within the same major) fail this check.
 
 set -euo pipefail
 
-REQUIRED_TOOLS=(
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MANIFEST="${REPO_ROOT}/.github/tool-versions.yaml"
+
+if [[ ! -f "${MANIFEST}" ]]; then
+  echo "verify-dependencies: ${MANIFEST} is missing." >&2
+  exit 1
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "verify-dependencies: 'yq' is required to parse ${MANIFEST}." >&2
+  echo "Install it from https://github.com/mikefarah/yq and re-run." >&2
+  exit 1
+fi
+
+# Tools required on PATH but whose versions are not pinned in the
+# manifest (e.g. host tools supplied by the OS or devcontainer, or
+# tools pinned by ref/SHA rather than a semver).
+PRESENCE_TOOLS=(
   # keep-sorted start
-  keep-sorted
-  mdformat
   python3
-  ripsecrets
-  ruff
-  shellcheck
-  shfmt
   systems-engineering
-  taplo
-  task
-  treefmt
-  uv
   yq
   # keep-sorted end
 )
 
+# Tools whose versions ARE pinned in the manifest. Each row is
+# pipe-separated:
+#   <path-name>|<manifest-key>|<version-command>|<version-regex>
+# The regex captures the version into \1 from the first matching line
+# of the command's combined stdout+stderr.
+VERSIONED_TOOLS=(
+  # keep-sorted start
+  "keep-sorted|keep-sorted|keep-sorted --version|^v?([0-9]+\\.[0-9]+\\.[0-9]+)"
+  "mdformat|mdformat|mdformat --version|mdformat ([0-9]+\\.[0-9]+\\.[0-9]+)"
+  "ripsecrets|ripsecrets|ripsecrets --version|ripsecrets ([0-9]+\\.[0-9]+\\.[0-9]+)"
+  "ruff|ruff|ruff --version|ruff ([0-9]+\\.[0-9]+\\.[0-9]+)"
+  "shellcheck|shellcheck|shellcheck --version|version: ([0-9]+\\.[0-9]+\\.[0-9]+)"
+  "shfmt|shfmt|shfmt --version|v([0-9]+\\.[0-9]+\\.[0-9]+)"
+  "taplo|taplo|taplo --version|taplo ([0-9]+\\.[0-9]+\\.[0-9]+)"
+  "task|go-task|task --version|v?([0-9]+\\.[0-9]+\\.[0-9]+)"
+  "treefmt|treefmt|treefmt --version|v?([0-9]+\\.[0-9]+\\.[0-9]+)"
+  "uv|uv|uv --version|uv ([0-9]+\\.[0-9]+\\.[0-9]+)"
+  # keep-sorted end
+)
+
 missing=()
-for tool in "${REQUIRED_TOOLS[@]}"; do
+too_old=()
+major_drift=()
+unparseable=()
+
+for tool in "${PRESENCE_TOOLS[@]}"; do
   if ! command -v "${tool}" >/dev/null 2>&1; then
     missing+=("${tool}")
+  fi
+done
+
+# ``sort -V`` places the lexicographically-smaller version first. If the
+# manifest pin sorts first (or both strings are equal), the installed
+# version is >= the pin.
+version_is_at_least() {
+  local installed="$1" pinned="$2"
+  [[ "$(printf '%s\n%s\n' "${installed}" "${pinned}" | sort -V | head -1)" == "${pinned}" ]]
+}
+
+for entry in "${VERSIONED_TOOLS[@]}"; do
+  IFS='|' read -r tool key version_cmd regex <<<"${entry}"
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    missing+=("${tool}")
+    continue
+  fi
+
+  pinned="$(yq -r ".[\"${key}\"].version" "${MANIFEST}")"
+  if [[ -z "${pinned}" || "${pinned}" == "null" ]]; then
+    echo "verify-dependencies: ${MANIFEST} is missing '${key}.version'." >&2
+    exit 1
+  fi
+
+  raw="$(eval "${version_cmd}" 2>&1 || true)"
+  installed=""
+  while IFS= read -r line; do
+    if [[ "${line}" =~ ${regex} ]]; then
+      installed="${BASH_REMATCH[1]}"
+      break
+    fi
+  done <<<"${raw}"
+
+  if [[ -z "${installed}" ]]; then
+    unparseable+=("${tool}: could not parse version from '${version_cmd}' output")
+    continue
+  fi
+
+  if [[ "${installed%%.*}" != "${pinned%%.*}" ]]; then
+    major_drift+=("${tool}: installed ${installed}, manifest pins ${pinned} (different major)")
+    continue
+  fi
+
+  if ! version_is_at_least "${installed}" "${pinned}"; then
+    too_old+=("${tool}: installed ${installed}, manifest pins ${pinned} (need >= within same major)")
   fi
 done
 
 if [[ ${#missing[@]} -gt 0 ]]; then
   echo "verify-dependencies: required tools are missing from PATH:" >&2
   printf '  - %s\n' "${missing[@]}" >&2
-  echo "Install them and re-run." >&2
+fi
+
+if [[ ${#too_old[@]} -gt 0 ]]; then
+  echo "verify-dependencies: required tools are older than the manifest pin:" >&2
+  printf '  - %s\n' "${too_old[@]}" >&2
+fi
+
+if [[ ${#major_drift[@]} -gt 0 ]]; then
+  echo "verify-dependencies: required tools run a different major than the manifest pin:" >&2
+  printf '  - %s\n' "${major_drift[@]}" >&2
+fi
+
+if [[ ${#unparseable[@]} -gt 0 ]]; then
+  echo "verify-dependencies: could not determine installed version for some tools:" >&2
+  printf '  - %s\n' "${unparseable[@]}" >&2
+fi
+
+if [[ ${#missing[@]} -gt 0 || ${#too_old[@]} -gt 0 || ${#major_drift[@]} -gt 0 || ${#unparseable[@]} -gt 0 ]]; then
+  echo "Install or upgrade the tools above and re-run." >&2
   exit 1
 fi
 
-echo "verify-dependencies: all required tools are on PATH (${REQUIRED_TOOLS[*]})."
+echo "verify-dependencies: all required tools are on PATH at versions compatible with ${MANIFEST}."

--- a/scripts/verify-dependencies.sh
+++ b/scripts/verify-dependencies.sh
@@ -37,8 +37,14 @@ fi
 # Tools required on PATH but whose versions are not pinned in the
 # manifest (e.g. host tools supplied by the OS or devcontainer, or
 # tools pinned by ref/SHA rather than a semver).
+#
+# keep-sorted: the google/keep-sorted_linux release asset reports a
+# build commit sha + timestamp ("ac58172 (2026-03-05T18:52:35Z)")
+# rather than a semantic version, so a `>= manifest` check isn't
+# meaningful. Presence is the only signal we can assert.
 PRESENCE_TOOLS=(
   # keep-sorted start
+  keep-sorted
   python3
   systems-engineering
   yq
@@ -52,7 +58,6 @@ PRESENCE_TOOLS=(
 # of the command's combined stdout+stderr.
 VERSIONED_TOOLS=(
   # keep-sorted start
-  "keep-sorted|keep-sorted|keep-sorted --version|^v?([0-9]+\\.[0-9]+\\.[0-9]+)"
   "mdformat|mdformat|mdformat --version|mdformat ([0-9]+\\.[0-9]+\\.[0-9]+)"
   "ripsecrets|ripsecrets|ripsecrets --version|ripsecrets ([0-9]+\\.[0-9]+\\.[0-9]+)"
   "ruff|ruff|ruff --version|ruff ([0-9]+\\.[0-9]+\\.[0-9]+)"

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -28,6 +28,10 @@
 #   2b. Every astral-sh/setup-uv invocation passes an explicit
 #      `with.version` so the uv binary can't silently upgrade between
 #      runs (see issue #84).
+#   2c. .github/tool-versions.yaml is the single source of truth for
+#      pinned tool versions — neither setup-toolchain/action.yml nor
+#      scripts/verify-dependencies.sh may hard-code a version literal
+#      that also appears in the manifest (see issue #87).
 #   3. Bash gating (shellcheck, shfmt) is wired into CI, treefmt, and
 #      lefthook per .claude/instructions/bash.md.
 #   4. Markdown (mdformat) and TOML (taplo) formatters are wired into
@@ -287,6 +291,54 @@ if [[ ${uv_version_matches} -eq 0 ]]; then
 else
   echo "verify-standards: all ${uv_version_matches} astral-sh/setup-uv invocations pin 'with.version'."
 fi
+
+# ---------------------------------------------------------------------------
+# Central tool-versions manifest is the only source of truth.
+# ---------------------------------------------------------------------------
+# .github/tool-versions.yaml is consumed by both
+# .github/actions/setup-toolchain/action.yml (CI) and
+# scripts/verify-dependencies.sh (local). Drift canary: assert no version
+# pinned in the manifest appears as a literal string in either consumer.
+# A bump to the manifest must propagate automatically; a literal slips
+# through this gate and surfaces on the next drift.
+TOOL_VERSIONS_MANIFEST=".github/tool-versions.yaml"
+TOOL_VERSIONS_CONSUMERS=(
+  ".github/actions/setup-toolchain/action.yml"
+  "scripts/verify-dependencies.sh"
+)
+
+if [[ ! -f "${TOOL_VERSIONS_MANIFEST}" ]]; then
+  echo "verify-standards: ${TOOL_VERSIONS_MANIFEST} is missing — consumers cannot resolve pinned versions." >&2
+  exit 1
+fi
+
+manifest_drift=0
+# sed here strips trailing `# ...` comments so a commented-out mention
+# ("# bump: 0.11.7 -> ...") doesn't trip the canary. strip_comments()
+# isn't yet defined at this point in the file, so this inlines the
+# same sed invocation.
+while IFS=$'\t' read -r tool_name version; do
+  [[ -n "${version}" && "${version}" != "null" ]] || continue
+  for consumer in "${TOOL_VERSIONS_CONSUMERS[@]}"; do
+    [[ -f "${consumer}" ]] || continue
+    # Match the version inside quotes or after `@v` so a fragment that
+    # coincides with a sha256 byte sequence can't false-positive.
+    if sed -E 's/(^|[[:space:]])#.*$//' "${consumer}" \
+      | grep -qE "[\"']${version//./\\.}[\"']|@v${version//./\\.}([^0-9.]|$)"; then
+      echo "verify-standards: ${consumer} hard-codes '${version}' (pinned as '${tool_name}' in ${TOOL_VERSIONS_MANIFEST})." >&2
+      manifest_drift=1
+    fi
+  done
+done < <(
+  yq -r '. | to_entries | .[] | [.key, (.value.version // "")] | @tsv' "${TOOL_VERSIONS_MANIFEST}"
+)
+
+if [[ ${manifest_drift} -ne 0 ]]; then
+  echo "  Both consumers must read ${TOOL_VERSIONS_MANIFEST} via yq — no duplicated literals. See issue #87." >&2
+  exit 1
+fi
+
+echo "verify-standards: ${TOOL_VERSIONS_MANIFEST} consumers contain no hard-coded version literals."
 
 # Bash tooling: shellcheck + shfmt must be wired into CI, treefmt, and
 # lefthook per .claude/instructions/bash.md. Strip comments before


### PR DESCRIPTION
## Summary

- Introduce `.github/tool-versions.yaml` as the single source of truth for every pinned CLI tool (version + sha256 for release-binary installs, `ref:` for systems-engineering).
- Refactor `.github/actions/setup-toolchain/action.yml` to read the manifest via a new "Read tool-versions manifest" step (using pre-installed `yq`) and consume `steps.versions.outputs.*`. Drops 14 composite inputs that no caller overrode.
- Refactor `scripts/verify-dependencies.sh`: treats the manifest pin as a **minimum within the same major**. `>= manifest_version` (same major) passes; older, or a different major, fails. CI installs the exact pin so runs stay reproducible.
- Extend `scripts/verify-standards.sh` with a drift canary asserting neither consumer hard-codes a version string that also appears in the manifest.
- Document under "Central tool-versions manifest" in `.claude/instructions/tooling-and-ci.md`.

## Why

Two copies of the same version numbers with nothing enforcing they match was drift waiting to happen. The minimum-within-major policy for local matches dev ergonomics (brew/asdf ships ahead of CI) without relaxing CI's exact-pin guarantee.

Renovate custom managers (coordinated via #205) will target the manifest so a single bump propagates to both environments.

## Test plan

- [x] `bash scripts/verify-standards.sh` passes; new manifest-drift canary logs "consumers contain no hard-coded version literals."
- [x] `bash scripts/verify-dependencies.sh` exercises all four codepaths locally: missing / too-old / major-drift / unparseable. The local shellcheck (0.9.0) is legitimately older than the manifest pin (0.10.0), so the script flags it — CI installs 0.10.0 so CI passes cleanly.
- [x] Drift canary negative path: injecting a `"0.11.7"` literal into `setup-toolchain/action.yml` causes `verify-standards` to exit 1 with a targeted message.
- [x] `shellcheck` and `treefmt --ci` — both clean.
- [ ] CI (setup-toolchain composite rebuilds; every workflow that uses it should still resolve the same versions).

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)