### PR TITLE
feat(vscode): commit .vscode workspace

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,14 @@
+{
+  "recommendations": [
+    "charliermarsh.ruff",
+    "editorconfig.editorconfig",
+    "foxundermoon.shell-format",
+    "github.vscode-github-actions",
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "redhat.vscode-yaml",
+    "tamasfe.even-better-toml",
+    "terrastruct.d2",
+    "timonwong.shellcheck"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,39 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "agent-auth serve",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "agent_auth.cli",
+      "args": [
+        "serve"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    },
+    {
+      "name": "things-bridge serve",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "things_bridge.cli",
+      "args": [
+        "serve"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    },
+    {
+      "name": "pytest: current file",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": [
+        "${file}",
+        "-v"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,39 @@
+{
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit",
+      "source.fixAll": "explicit"
+    }
+  },
+  "[shellscript]": {
+    "editor.defaultFormatter": "foxundermoon.shell-format",
+    "editor.formatOnSave": true
+  },
+  "[toml]": {
+    "editor.defaultFormatter": "tamasfe.even-better-toml",
+    "editor.formatOnSave": true
+  },
+  "[markdown]": {
+    "editor.formatOnSave": false
+  },
+  "ruff.importStrategy": "fromEnvironment",
+  "python.testing.pytestEnabled": true,
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "python.analysis.typeCheckingMode": "strict",
+  "python.terminal.activateEnvironment": false,
+  "files.exclude": {
+    "**/__pycache__": true,
+    "**/*.egg-info": true,
+    ".coverage": true,
+    ".coverage.*": true,
+    ".venv-*": true,
+    "dist": true,
+    "htmlcov": true,
+    "mutants": true
+  }
+}

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -25,6 +25,9 @@ SPDX-License-Identifier = "MIT"
 [[annotations]]
 path = [
     ".releaserc.mjs",
+    ".vscode/extensions.json",
+    ".vscode/launch.json",
+    ".vscode/settings.json",
     "package-lock.json",
     "package.json",
     "pyrightconfig.json",

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -75,6 +75,10 @@
 #      AND a scheduled CI workflow (.github/workflows/benchmark.yml)
 #      invokes it on `on: schedule:`, per
 #      .claude/instructions/testing-standards.md "Benchmark suite".
+#  16. .vscode/extensions.json, .vscode/settings.json, and
+#      .vscode/launch.json all exist so a fresh checkout opens with
+#      recommended extensions, formatter-on-save, and debug configs,
+#      per .claude/instructions/tooling-and-ci.md "IDE".
 
 set -euo pipefail
 
@@ -2104,3 +2108,29 @@ if [[ ${benchmark_missing} -ne 0 ]]; then
 fi
 
 echo "verify-standards: benchmark suite exists under ${benchmarks_dir}/ and ${benchmark_workflow} runs it on a schedule."
+
+# ---------------------------------------------------------------------------
+# VS Code project scaffolding.
+# ---------------------------------------------------------------------------
+# .claude/instructions/tooling-and-ci.md (IDE — "VS Code project")
+# requires the repository to commit a .vscode/ directory covering
+# recommended extensions, formatter-on-save settings, and debug
+# configurations. The deterministic regression check asserts the
+# three files exist; it does not inspect content because a
+# partial/experimental settings.json should still open cleanly for
+# contributors.
+
+vscode_missing=0
+for vscode_file in .vscode/extensions.json .vscode/settings.json .vscode/launch.json; do
+  if [[ ! -f "${vscode_file}" ]]; then
+    echo "verify-standards: ${vscode_file} is missing." >&2
+    vscode_missing=1
+  fi
+done
+
+if [[ ${vscode_missing} -ne 0 ]]; then
+  echo "  Add the .vscode/ workspace per .claude/instructions/tooling-and-ci.md § IDE." >&2
+  exit 1
+fi
+
+echo "verify-standards: .vscode/ workspace provides extensions, settings, and launch configurations."


### PR DESCRIPTION
## Summary

Adds a `.vscode/` directory matching the project toolchain so a fresh checkout opens with the right extensions, formatter-on-save, and debug configs.

- `extensions.json` — recommends ruff, Python/Pylance, taplo, shfmt + shellcheck, editorconfig, GitHub Actions, YAML, D2.
- `settings.json` — format-on-save wired (ruff/shfmt/taplo); pytest discovery on `tests/`; strict type-checking; ruff imports from project venv.
- `launch.json` — debug configs for `agent-auth serve`, `things-bridge serve`, and `pytest` on the current test file.
- `scripts/verify-standards.sh` gains item 16 asserting the three files exist; gate is load-bearing.
- `REUSE.toml` picks up the new JSON files under the existing override block.

Markdown format-on-save is intentionally off — there is no first-party mdformat VS Code extension, and the project gate remains `task format`.

Closes #46.

## Test plan

- [x] `task verify-standards` — passes on this branch; fails cleanly when any of the three files is removed.
- [x] `task reuse-lint` — 302 / 302.
- [x] `task lint`, `task format -- --check` — green.
- [x] JSON syntax validated via `python3 -c 'json.load(...)'`.
- [ ] Open workspace in VS Code and confirm extensions recommendation prompt + debug configs show up (reviewer, since the sandbox has no VS Code install).