### PR TITLE
fix(verify-standards): tighten tool-name regexes against hyphen word boundaries

### DIFF
--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -365,6 +365,55 @@ strip_comments() {
   sed -E 's/(^|[[:space:]])#.*$//' "$@"
 }
 
+# Build a tight word-boundary regex for a tool-invocation token.
+#
+# ERE `\b` treats `-` as a word boundary, so `\btask check\b` would
+# also match `task check-foo` (and `\bmy-task check\b` matches a
+# substring of `my-task check`). Substituting `[^-[:alnum:]_]` for
+# the boundary excludes hyphens on both sides, so a future
+# `task check-dry` cannot satisfy a gate looking for `task check`.
+#
+# Use this helper in preference to `\btoken\b` whenever the token
+# names a CLI tool, subcommand, or flag — anything that could grow
+# a hyphenated sibling. See issue #77.
+#
+# Tokens are inserted verbatim; pass plain words (`ruff`,
+# `ruff format --check`), not regexes. Regex metacharacters in the
+# token will be interpreted.
+tool_pattern() {
+  local token="$1"
+  printf '(^|[^-[:alnum:]_])%s([^-[:alnum:]_]|$)' "${token}"
+}
+
+# Self-test: lock in the behaviour that tool_pattern promises above so
+# a future refactor cannot silently regress it. The assertions run on
+# every invocation — they are O(microseconds) and save a whole class of
+# false-positive bugs.
+_tool_pattern_selftest() {
+  local pat
+  pat="$(tool_pattern "task check")"
+  # Exact token matches.
+  grep -qE "${pat}" <<<"task check" || return 1
+  grep -qE "${pat}" <<<"- run: task check" || return 2
+  grep -qE "${pat}" <<<"'task check'" || return 3
+  # Hyphenated suffix must NOT satisfy the pattern.
+  if grep -qE "${pat}" <<<"task check-dry"; then return 4; fi
+  # Hyphenated prefix must NOT satisfy the pattern.
+  if grep -qE "${pat}" <<<"my-task check"; then return 5; fi
+  # Same guarantees with a single-word token.
+  pat="$(tool_pattern "ruff")"
+  grep -qE "${pat}" <<<"- ruff check ." || return 6
+  if grep -qE "${pat}" <<<"ruff-lsp"; then return 7; fi
+  if grep -qE "${pat}" <<<"my-ruff"; then return 8; fi
+  return 0
+}
+if ! _tool_pattern_selftest; then
+  echo "verify-standards: tool_pattern self-test failed (code $?)." >&2
+  echo "  The helper in scripts/verify-standards.sh is broken. See issue #77." >&2
+  exit 1
+fi
+unset -f _tool_pattern_selftest
+
 # Collect comment-stripped content into variables so the match step
 # doesn't early-exit its upstream pipeline — `grep -q` exiting on first
 # match would otherwise SIGPIPE `sed`/`cat`, and `pipefail` turns that
@@ -388,7 +437,7 @@ scripts_stripped="$(find scripts -name '*.sh' -print0 2>/dev/null \
   | strip_comments)"
 
 for tool in shellcheck shfmt; do
-  if ! grep -qE "\\b${tool}\\b" <<<"${workflows_stripped}"; then
+  if ! grep -qE "$(tool_pattern "${tool}")" <<<"${workflows_stripped}"; then
     fail_bash_check "${tool}" ".github/workflows/*.yml" \
       "Add a workflow step that invokes '${tool}' (see .github/workflows/check.yml)."
   fi
@@ -401,8 +450,8 @@ for tool in shellcheck shfmt; do
   # lefthook is satisfied either by a direct invocation of the tool or by
   # invoking treefmt — treefmt runs the tool transitively via its
   # [formatter.${tool}] entry (asserted above).
-  if ! grep -qE "\\b${tool}\\b" <<<"${lefthook_stripped}" \
-    && ! grep -qE "\\btreefmt\\b" <<<"${lefthook_stripped}"; then
+  if ! grep -qE "$(tool_pattern "${tool}")" <<<"${lefthook_stripped}" \
+    && ! grep -qE "$(tool_pattern treefmt)" <<<"${lefthook_stripped}"; then
     fail_bash_check "${tool}" "lefthook.yml" \
       "Add a pre-commit command that invokes '${tool}' (or 'treefmt') to lefthook.yml."
   fi
@@ -595,7 +644,7 @@ if ! grep -qE "^\\[formatter\\.ruff\\]" <<<"${treefmt_stripped}"; then
     "Add a [formatter.ruff] entry to treefmt.toml."
 fi
 
-if ! grep -qE "\\bruff\\b" <<<"${lefthook_stripped}"; then
+if ! grep -qE "$(tool_pattern ruff)" <<<"${lefthook_stripped}"; then
   fail_ruff_check "lefthook.yml" \
     "Add pre-commit commands that invoke 'ruff check' and 'ruff format --check' to lefthook.yml."
 fi
@@ -604,9 +653,9 @@ fi
 # gate (it dispatches through scripts/lint.sh and scripts/format.sh
 # --check, each of which invokes ruff). Accept direct `ruff check` +
 # `ruff format --check` as an equivalent alternative.
-if ! grep -qE "\\btask check\\b" <<<"${workflows_stripped}" \
-  && ! { grep -qE "\\bruff check\\b" <<<"${workflows_stripped}" \
-    && grep -qE "\\bruff format --check\\b" <<<"${workflows_stripped}"; }; then
+if ! grep -qE "$(tool_pattern "task check")" <<<"${workflows_stripped}" \
+  && ! { grep -qE "$(tool_pattern "ruff check")" <<<"${workflows_stripped}" \
+    && grep -qE "$(tool_pattern "ruff format --check")" <<<"${workflows_stripped}"; }; then
   fail_ruff_check ".github/workflows/*.yml" \
     "Add a workflow step that runs 'task check' (or both 'ruff check' and 'ruff format --check' directly)."
 fi


### PR DESCRIPTION
## Summary

ERE `\b` treats `-` as a word boundary, so `\btask check\b` matches `task check-foo` and `\bmy-task check\b` matches the substring `task check`. Either hyphen-neighbour could falsely satisfy a gate looking for the bare token — a latent fragility flagged in the #74 review.

- New `tool_pattern TOKEN` helper wraps the token in `(^|[^-[:alnum:]_])...([^-[:alnum:]_]|$)` — explicit non-hyphen, non-word boundaries.
- Applied to the three blocks named in #77: the `shellcheck`/`shfmt` loop, the `ruff` lefthook gate, and the `task check` / `ruff check` / `ruff format --check` CI gates.
- Inline self-test runs on every script invocation; fires before any regression check so a future refactor that breaks the helper fails with a clear pointer back to this issue.

Other tool-name patterns (`ripsecrets`, `treefmt`, `pip-audit`, `mypy`, `pyright`) carry the same latent hazard. Per the issue's three-block scope those are not touched here, but the helper is now in place for follow-up.

Closes #77.

## Test plan

- [x] `task verify-standards` — passes (self-test silent).
- [x] Self-test confirmed load-bearing by temporarily removing `-` from the negated class — `verify-standards` fails with the new "tool_pattern self-test failed" message.
- [x] `task lint`, `task format -- --check` — green.