### PR TITLE
ci: sha256-verify d2 and systems-engineering install scripts

### DIFF
--- a/.claude/instructions/tooling-and-ci.md
+++ b/.claude/instructions/tooling-and-ci.md
@@ -83,6 +83,16 @@ language: `python.md`, `bash.md`.
   checksum file would travel over the same TLS channel as the artefact
   it claims to verify.
 
+  The same rule applies to **install scripts fetched over the network**
+  (`curl ... | sh`, `curl ... | bash`). Replace the pipe with
+  download → `sha256sum -c` → execute, with the hash pinned in the
+  tool-versions manifest and bumped together with any upstream change.
+  A ref-pin alone (e.g. a commit SHA in the URL) is not sufficient: the
+  install.sh body at that ref is still editable if the upstream repo is
+  a moving target, and the pipe form never sees the bytes it ran.
+  `verify-standards.sh` asserts the absence of unverified pipes in
+  `setup-toolchain/action.yml`.
+
 - **Pin release-affecting GitHub Actions to commit SHAs** — third-party
   `uses:` references in any workflow that holds `id-token: write`,
   `contents: write`, or otherwise sits on the release path must be pinned

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -54,7 +54,10 @@ runs:
         emit taplo-sha256               '.taplo.sha256_linux_x86_64'
         emit treefmt-version            '.treefmt.version'
         emit treefmt-sha256             '.treefmt.sha256_linux_x86_64'
-        emit systems-engineering-ref    '.["systems-engineering"].ref'
+        emit systems-engineering-ref              '.["systems-engineering"].ref'
+        emit systems-engineering-install-sha256   '.["systems-engineering"].install_sha256'
+        emit d2-install-url                       '.d2.install_url'
+        emit d2-install-sha256                    '.d2.install_sha256'
 
     - name: Install uv
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
@@ -64,23 +67,47 @@ runs:
 
     - name: Install d2
       shell: bash
-      run: curl -fsSL https://d2lang.com/install.sh | sh -s --
+      env:
+        D2_INSTALL_URL: ${{ steps.versions.outputs.d2-install-url }}
+        D2_INSTALL_SHA256: ${{ steps.versions.outputs.d2-install-sha256 }}
+      run: |
+        # curl -> tmp file -> sha256 verify -> execute. Piping straight
+        # to `sh` would run whatever the network returns; a content
+        # change at the upstream CDN would silently execute. See #157.
+        set -euo pipefail
+        curl -fsSL \
+          --retry 5 --retry-max-time 60 --retry-all-errors \
+          -o /tmp/d2-install.sh \
+          "${D2_INSTALL_URL}"
+        echo "${D2_INSTALL_SHA256}  /tmp/d2-install.sh" | sha256sum -c -
+        # The previous form `curl ... | sh -s --` passed `--` to sh
+        # (end-of-options), not to the install script, so execute the
+        # downloaded script with no trailing args.
+        sh /tmp/d2-install.sh
 
     - name: Install systems-engineering
       shell: bash
       env:
         SYSTEMS_ENGINEERING_REF: ${{ steps.versions.outputs.systems-engineering-ref }}
+        SYSTEMS_ENGINEERING_INSTALL_SHA256: ${{ steps.versions.outputs.systems-engineering-install-sha256 }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        # Stays inline (not via scripts/ci/fetch-release-asset.sh) because
-        # it fetches via the Contents API with a custom Accept header and
-        # has no pinned sha256 (dynamic ref). See the helper for retry-flag
-        # rationale.
+        # Same shape as the d2 step: download to /tmp, verify against a
+        # manifest-pinned sha256, only then execute. The ref field alone
+        # doesn't gate execution — an install.sh edit at that ref would
+        # still run unchecked without this verify. See #157.
+        #
+        # Fetches via the Contents API with a custom Accept header so
+        # can't use scripts/ci/fetch-release-asset.sh which targets the
+        # releases endpoint.
+        set -euo pipefail
         curl -fsSL --retry 5 --retry-max-time 60 --retry-all-errors \
           -H "Accept: application/vnd.github.raw" \
           -H "Authorization: Bearer ${GITHUB_TOKEN}" \
           -o /tmp/systems-engineering-install.sh \
           "https://api.github.com/repos/aidanns/systems-engineering/contents/install.sh?ref=${SYSTEMS_ENGINEERING_REF}"
+
+        echo "${SYSTEMS_ENGINEERING_INSTALL_SHA256}  /tmp/systems-engineering-install.sh" | sha256sum -c -
 
         bash /tmp/systems-engineering-install.sh
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/.github/tool-versions.yaml
+++ b/.github/tool-versions.yaml
@@ -63,3 +63,14 @@ treefmt:
 
 systems-engineering:
   ref: "d8e664a5ad20c071d4ec1cd62377597f9404b6e9"
+  # sha256 of the install.sh body fetched from the ref above. Bump
+  # this together with `ref`; setup-toolchain verifies the script
+  # before executing it. See issue #157.
+  install_sha256: "f83a266a0b5f1bb754cf67e7b5d0bb9f0d5610907c06e9cd6a81ff4acecefb9a"
+
+# d2 has no semver pin — the integrity check is the install.sh body
+# sha256 itself, which must be bumped together with any upstream
+# install-script change at d2lang.com. See issue #157.
+d2:
+  install_url: "https://d2lang.com/install.sh"
+  install_sha256: "2b7f4dd773a8d6ba57903f404d82d95e22f5efb618efb6b3c8d8142325a52ae2"

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -32,6 +32,9 @@
 #      pinned tool versions — neither setup-toolchain/action.yml nor
 #      scripts/verify-dependencies.sh may hard-code a version literal
 #      that also appears in the manifest (see issue #87).
+#   2d. setup-toolchain/action.yml has no unverified `curl | sh|bash`
+#      pipes — every network-fetched install script must be
+#      sha256-checked before execution (see issue #157).
 #   3. Bash gating (shellcheck, shfmt) is wired into CI, treefmt, and
 #      lefthook per .claude/instructions/bash.md.
 #   4. Markdown (mdformat) and TOML (taplo) formatters are wired into
@@ -343,6 +346,27 @@ if [[ ${manifest_drift} -ne 0 ]]; then
 fi
 
 echo "verify-standards: ${TOOL_VERSIONS_MANIFEST} consumers contain no hard-coded version literals."
+
+# ---------------------------------------------------------------------------
+# No unverified `curl ... | sh|bash` pipes in setup-toolchain.
+# ---------------------------------------------------------------------------
+# Piping an installer script directly from the network into a shell
+# executes whatever bytes the CDN returns — a content swap is silent.
+# Every install.sh fetch in setup-toolchain must go through the
+# download -> sha256-verify -> execute pattern gated by a pinned hash
+# in .github/tool-versions.yaml. See issue #157.
+SETUP_TOOLCHAIN=".github/actions/setup-toolchain/action.yml"
+if [[ -f "${SETUP_TOOLCHAIN}" ]]; then
+  # strip_comments() isn't yet defined at this point in the file; the
+  # inline sed below matches that function's body.
+  if sed -E 's/(^|[[:space:]])#.*$//' "${SETUP_TOOLCHAIN}" \
+    | grep -qE "curl[^|]*\|[[:space:]]*(bash|sh)\b"; then
+    echo "verify-standards: ${SETUP_TOOLCHAIN} pipes 'curl' directly into a shell." >&2
+    echo "  Download to a tmp file, verify the sha256 pinned in ${TOOL_VERSIONS_MANIFEST}, then execute. See issue #157." >&2
+    exit 1
+  fi
+  echo "verify-standards: ${SETUP_TOOLCHAIN} has no unverified 'curl | sh|bash' pipes."
+fi
 
 # Bash tooling: shellcheck + shfmt must be wired into CI, treefmt, and
 # lefthook per .claude/instructions/bash.md. Strip comments before


### PR DESCRIPTION
## Summary

- Pin `d2.install_sha256` and `systems-engineering.install_sha256` in `.github/tool-versions.yaml`.
- Replace both `curl ... | sh|bash` pipes in `setup-toolchain/action.yml` with download → `sha256sum -c` → execute. A failed verify aborts the step.
- Add a `verify-standards` canary asserting no unverified `curl | sh|bash` pipe remains in `setup-toolchain`.
- Document under `tooling-and-ci.md` § "Pin sha256 for tool binary downloads".

## Why

Piping an installer script straight from the network into a shell executes whatever bytes the CDN returns — a content swap is silent. The systems-engineering ref-pin alone doesn't help because the install.sh body at that ref can still be edited upstream and the pipe form never sees the bytes it executes. Sibling of #135 (binary-archive sha256 pinning). Coordinated with #87 — both hashes live in the manifest so bumps travel together.

## Test plan

- [x] Manifest shas match upstream (re-fetched both just now).
- [x] `bash scripts/verify-standards.sh` passes; new canary logs "has no unverified 'curl | sh|bash' pipes."
- [x] Negative path: injecting `run: curl ... | bash` into setup-toolchain causes verify-standards to exit 1.
- [x] `shellcheck scripts/verify-standards.sh` — clean. `treefmt --ci` — clean.
- [ ] CI — setup-toolchain should execute both install steps successfully with the sha256 check inline.

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)