### PR TITLE
refactor(test-harness): in-tree DockerComposeCluster builder

### DIFF
--- a/design/decisions/0004-docker-integration-tests.md
+++ b/design/decisions/0004-docker-integration-tests.md
@@ -8,7 +8,13 @@ SPDX-License-Identifier: MIT
 
 ## Status
 
-Accepted — 2026-04-18.
+Accepted — 2026-04-18. The `testcontainers-python` implementation
+choice in § Decision is superseded by ADR 0034 (2026-04-24): the
+per-test Compose-project shape, session-scoped image build, and
+readiness-probe indirection carry over unchanged, but the Compose
+lifecycle is now driven by an in-tree subprocess harness under
+`tests/integration/harness/`. Read this ADR for the product
+motivation; read 0034 for the current harness shape.
 
 ## Context
 

--- a/design/decisions/0005-things-services-docker-tests.md
+++ b/design/decisions/0005-things-services-docker-tests.md
@@ -9,7 +9,12 @@ SPDX-License-Identifier: MIT
 ## Status
 
 Accepted — 2026-04-19. Amended 2026-04-23 (see *Amendment — 2026-04-23*
-below).
+below). ADR 0034 (2026-04-24) additionally supersedes the harness
+implementation — `testcontainers.compose.DockerCompose` is replaced by
+an in-tree subprocess builder under `tests/integration/harness/`. The
+per-service topology described below (per-service images, one compose
+file, per-test Compose project, `docker compose run` for `things-cli`,
+`docker run` for the AppleScript contract) is unchanged.
 
 ## Context
 

--- a/design/decisions/0034-integration-harness-rework.md
+++ b/design/decisions/0034-integration-harness-rework.md
@@ -1,0 +1,175 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# ADR 0034 — In-tree `DockerComposeCluster` harness for integration tests
+
+## Status
+
+Accepted — 2026-04-23. Supersedes the `testcontainers-python`
+implementation choices from ADR 0004 § Decision ("using
+`testcontainers-python` to drive the Compose lifecycle instead of
+hand-rolled subprocess calls") and ADR 0005 § Decision (single shared
+Compose file). The broader decisions from 0004 / 0005 — per-test
+Compose project, shared `Dockerfile.test`, one `docker-compose.yaml`
+for all services — are unchanged. Closes
+[#80](https://github.com/aidanns/agent-auth/issues/80).
+
+## Context
+
+ADR 0004 adopted `testcontainers-python` to drive the per-test Compose
+lifecycle, and ADR 0005 extended the same pattern to the `things-*`
+services. The conftest layers in `tests/integration/` grew three
+friction points that were called out on #80:
+
+1. **Placeholder-rendered compose file.** The shared
+   `docker/docker-compose.yaml` carried `{{ COMPOSE_PROJECT_NAME }}`
+   / `{{ AGENT_AUTH_TEST_IMAGE }}` / `{{ THINGS_BRIDGE_TEST_FIXTURES_DIR }}`
+   double-brace placeholders that the conftest substituted via a
+   Python renderer (`render_compose_file`) before docker compose ever
+   saw the file. The rendered file was self-contained, but the
+   substitution mechanism was bespoke — reading the compose file alone
+   didn't reveal what the tests actually ran.
+2. **Handwritten readiness polling.** `wait_until_server_ready` was
+   an HTTP loop in `tests/integration/_support.py` that every
+   per-service conftest imported and called after `compose.start()`.
+   Service readiness was expressed imperatively rather than declared on
+   a cluster definition.
+3. **Untyped port discovery.** Host and port came from
+   `compose.get_service_host(svc, 9100)` /
+   `compose.get_service_port(svc, 9100)` — two positional lookups
+   string-concatenated into `base_url`. Negative tests that needed
+   to shell out directly (`stop_agent_auth`, the `things-cli`
+   invoker) also hand-rolled their own `docker compose` argv.
+
+There was no `docker compose logs` capture on teardown either — a
+flaky integration test left no artefact for post-mortem, so CI
+reproduction meant re-running locally.
+
+`palantir/docker-compose-rule` (JUnit rule for Compose-backed tests)
+addresses the same concerns with a fluent builder, typed port
+accessors, declarative wait strategies, and log capture on failure.
+That shape ported cleanly.
+
+## Considered alternatives
+
+### Keep `testcontainers-python` and bolt on the missing pieces
+
+Wrap `DockerCompose` with our own readiness + log-capture helpers
+and keep the Python-side template renderer.
+
+**Rejected** because:
+
+- `DockerCompose` in testcontainers 4.x does not expose
+  `project_name=`; the conftest's workaround writes
+  `COMPOSE_PROJECT_NAME` into `os.environ` before every
+  `start()` / `stop()`. The Python-side renderer sidestepped that
+  by baking the project into the rendered compose file, but it layers
+  yet another templating mechanism on top of the one docker compose
+  already provides natively.
+- `exec_in_container` wraps `subprocess.run(check=True)` and
+  raises on non-zero exit, so the `things-cli` invoker already
+  bypasses it and shells out to `docker compose exec` by hand. Two
+  subprocess paths for the same API surface is worse than one.
+- Every feature we would add (wait strategies, log capture, typed
+  ports) has a near-identical JUnit precedent to borrow from; the
+  wrapper would be thicker than the thing it wraps.
+
+### Port testcontainers upstream
+
+Contribute `project_name=` and log capture back to
+`testcontainers-python`.
+
+**Rejected.** Valuable generally, but the review / release cycle of an
+upstream library is the wrong thing to block our integration-test
+ergonomics on, and the ADR 0004 harness already duplicates a single
+caller's worth of logic on top of testcontainers (subprocess for
+`docker build`, bespoke readiness polling). A small in-tree harness
+is cheaper in aggregate.
+
+## Decision
+
+Replace `testcontainers-python` in the integration-test harness with
+an in-tree `DockerComposeCluster` module under
+`tests/integration/harness/`. Headline properties:
+
+- **Fluent builder.** `DockerComposeCluster.builder().project_name(x) .file(...).env(K, V).waiting_for_service(name, HealthChecks.…) .save_logs_to(dir, on_success=False).build()` — configuration is
+  explicit and local to the fixture.
+- **Subprocess-native.** Every action (`config`, `up`, `port`,
+  `exec`, `stop`, `logs`, `down`) is a direct `docker compose`
+  CLI invocation, so every harness failure maps 1:1 to a command a
+  developer can reproduce. The test runner never calls into a
+  third-party Python library for container lifecycle.
+- **Project name on the CLI.** `--project-name` is passed on the
+  command line; configured env vars flow into the subprocess via
+  `subprocess.run(env=...)`. `os.environ` is never mutated.
+- **Typed port accessor.** `running.service("agent-auth").port(9100)`
+  returns a `DockerPort` dataclass (`host` / `external_port` /
+  `internal_port`) with `in_format("http://$HOST:$EXTERNAL_PORT")`
+  — no more hand-rolled string concatenation.
+- **Declarative wait strategies.** `HealthChecks.to_respond_over_http`
+  and `HealthChecks.to_have_ports_open` cover the common cases; custom
+  callables `(ServiceHandle) -> (bool, diagnostic)` cover the rest.
+  Per-service waits run in parallel under a shared deadline: the first
+  unhealthy service fails the whole startup instead of waiting the full
+  timeout on every sibling.
+- **Log capture on teardown.** `save_logs_to(dir, on_success=False)`
+  dumps `docker compose logs <service>` into `dir/<service>.log`
+  before `docker compose down` runs, so a flaky CI run leaves an
+  artefact to upload.
+- **Compose file uses native interpolation.** The shared
+  `docker/docker-compose.yaml` now uses `${AGENT_AUTH_TEST_IMAGE}`
+  / `${AGENT_AUTH_TEST_CONFIG_DIR}` / `${THINGS_BRIDGE_TEST_FIXTURES_DIR}`
+  / `${NOTIFIER_MODE}`. `render_compose_file` and the
+  `COMPOSE_PROJECT_NAME` placeholder are gone; the project name is
+  passed via `--project-name`. One substitution mechanism, not two.
+- **Pre-flight validation.** `docker compose config --quiet` runs
+  before `up` so a typo in the compose file surfaces as "bad file"
+  rather than "container exited immediately".
+- **No external dependency.** `testcontainers[compose]` is dropped
+  from the `dev` extra and from the `tool.mypy.overrides` shim.
+
+`tests/integration/conftest.py` and
+`tests/integration/things_bridge/conftest.py` are rewritten on this
+harness; the `things-cli` invoker funnels `docker compose exec`
+through `StartedCluster.exec` so compose wiring lives in one place.
+`tests/integration/_support.py` keeps the session-scoped image-build
+helper, the docker-availability probe, the empty-fixture seed, and the
+structured phase-timing logger; `wait_until_server_ready` and
+`render_compose_file` are deleted.
+
+## Consequences
+
+- The integration suite no longer installs `testcontainers-python` —
+  the `dev` extra shrinks by one transitive graph. Docker + docker
+  compose remain required on the host (same as before).
+- Every fixture-layer action maps to a CLI invocation a developer can
+  reproduce on the command line, which shortens the loop when a test
+  fails only on CI.
+- `docker compose port` output is parsed from the right (`host, _, port_str = first_line.rpartition(":")`) so IPv6-bracketed hosts
+  still round-trip correctly. The parse is unit-tested.
+- Wait strategies are arbitrary callables; a careless probe that
+  performs heavy work on every poll can slow the whole suite. The
+  built-in `HealthChecks` stay cheap (a single HTTP GET or TCP
+  connect); custom probes are the caller's responsibility.
+- `save_logs_to(on_success=False)` needs the pytest node's per-phase
+  report to branch on test outcome. The top-level conftest installs a
+  `pytest_runtest_makereport` hook that exposes the reports on the
+  item, and a shared `_test_failed(request)` helper reads them — a
+  tiny fixture-layer dependency that every per-service teardown now
+  shares.
+- ADR 0004's Follow-ups entry "pin the base image by digest" is
+  unchanged. The "container scope" follow-up remains — the harness's
+  fluent builder makes a session-scoped `DockerComposeCluster`
+  straightforward to introduce if wall-clock becomes the bottleneck,
+  but that's a future lever rather than today's move.
+
+## Follow-ups
+
+- Consider exposing harness unit tests as a smoke gate in CI once the
+  integration runner stabilises on the new pattern.
+- If a second consumer outside this repo grows interest in the same
+  harness, lift it under `tests/` into a reusable internal package.
+  For now, a single caller doesn't justify the extra API surface.

--- a/design/decisions/README.md
+++ b/design/decisions/README.md
@@ -87,3 +87,5 @@ is linked from this index.
   — each service lives under `packages/<svc>/` with its own `pyproject.toml` + `install.sh`; `agent-auth-common` holds shared types; root `install.sh` is deleted and the README catalogues the per-service installers.
 - [ADR 0033 — Host-delegated GPG signing via gpg-cli / gpg-bridge split](0033-gpg-bridge-cli-split.md)
   — devcontainer `gpg-cli` forwards git's sign / verify requests over HTTPS to a host `gpg-bridge`, which validates with agent-auth (`gpg:sign` scope, `allowed_signing_keys` allowlist) and shells out to a host backend CLI that drives the real `gpg`. Private keys never leave the host; unblocks re-enabling `required_signatures` (#217).
+- [ADR 0034 — In-tree `DockerComposeCluster` harness for integration tests](0034-integration-harness-rework.md)
+  — replaces `testcontainers-python` with a subprocess-native fluent builder under `tests/integration/harness/`; supersedes the testcontainers-specific parts of ADR 0004 / 0005 while keeping the per-test Compose-project shape. Closes #80.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: MIT
 
-# Template — Python-style double-brace placeholders are substituted by
-# render_compose_file() in tests/integration/_support.py before docker
-# compose ever sees the file. Keeping the substitution surface in
-# Python (rather than $VAR interpolation handled by docker compose
-# itself) means the rendered, per-test file is self-contained and
-# docker compose never has to inherit env vars from the test process.
-name: {{ COMPOSE_PROJECT_NAME }}
+# Compose file used by every per-service integration-test fixture. The
+# test harness passes the project name via ``--project-name`` on the
+# docker compose CLI, and per-test values (per-service image tags,
+# bind-mount directories, notifier mode) via docker compose's native
+# ``${VAR}`` interpolation — fed from ``subprocess.run(env=...)`` so
+# the test runner's ``os.environ`` is never mutated. See
+# tests/integration/harness/ for the builder that stitches them
+# together.
 
 services:
   notifier:
@@ -18,12 +19,12 @@ services:
     # ``tests_support`` package at /opt/tests-support/. Mode is
     # substituted per-test so one compose template serves both
     # approve- and deny-path integration tests.
-    image: {{ AGENT_AUTH_TEST_IMAGE }}
-    entrypoint: ["python", "-m", "tests_support.notifier", "{{ NOTIFIER_MODE }}", "--host", "0.0.0.0", "--port", "9150"]
+    image: ${AGENT_AUTH_TEST_IMAGE}
+    entrypoint: ["python", "-m", "tests_support.notifier", "${NOTIFIER_MODE}", "--host", "0.0.0.0", "--port", "9150"]
     stop_grace_period: 5s
 
   agent-auth:
-    image: {{ AGENT_AUTH_TEST_IMAGE }}
+    image: ${AGENT_AUTH_TEST_IMAGE}
     # Bind only on loopback so the container is never reachable from the
     # rest of the network.
     ports:
@@ -32,19 +33,19 @@ services:
       # Per-test tmpdir holding config.yaml. The fixture copies
       # docker/config.test.yaml here and applies any per-test overrides
       # (TTLs, notifier URL) before starting the container.
-      - {{ AGENT_AUTH_TEST_CONFIG_DIR }}:/home/agent-auth/.config/agent-auth:ro
+      - ${AGENT_AUTH_TEST_CONFIG_DIR}:/home/agent-auth/.config/agent-auth:ro
     depends_on:
       - notifier
     stop_grace_period: 5s
 
   things-bridge:
-    image: {{ THINGS_BRIDGE_TEST_IMAGE }}
+    image: ${THINGS_BRIDGE_TEST_IMAGE}
     # Bind only on loopback so the container is never reachable from
     # the rest of the network.
     ports:
       - "127.0.0.1::9200"
     volumes:
-      - {{ THINGS_BRIDGE_TEST_FIXTURES_DIR }}:/srv/things-fixtures:ro
+      - ${THINGS_BRIDGE_TEST_FIXTURES_DIR}:/srv/things-fixtures:ro
     configs:
       - source: things_bridge_config
         target: /home/agent-auth/.config/things-bridge/config.yaml
@@ -63,7 +64,7 @@ services:
     # ``--wait`` into returning non-zero. ``docker compose run`` does
     # not require the target profile to be active, so the CLI test
     # harness still reaches the service without passing ``--profile``.
-    image: {{ THINGS_CLI_TEST_IMAGE }}
+    image: ${THINGS_CLI_TEST_IMAGE}
     profiles:
       - on-demand
     stop_grace_period: 5s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dev = [
     "pytest-cov>=5.0",
     "pytest>=8.0",
     "reuse>=4.0",
-    "testcontainers[compose]>=4",
     # keep-sorted end
 ]
 
@@ -209,8 +208,6 @@ module = [
     # keep-sorted start
     "keyring",
     "keyring.*",
-    "testcontainers",
-    "testcontainers.*",
     "yaml",
     # keep-sorted end
 ]

--- a/scripts/verify-integration-isolation.sh
+++ b/scripts/verify-integration-isolation.sh
@@ -114,6 +114,10 @@ for service_dir in tests/integration/*/; do
   # Skip pytest's bytecode caches and any other dunder directory.
   case "${service_dir}" in
     */__*__/) continue ;;
+    # Shared support packages — not a service, no container topology
+    # of their own. ``harness/`` carries the DockerComposeCluster
+    # builder every per-service conftest imports.
+    */harness/) continue ;;
   esac
   service_conftest="${service_dir}conftest.py"
   if [[ ! -f "${service_conftest}" ]]; then

--- a/tests/integration/_support.py
+++ b/tests/integration/_support.py
@@ -4,34 +4,30 @@
 
 """Shared helpers for the per-service Docker integration test fixtures.
 
-Each per-service ``conftest.py`` imports the helpers here so the
-compose template renderer, container-readiness probe, and Docker
-availability check have a single implementation.
+Per-service conftests use the :mod:`tests.integration.harness` builder
+to drive the compose lifecycle. The helpers here cover everything
+adjacent to that: session-scoped per-service image builds (with
+optional GitHub Actions cache passthrough), the docker availability
+probe, the empty ``things.yaml`` seed for the bridge bind-mount, and
+the structured phase-timing logger.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import re
 import shutil
 import subprocess
 import time
-import urllib.error
-import urllib.request
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCKER_DIR = REPO_ROOT / "docker"
-COMPOSE_TEMPLATE = DOCKER_DIR / "docker-compose.yaml"
-COMPOSE_FILE_NAME = "docker-compose.yaml"
-_PLACEHOLDER_PATTERN = re.compile(r"\{\{\s*([A-Za-z][A-Za-z0-9_]*)\s*\}\}")
+COMPOSE_FILE = DOCKER_DIR / "docker-compose.yaml"
 
 DOCKER_BUILD_TIMEOUT_SECONDS = 600.0
-READY_POLL_TIMEOUT_SECONDS = 30.0
-READY_POLL_INTERVAL_SECONDS = 0.2
 
 # Mapping from service name (as used by the Compose topology) to the
 # per-service Dockerfile that builds its integration test image. One
@@ -85,82 +81,10 @@ def docker_compose_available() -> bool:
     return True
 
 
-def wait_until_server_ready(
-    health_url: str,
-    *,
-    accept_status: tuple[int, ...] = (401, 403),
-) -> None:
-    """Block until ``health_url`` answers, treating ``accept_status`` as up.
-
-    Both health endpoints (``agent-auth/health`` and
-    ``things-bridge/health``) require a scoped bearer token, so an
-    unauthenticated probe returns ``401``. The fixture treats that —
-    along with ``403`` (valid shape, scope missing) — as a positive
-    "server is up" signal.
-    """
-    with phase_timer("wait_until_server_ready", url=health_url):
-        deadline = time.monotonic() + READY_POLL_TIMEOUT_SECONDS
-        last_error: Exception | None = None
-        while time.monotonic() < deadline:
-            try:
-                with urllib.request.urlopen(health_url, timeout=2) as resp:
-                    if 200 <= resp.status < 300:
-                        return
-            except urllib.error.HTTPError as exc:
-                if exc.code in accept_status:
-                    return
-                last_error = exc
-            except (urllib.error.URLError, ConnectionError, TimeoutError) as exc:
-                last_error = exc
-            time.sleep(READY_POLL_INTERVAL_SECONDS)
-        raise RuntimeError(
-            f"Service never became reachable at {health_url} within "
-            f"{READY_POLL_TIMEOUT_SECONDS}s (last error: {last_error!r})"
-        )
-
-
-def render_compose_file(target_dir: Path, **substitutions: str) -> Path:
-    """Render the compose template with double-brace placeholders
-    substituted, writing the result into ``target_dir`` and returning
-    the rendered path.
-
-    The compose template carries every test-specific value as a
-    double-brace placeholder so the rendered file is self-contained:
-    docker compose never has to inherit env vars from the test runner,
-    and there is no shared mutable state between concurrent fixture
-    invocations.
-
-    Comment lines (those whose first non-whitespace char is ``#``) are
-    excluded from the leftover-placeholder check, so the template can
-    document its own substitution syntax in YAML comments without
-    tripping the guard.
-
-    Raises ``KeyError`` if a substitution doesn't match any placeholder
-    in the template (typo guard) or if the rendered output still
-    contains an unsubstituted placeholder outside a comment (forgotten
-    value guard).
-    """
-    template = COMPOSE_TEMPLATE.read_text()
-    for key, value in substitutions.items():
-        placeholder = f"{{{{ {key} }}}}"
-        if placeholder not in template:
-            raise KeyError(f"placeholder {placeholder!r} not found in {COMPOSE_TEMPLATE.name}")
-        template = template.replace(placeholder, value)
-    non_comment = "\n".join(
-        line for line in template.splitlines() if not line.lstrip().startswith("#")
-    )
-    leftover = sorted(set(_PLACEHOLDER_PATTERN.findall(non_comment)))
-    if leftover:
-        raise KeyError(f"unsubstituted placeholders in {COMPOSE_TEMPLATE.name}: {leftover}")
-    target = target_dir / COMPOSE_FILE_NAME
-    target.write_text(template)
-    return target
-
-
 def seed_empty_fixtures_dir(fixtures_dir: Path) -> None:
     """Write an empty ``things.yaml`` into ``fixtures_dir``.
 
-    The combined Compose file always starts the things-bridge container
+    The shared Compose file always starts the things-bridge container
     (even for agent-auth-only tests), and the bridge invokes the fake
     Things CLI which expects a fixture file. Tests that exercise the
     bridge overwrite this file via ``ThingsBridgeStack.write_fixture``.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,9 +10,11 @@ port, and filesystem. The test talks to the mapped loopback port and
 drives state through the agent-auth HTTP API + the ``agent-auth`` CLI
 running inside the container.
 
-The Compose lifecycle is managed by ``testcontainers-python``; the
-session-scoped image build remains a direct ``docker build`` call so the
-test image is rebuilt once per pytest run off the working tree.
+Compose lifecycle is handled by :mod:`tests.integration.harness` — a
+fluent builder over ``docker compose`` (subprocess, no testcontainers).
+The session-scoped image build remains a direct ``docker build`` call so
+each per-service test image is rebuilt once per pytest run off the
+working tree.
 """
 
 from __future__ import annotations
@@ -29,18 +31,21 @@ from typing import Any, cast
 
 import pytest
 import yaml
-from testcontainers.compose import DockerCompose
 
 from agent_auth_client import AgentAuthClient
 from tests.integration._support import (
+    COMPOSE_FILE,
     DOCKER_DIR,
     PER_SERVICE_DOCKERFILES,
     build_test_image,
     docker_compose_available,
     phase_timer,
-    render_compose_file,
     seed_empty_fixtures_dir,
-    wait_until_server_ready,
+)
+from tests.integration.harness import (
+    DockerComposeCluster,
+    HealthChecks,
+    StartedCluster,
 )
 
 # The integration runner enables ``log_cli_level=INFO`` so the
@@ -49,7 +54,7 @@ from tests.integration._support import (
 # under noise unrelated to timing. Raise their floors to WARNING so
 # the CI log stays grep-friendly. Done unconditionally because this
 # module is only imported when the integration suite runs.
-for _noisy_logger in ("docker", "urllib3", "testcontainers", "asyncio"):
+for _noisy_logger in ("docker", "urllib3", "asyncio"):
     logging.getLogger(_noisy_logger).setLevel(logging.WARNING)
 
 BASELINE_CONFIG = DOCKER_DIR / "config.test.yaml"
@@ -69,19 +74,21 @@ APPROVAL_PLUGINS = {
 # DNS.
 NOTIFIER_SIDECAR_URL = "http://notifier:9150/"
 
+AGENT_AUTH_INTERNAL_PORT = 9100
+
 
 @dataclass
 class AgentAuthContainer:
     """Handle for a running agent-auth integration-test container.
 
-    The compose file is rendered per-test (every placeholder is
-    substituted in Python before docker compose ever sees the file), so
-    no env-var inheritance is required around ``exec_in_container`` or
-    teardown calls.
+    ``cluster`` is the started compose cluster the ``agent-auth`` service
+    belongs to. The external port is resolved lazily via the harness's
+    :class:`DockerPort` accessor so base_url construction never hand-rolls
+    a URL string.
     """
 
     base_url: str
-    compose: DockerCompose
+    cluster: StartedCluster
     service: str = "agent-auth"
     _mgmt_token_cache: str | None = field(default=None, init=False, repr=False, compare=False)
     _client_cache: AgentAuthClient | None = field(
@@ -110,16 +117,14 @@ class AgentAuthContainer:
         exit so pytest tracebacks show *why* the CLI failed rather than an
         opaque ``CalledProcessError``.
         """
-        stdout, stderr, exit_code = self.compose.exec_in_container(
-            ["agent-auth", *args],
-            service_name=self.service,
-        )
-        if exit_code != 0:
+        result = self.cluster.exec(self.service, ["agent-auth", *args])
+        if result.returncode != 0:
             raise RuntimeError(
                 f"`agent-auth {' '.join(args)}` failed: "
-                f"exit={exit_code} stdout={stdout!r} stderr={stderr!r}"
+                f"exit={result.returncode} stdout={result.stdout!r} "
+                f"stderr={result.stderr!r}"
             )
-        return cast(str, stdout)
+        return result.stdout
 
     def create_token(self, *scopes: str) -> dict[str, Any]:
         """Create a token family inside the container and return the parsed JSON.
@@ -238,17 +243,103 @@ def _write_test_config(config_dir: Path, **overrides: object) -> None:
     os.chmod(config_path, 0o644)
 
 
+def _compose_image_env(image_tags: dict[str, str]) -> dict[str, str]:
+    """Return the per-service image env vars the shared compose file reads.
+
+    Centralised so the agent-auth-only and bridge fixtures pass the
+    same keys — the compose file rejects a run that leaves a ``${VAR}``
+    unresolved.
+    """
+    return {
+        "AGENT_AUTH_TEST_IMAGE": image_tags["agent-auth"],
+        "THINGS_BRIDGE_TEST_IMAGE": image_tags["things-bridge"],
+        "THINGS_CLI_TEST_IMAGE": image_tags["things-cli"],
+    }
+
+
+def _agent_auth_cluster(
+    *,
+    project_name: str,
+    image_tags: dict[str, str],
+    config_dir: Path,
+    fixtures_dir: Path,
+    notifier_mode: str,
+    logs_dir: Path,
+) -> DockerComposeCluster:
+    """Build the per-test cluster definition for agent-auth integration tests.
+
+    Factored out so the bridge fixture (which uses the same compose file
+    but waits for ``things-bridge`` too) can extend it without copying
+    the env-var wiring.
+    """
+    builder = (
+        DockerComposeCluster.builder()
+        .project_name(project_name)
+        .file(COMPOSE_FILE)
+        .env("AGENT_AUTH_TEST_CONFIG_DIR", str(config_dir))
+        .env("THINGS_BRIDGE_TEST_FIXTURES_DIR", str(fixtures_dir))
+        .env("NOTIFIER_MODE", notifier_mode)
+    )
+    for key, value in _compose_image_env(image_tags).items():
+        builder = builder.env(key, value)
+    return (
+        builder.waiting_for_service(
+            "agent-auth",
+            HealthChecks.to_respond_over_http(
+                internal_port=AGENT_AUTH_INTERNAL_PORT,
+                url_format="http://$HOST:$EXTERNAL_PORT/agent-auth/health",
+                accept_statuses={401, 403},
+            ),
+        )
+        .save_logs_to(logs_dir, on_success=False)
+        .build()
+    )
+
+
+def _test_failed(request: pytest.FixtureRequest) -> bool:
+    """Return True if the pytest node that requested the fixture failed.
+
+    Relies on the ``makereport`` hook in this conftest setting
+    ``rep_setup`` / ``rep_call`` attributes on the test item. A missing
+    attribute means the test never reached the call phase (collection
+    failure or setup-time error), which we conservatively treat as a
+    failure so logs are still captured.
+    """
+    setup = getattr(request.node, "rep_setup", None)
+    call = getattr(request.node, "rep_call", None)
+    if setup is not None and setup.failed:
+        return True
+    if call is None:
+        return True
+    return bool(call.failed)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Expose the per-phase report on the item so fixtures can branch on test failure.
+
+    Required for ``save_logs_to(..., on_success=False)`` to see whether
+    the test passed or failed before teardown triggers log capture.
+    """
+    outcome = yield
+    report = outcome.get_result()
+    setattr(item, f"rep_{report.when}", report)
+
+
 @pytest.fixture
 def agent_auth_container_factory(
     _test_image_tags: dict[str, str],
     tmp_path_factory: pytest.TempPathFactory,
+    request: pytest.FixtureRequest,
 ) -> Generator[Callable[..., AgentAuthContainer], None, None]:
     """Factory fixture — spin up an agent-auth container with custom config.
 
     Each invocation starts a fresh Compose project. Teardown is registered
-    on the fixture so every container is removed at the end of the test.
+    on the fixture so every cluster is stopped at the end of the test.
+    Per-service ``docker compose logs`` are dumped into a tmpdir on
+    failure for CI to upload.
     """
-    started: list[tuple[str, DockerCompose]] = []
+    started: list[StartedCluster] = []
 
     def _factory(
         *,
@@ -272,54 +363,35 @@ def agent_auth_container_factory(
         )
 
         # The combined Compose file always starts the things-bridge
-        # container alongside agent-auth (its config is shipped inline
-        # by docker-compose.yaml), so we only need to satisfy the
-        # fixtures bind mount even when this test never drives the
-        # bridge. Tests that exercise the bridge use the
-        # things_bridge_stack fixture which writes its own fixture data.
+        # container alongside agent-auth, so we still need a fixtures
+        # dir even when this test never drives the bridge.
         bridge_fixtures_dir = tmp_path_factory.mktemp(f"tb-fix-{project_name}")
         seed_empty_fixtures_dir(bridge_fixtures_dir)
 
-        rendered_compose = render_compose_file(
-            tmp_path_factory.mktemp(f"compose-{project_name}"),
-            COMPOSE_PROJECT_NAME=project_name,
-            AGENT_AUTH_TEST_IMAGE=_test_image_tags["agent-auth"],
-            THINGS_BRIDGE_TEST_IMAGE=_test_image_tags["things-bridge"],
-            THINGS_CLI_TEST_IMAGE=_test_image_tags["things-cli"],
-            AGENT_AUTH_TEST_CONFIG_DIR=str(config_dir),
-            THINGS_BRIDGE_TEST_FIXTURES_DIR=str(bridge_fixtures_dir),
-            NOTIFIER_MODE=APPROVAL_PLUGINS[approval],
+        logs_dir = tmp_path_factory.mktemp(f"logs-{project_name}")
+        cluster = _agent_auth_cluster(
+            project_name=project_name,
+            image_tags=_test_image_tags,
+            config_dir=config_dir,
+            fixtures_dir=bridge_fixtures_dir,
+            notifier_mode=APPROVAL_PLUGINS[approval],
+            logs_dir=logs_dir,
         )
-
-        compose = DockerCompose(
-            context=str(rendered_compose.parent),
-            compose_file_name=rendered_compose.name,
-        )
-        started.append((project_name, compose))
         with phase_timer("compose_start", project=project_name, service="agent-auth"):
-            compose.start()
+            running = cluster.start()
+        started.append(running)
 
-        host = compose.get_service_host("agent-auth", 9100)
-        port = compose.get_service_port("agent-auth", 9100)
-        base_url = f"http://{host}:{port}"
-        # /agent-auth/health requires an ``agent-auth:health`` token,
-        # so an unauthenticated probe gets 401 (or 403 if the scope
-        # check ran). Either is a positive "server is up" signal.
-        wait_until_server_ready(
-            f"{base_url}/agent-auth/health",
-            accept_status=(401, 403),
-        )
-        return AgentAuthContainer(
-            base_url=base_url,
-            compose=compose,
-        )
+        port = running.service("agent-auth").port(AGENT_AUTH_INTERNAL_PORT)
+        base_url = port.in_format("http://$HOST:$EXTERNAL_PORT")
+        return AgentAuthContainer(base_url=base_url, cluster=running)
 
     yield _factory
 
-    for project_name, compose in started:
+    failed = _test_failed(request)
+    for running in started:
         try:
-            with phase_timer("compose_stop", project=project_name, service="agent-auth"):
-                compose.stop()
+            with phase_timer("compose_stop", project=running.project_name, service="agent-auth"):
+                running.stop(test_failed=failed)
         except Exception as e:
             print(f"warning: compose teardown failed: {e!r}")
 

--- a/tests/integration/harness/__init__.py
+++ b/tests/integration/harness/__init__.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Fluent Docker Compose harness for the integration test suite.
+
+Each per-service ``conftest.py`` builds a :class:`DockerComposeCluster`
+per test, starts it, reads ports off :class:`DockerPort` accessors, and
+tears it down on fixture teardown — with optional log capture into the
+pytest ``tmp_path`` when a test fails.
+
+The harness wraps ``docker compose`` directly (subprocess, no
+``testcontainers-python``), so every action maps 1:1 to a CLI invocation
+a developer can reproduce locally. It explicitly never mutates
+``os.environ`` — configured env vars flow into the ``docker compose``
+subprocess via ``env=``, and the project name is passed on the CLI via
+``--project-name``.
+
+Inspired by ``palantir/docker-compose-rule`` (JUnit rule). See
+``design/decisions/0005-integration-harness-rework.md`` for the rework
+rationale.
+"""
+
+from tests.integration.harness._cluster import (
+    ClusterStartupTimeout,
+    DockerComposeCluster,
+    DockerComposeClusterBuilder,
+    ServiceHandle,
+    StartedCluster,
+)
+from tests.integration.harness._port import DockerPort
+from tests.integration.harness._wait import (
+    HealthChecks,
+    ServiceWaitFn,
+)
+
+__all__ = [
+    "ClusterStartupTimeout",
+    "DockerComposeCluster",
+    "DockerComposeClusterBuilder",
+    "DockerPort",
+    "HealthChecks",
+    "ServiceHandle",
+    "ServiceWaitFn",
+    "StartedCluster",
+]

--- a/tests/integration/harness/_cluster.py
+++ b/tests/integration/harness/_cluster.py
@@ -1,0 +1,611 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Fluent builder for a ``docker compose`` lifecycle under integration tests.
+
+The harness wraps ``docker compose`` directly via ``subprocess`` — there
+is no testcontainers dependency. Every action (``config``, ``up``,
+``port``, ``exec``, ``logs``, ``down``) maps 1:1 to a CLI invocation
+the developer can reproduce by hand, which keeps failures debuggable.
+
+Design properties preserved from ``palantir/docker-compose-rule``:
+
+- **Fluent builder** — configuration is explicit and local to the test
+  fixture; no hidden state.
+- **Project name on the CLI** — passed via ``--project-name`` rather than
+  mutating ``os.environ``'s ``COMPOSE_PROJECT_NAME``.
+- **Env via subprocess ``env=``** — configured env vars are handed to
+  ``docker compose`` through ``subprocess.run(env=...)`` only. The test
+  process's ``os.environ`` is never mutated.
+- **Parallel wait with shared deadline** — the first unhealthy service
+  fails the whole startup instead of waiting the full timeout on every
+  other service serially.
+- **Pre-flight ``docker compose config``** — cheap YAML validation so a
+  typo surfaces as "bad file" rather than "container exited immediately".
+- **Log capture on teardown** — ``save_logs_to(dir, on_success=False)``
+  dumps ``docker compose logs`` per service on failure (or always, if
+  the caller wants it), giving CI an artefact to upload.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from tests.integration.harness._port import DockerPort
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Self
+
+    from tests.integration.harness._wait import ServiceWaitFn
+
+_log = logging.getLogger("integration.harness")
+
+DEFAULT_START_TIMEOUT_SECONDS = 30.0
+DEFAULT_POLL_INTERVAL_SECONDS = 0.2
+DEFAULT_STOP_TIMEOUT_SECONDS = 30.0
+DEFAULT_CONFIG_TIMEOUT_SECONDS = 30.0
+DEFAULT_UP_TIMEOUT_SECONDS = 300.0
+DEFAULT_PORT_LOOKUP_TIMEOUT_SECONDS = 15.0
+DEFAULT_LOGS_TIMEOUT_SECONDS = 30.0
+
+
+class ClusterStartupTimeout(RuntimeError):
+    """Raised when one or more services fail every wait probe before the deadline."""
+
+
+@dataclass(frozen=True)
+class _ServiceWait:
+    """Binds a ``ServiceWaitFn`` to the service it probes."""
+
+    service: str
+    check: ServiceWaitFn
+    label: str
+
+
+@dataclass
+class DockerComposeClusterBuilder:
+    """Fluent builder for :class:`DockerComposeCluster`.
+
+    Only a builder, not a runtime object — call :meth:`build` to freeze
+    the configuration into a :class:`DockerComposeCluster`, then
+    :meth:`DockerComposeCluster.start` to launch it. Separating the two
+    means the same cluster definition can be inspected by unit tests
+    without starting a subprocess.
+    """
+
+    _project_name: str | None = None
+    _files: list[Path] = field(default_factory=list)
+    _env: dict[str, str] = field(default_factory=dict)
+    _waits: list[_ServiceWait] = field(default_factory=list)
+    _logs_dir: Path | None = None
+    _logs_on_success: bool = False
+    _start_timeout_seconds: float = DEFAULT_START_TIMEOUT_SECONDS
+    _poll_interval_seconds: float = DEFAULT_POLL_INTERVAL_SECONDS
+    _stop_timeout_seconds: float = DEFAULT_STOP_TIMEOUT_SECONDS
+
+    def project_name(self, name: str) -> Self:
+        """Set the ``docker compose --project-name`` value. Required."""
+        self._project_name = name
+        return self
+
+    def file(self, path: Path | str) -> Self:
+        """Add a ``-f <path>`` compose file. At least one is required."""
+        self._files.append(Path(path))
+        return self
+
+    def env(self, key: str, value: str) -> Self:
+        """Add an env var to the ``docker compose`` subprocess. Never touches ``os.environ``."""
+        self._env[key] = value
+        return self
+
+    def waiting_for_service(
+        self, service: str, check: ServiceWaitFn, *, label: str | None = None
+    ) -> Self:
+        """Register a readiness probe polled until healthy or timeout.
+
+        ``label`` is surfaced in timeout error messages when set — useful
+        when the same service has multiple probes and you want to tell
+        them apart.
+        """
+        self._waits.append(_ServiceWait(service=service, check=check, label=label or service))
+        return self
+
+    def save_logs_to(self, directory: Path | str, *, on_success: bool = False) -> Self:
+        """Persist ``docker compose logs`` per service into ``directory`` on teardown.
+
+        ``on_success=False`` (default) only writes logs when the cluster
+        startup failed or the caller passed ``test_failed=True`` to
+        :meth:`StartedCluster.stop`. Flip to ``True`` to always capture.
+        """
+        self._logs_dir = Path(directory)
+        self._logs_on_success = on_success
+        return self
+
+    def start_timeout_seconds(self, seconds: float) -> Self:
+        """Override the cluster-wide wait deadline (default 30 s)."""
+        self._start_timeout_seconds = seconds
+        return self
+
+    def poll_interval_seconds(self, seconds: float) -> Self:
+        """Override the wait-strategy poll interval (default 0.2 s)."""
+        self._poll_interval_seconds = seconds
+        return self
+
+    def build(self) -> DockerComposeCluster:
+        """Freeze builder state into an immutable :class:`DockerComposeCluster`.
+
+        Raises ``ValueError`` on missing required inputs — caught early so
+        a typo shows up at fixture-setup time, not inside ``docker compose``.
+        """
+        if self._project_name is None:
+            raise ValueError("DockerComposeClusterBuilder: project_name() is required")
+        if not self._files:
+            raise ValueError("DockerComposeClusterBuilder: at least one file() is required")
+        return DockerComposeCluster(
+            project_name=self._project_name,
+            files=tuple(self._files),
+            env=dict(self._env),
+            waits=tuple(self._waits),
+            logs_dir=self._logs_dir,
+            logs_on_success=self._logs_on_success,
+            start_timeout_seconds=self._start_timeout_seconds,
+            poll_interval_seconds=self._poll_interval_seconds,
+            stop_timeout_seconds=self._stop_timeout_seconds,
+        )
+
+
+@dataclass(frozen=True)
+class DockerComposeCluster:
+    """Immutable definition of a compose project.
+
+    Build via :meth:`builder`; launch via :meth:`start`.
+    """
+
+    project_name: str
+    files: tuple[Path, ...]
+    env: dict[str, str]
+    waits: tuple[_ServiceWait, ...]
+    logs_dir: Path | None
+    logs_on_success: bool
+    start_timeout_seconds: float
+    poll_interval_seconds: float
+    stop_timeout_seconds: float
+
+    @staticmethod
+    def builder() -> DockerComposeClusterBuilder:
+        """Return a new :class:`DockerComposeClusterBuilder`."""
+        return DockerComposeClusterBuilder()
+
+    def start(self) -> StartedCluster:
+        """Validate the compose file, ``up -d``, wait for services, return the handle.
+
+        On any failure before all waits succeed, the partially-started
+        project is torn down (and logs are captured if ``save_logs_to``
+        is configured) before the exception propagates. That way a
+        failed startup never leaves orphan containers behind.
+        """
+        running = StartedCluster(
+            project_name=self.project_name,
+            files=self.files,
+            env=dict(self.env),
+            logs_dir=self.logs_dir,
+            logs_on_success=self.logs_on_success,
+            stop_timeout_seconds=self.stop_timeout_seconds,
+        )
+        try:
+            running._validate_compose_files()
+            running._compose_up()
+            if self.waits:
+                running._wait_for_all_services(
+                    waits=self.waits,
+                    deadline_seconds=self.start_timeout_seconds,
+                    poll_interval_seconds=self.poll_interval_seconds,
+                )
+        except BaseException:
+            running.stop(test_failed=True)
+            raise
+        return running
+
+
+@dataclass
+class StartedCluster:
+    """Running compose project — ports, exec, teardown.
+
+    Don't instantiate directly — obtained from :meth:`DockerComposeCluster.start`.
+    """
+
+    project_name: str
+    files: tuple[Path, ...]
+    env: dict[str, str]
+    logs_dir: Path | None
+    logs_on_success: bool
+    stop_timeout_seconds: float
+    _stopped: bool = field(default=False, init=False, repr=False, compare=False)
+    _port_cache: dict[tuple[str, int], DockerPort] = field(
+        default_factory=dict, init=False, repr=False, compare=False
+    )
+
+    @property
+    def compose_file(self) -> Path:
+        """Return the first ``-f`` file. Convenience for callers that shell out.
+
+        Compose v2 accepts one ``-f`` from the fixture today; if a future
+        test needs to stack multiple files, use :meth:`file_args` instead.
+        """
+        return self.files[0]
+
+    def file_args(self) -> list[str]:
+        """Return ``["-f", path, "-f", path, ...]`` for subprocess arg construction."""
+        args: list[str] = []
+        for file in self.files:
+            args.extend(["-f", str(file)])
+        return args
+
+    def service(self, name: str) -> ServiceHandle:
+        """Return a handle to ``name`` for port lookup and exec."""
+        return ServiceHandle(cluster=self, name=name)
+
+    def resolve_port(self, service: str, internal_port: int) -> DockerPort:
+        """Resolve and cache the external mapping for ``service:internal_port``.
+
+        Results are cached for the lifetime of the :class:`StartedCluster`
+        because external port assignments don't change after ``up`` — the
+        wait loop would otherwise shell out on every poll iteration.
+        """
+        key = (service, internal_port)
+        cached = self._port_cache.get(key)
+        if cached is not None:
+            return cached
+        port = self._lookup_port(service, internal_port)
+        self._port_cache[key] = port
+        return port
+
+    def exec(
+        self,
+        service: str,
+        argv: Sequence[str],
+        *,
+        timeout_seconds: float | None = None,
+        input_text: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run ``docker compose exec -T <service> <argv>`` and return the result.
+
+        Does not raise on non-zero exit — callers decide how to interpret
+        exit codes (negative-path tests sometimes want the failure for
+        assertion). ``-T`` disables TTY allocation; required because the
+        test runner is not attached to a terminal.
+        """
+        return subprocess.run(
+            [
+                "docker",
+                "compose",
+                *self.file_args(),
+                "--project-name",
+                self.project_name,
+                "exec",
+                "-T",
+                service,
+                *argv,
+            ],
+            env=self._subprocess_env(),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_seconds,
+            input=input_text,
+        )
+
+    def stop_service(self, service: str, *, timeout_seconds: float = 30.0) -> None:
+        """Stop a single service without tearing the rest of the project down.
+
+        Used to exercise cross-service failure modes (e.g. the bridge's
+        ``authz_unavailable`` path where ``agent-auth`` goes away but
+        the bridge keeps serving).
+        """
+        result = subprocess.run(
+            [
+                "docker",
+                "compose",
+                *self.file_args(),
+                "--project-name",
+                self.project_name,
+                "stop",
+                service,
+            ],
+            env=self._subprocess_env(),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"docker compose stop {service!r} failed for project "
+                f"{self.project_name!r}: exit={result.returncode} "
+                f"stdout={result.stdout!r} stderr={result.stderr!r}"
+            )
+
+    def logs(
+        self,
+        service: str | None = None,
+        *,
+        timeout_seconds: float = DEFAULT_LOGS_TIMEOUT_SECONDS,
+    ) -> str:
+        """Return ``docker compose logs`` output. All services when ``service is None``."""
+        cmd = [
+            "docker",
+            "compose",
+            *self.file_args(),
+            "--project-name",
+            self.project_name,
+            "logs",
+            "--no-color",
+        ]
+        if service is not None:
+            cmd.append(service)
+        result = subprocess.run(
+            cmd,
+            env=self._subprocess_env(),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+        return result.stdout
+
+    def list_services(self) -> list[str]:
+        """Return service names defined in the compose files (via ``config --services``)."""
+        result = subprocess.run(
+            [
+                "docker",
+                "compose",
+                *self.file_args(),
+                "--project-name",
+                self.project_name,
+                "config",
+                "--services",
+            ],
+            env=self._subprocess_env(),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=DEFAULT_CONFIG_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0:
+            return []
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    def stop(self, *, test_failed: bool = False) -> None:
+        """Tear the project down (``down -v --remove-orphans``). Idempotent.
+
+        Captures ``docker compose logs`` into ``logs_dir`` BEFORE running
+        ``down`` so the container logs still exist. When ``test_failed``
+        is ``True`` or the caller opted into ``on_success=True``, per-
+        service logs are written under ``logs_dir``.
+        """
+        if self._stopped:
+            return
+        self._stopped = True
+        if self.logs_dir is not None and (test_failed or self.logs_on_success):
+            self._save_logs()
+        self._compose_down()
+
+    # --- subprocess helpers -------------------------------------------------
+
+    def _subprocess_env(self) -> dict[str, str]:
+        """Build the env for ``docker compose`` — inherited PATH/DOCKER_* plus our overrides.
+
+        Never mutates ``os.environ``.
+        """
+        merged = dict(os.environ)
+        merged.update(self.env)
+        return merged
+
+    def _validate_compose_files(self) -> None:
+        result = subprocess.run(
+            [
+                "docker",
+                "compose",
+                *self.file_args(),
+                "--project-name",
+                self.project_name,
+                "config",
+                "--quiet",
+            ],
+            env=self._subprocess_env(),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=DEFAULT_CONFIG_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"docker compose config failed for project {self.project_name!r}: "
+                f"exit={result.returncode} stdout={result.stdout!r} "
+                f"stderr={result.stderr!r}"
+            )
+
+    def _compose_up(self) -> None:
+        result = subprocess.run(
+            [
+                "docker",
+                "compose",
+                *self.file_args(),
+                "--project-name",
+                self.project_name,
+                "up",
+                "-d",
+                "--remove-orphans",
+            ],
+            env=self._subprocess_env(),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=DEFAULT_UP_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"docker compose up failed for project {self.project_name!r}: "
+                f"exit={result.returncode} stdout={result.stdout!r} "
+                f"stderr={result.stderr!r}"
+            )
+
+    def _compose_down(self) -> None:
+        # Defensive: docker compose down -t takes an int (seconds).
+        down_timeout = int(self.stop_timeout_seconds)
+        result = subprocess.run(
+            [
+                "docker",
+                "compose",
+                *self.file_args(),
+                "--project-name",
+                self.project_name,
+                "down",
+                "-v",
+                "--remove-orphans",
+                "-t",
+                str(down_timeout),
+            ],
+            env=self._subprocess_env(),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=max(60.0, self.stop_timeout_seconds + 30.0),
+        )
+        if result.returncode != 0:
+            # Log rather than raise — teardown must be best-effort so a
+            # failing-down doesn't mask the test's original failure.
+            _log.warning(
+                "docker compose down failed for project %r: exit=%d stdout=%r stderr=%r",
+                self.project_name,
+                result.returncode,
+                result.stdout,
+                result.stderr,
+            )
+
+    def _save_logs(self) -> None:
+        assert self.logs_dir is not None
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        services = self.list_services()
+        if not services:
+            # Fall back to a single combined dump so we at least leave
+            # *something* behind when ``config --services`` fails (e.g.
+            # the compose file no longer parses).
+            combined = self.logs()
+            (self.logs_dir / "combined.log").write_text(combined)
+            return
+        for service in services:
+            output = self.logs(service)
+            (self.logs_dir / f"{service}.log").write_text(output)
+
+    def _lookup_port(self, service: str, internal_port: int) -> DockerPort:
+        result = subprocess.run(
+            [
+                "docker",
+                "compose",
+                *self.file_args(),
+                "--project-name",
+                self.project_name,
+                "port",
+                service,
+                str(internal_port),
+            ],
+            env=self._subprocess_env(),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=DEFAULT_PORT_LOOKUP_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            raise RuntimeError(
+                f"could not resolve external port for service {service!r} "
+                f"internal_port={internal_port} in project "
+                f"{self.project_name!r}: exit={result.returncode} "
+                f"stdout={result.stdout!r} stderr={result.stderr!r}"
+            )
+        # docker compose port prints one "host:port" line per published
+        # mapping; our fixtures bind each port once, so take the first
+        # line and parse from the right to handle IPv6-bracketed hosts.
+        first_line = result.stdout.strip().splitlines()[0].strip()
+        host, sep, port_str = first_line.rpartition(":")
+        if not sep or not port_str.isdigit() or not host:
+            raise RuntimeError(
+                f"could not parse docker compose port output {first_line!r} "
+                f"for service {service!r} internal_port={internal_port}"
+            )
+        return DockerPort(
+            host=host,
+            external_port=int(port_str),
+            internal_port=internal_port,
+        )
+
+    def _wait_for_all_services(
+        self,
+        *,
+        waits: tuple[_ServiceWait, ...],
+        deadline_seconds: float,
+        poll_interval_seconds: float,
+    ) -> None:
+        deadline = time.monotonic() + deadline_seconds
+        # max_workers must be >=1 even if waits is somehow empty; build
+        # guards that upstream but we keep the clamp defensive here.
+        worker_count = max(1, len(waits))
+        with ThreadPoolExecutor(max_workers=worker_count) as pool:
+            futures = {
+                pool.submit(self._poll_service, wait, deadline, poll_interval_seconds): wait
+                for wait in waits
+            }
+            for fut in as_completed(futures):
+                ok, diagnostic = fut.result()
+                wait = futures[fut]
+                if not ok:
+                    raise ClusterStartupTimeout(
+                        f"service {wait.service!r} ({wait.label}) not healthy "
+                        f"within {deadline_seconds}s: {diagnostic}"
+                    )
+
+    def _poll_service(
+        self,
+        wait: _ServiceWait,
+        deadline: float,
+        poll_interval_seconds: float,
+    ) -> tuple[bool, str]:
+        last_diagnostic = "no attempts recorded"
+        while True:
+            try:
+                ok, diagnostic = wait.check(self.service(wait.service))
+                last_diagnostic = diagnostic
+                if ok:
+                    return True, diagnostic
+            except Exception as exc:
+                last_diagnostic = f"probe raised: {exc!r}"
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False, last_diagnostic
+            time.sleep(min(poll_interval_seconds, remaining))
+
+
+@dataclass(frozen=True)
+class ServiceHandle:
+    """View of one service inside a :class:`StartedCluster`.
+
+    Lightweight — created on demand by ``StartedCluster.service(name)``.
+    Actual port lookup + caching lives on the cluster so repeated
+    ``service("x").port(9100)`` calls share the cache.
+    """
+
+    cluster: StartedCluster
+    name: str
+
+    def port(self, internal_port: int) -> DockerPort:
+        """Return the external :class:`DockerPort` mapped to ``internal_port``."""
+        return self.cluster.resolve_port(self.name, internal_port)

--- a/tests/integration/harness/_port.py
+++ b/tests/integration/harness/_port.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Typed accessor for a Compose service's external port mapping."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DockerPort:
+    """External/internal port mapping for a running Compose service.
+
+    Obtained via ``StartedCluster.service(name).port(internal_port)``.
+    Mirrors ``DockerPort`` from ``palantir/docker-compose-rule`` — the
+    structured triple replaces hand-rolled string concatenation of host +
+    port pairs that the testcontainers-era harness relied on.
+    """
+
+    host: str
+    external_port: int
+    internal_port: int
+
+    def in_format(self, template: str) -> str:
+        """Substitute ``$HOST``, ``$EXTERNAL_PORT``, ``$INTERNAL_PORT`` into ``template``.
+
+        Typical use: ``port.in_format("http://$HOST:$EXTERNAL_PORT/api")``.
+        Placeholders are plain string replacements — no regex, no escaping —
+        so a literal ``$`` in the template outside a placeholder is preserved
+        as-is.
+        """
+        return (
+            template.replace("$HOST", self.host)
+            .replace("$EXTERNAL_PORT", str(self.external_port))
+            .replace("$INTERNAL_PORT", str(self.internal_port))
+        )

--- a/tests/integration/harness/_wait.py
+++ b/tests/integration/harness/_wait.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Readiness probes for services in a Docker Compose cluster.
+
+Each probe is a callable ``(ServiceHandle) -> (ok, diagnostic)``. The
+diagnostic is surfaced in the startup-timeout error message so a flaky
+probe shows up as a concrete symptom ("status=502 not in accept_statuses")
+rather than an opaque timeout. The :class:`HealthChecks` factory hosts
+the common strategies — callers that need bespoke logic can just write
+their own callable.
+"""
+
+from __future__ import annotations
+
+import socket
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tests.integration.harness._cluster import ServiceHandle
+
+
+ServiceWaitFn = Callable[["ServiceHandle"], tuple[bool, str]]
+"""Readiness probe: ``(service) -> (is_healthy, diagnostic_message)``.
+
+``ServiceWaitFn`` is polled until it returns ``True`` or the cluster's
+start-timeout deadline fires. The diagnostic is only shown on failure,
+but cheap-to-compute descriptions make debugging faster.
+"""
+
+
+_DEFAULT_HTTP_TIMEOUT_SECONDS = 2.0
+_DEFAULT_SOCKET_TIMEOUT_SECONDS = 0.5
+
+
+class HealthChecks:
+    """Factory for the built-in readiness probes.
+
+    Named to mirror ``docker-compose-rule``'s ``HealthChecks`` class so
+    the JUnit references in the rework issue map 1:1 to the Python API.
+    """
+
+    @staticmethod
+    def to_respond_over_http(
+        *,
+        internal_port: int,
+        url_format: str,
+        accept_statuses: Iterable[int] = (200, 204),
+        request_timeout_seconds: float = _DEFAULT_HTTP_TIMEOUT_SECONDS,
+    ) -> ServiceWaitFn:
+        """Build an HTTP-response probe.
+
+        ``url_format`` is passed through :meth:`DockerPort.in_format`, so
+        callers interpolate host / port via ``$HOST`` / ``$EXTERNAL_PORT``.
+        Any response whose status code lives in ``accept_statuses`` counts
+        as healthy — useful for health endpoints that require a bearer
+        token (``401``/``403`` answered unauthenticated is still a
+        positive "server is listening" signal).
+        """
+        statuses = frozenset(accept_statuses)
+        if not statuses:
+            raise ValueError("accept_statuses must be non-empty")
+
+        def _check(service: ServiceHandle) -> tuple[bool, str]:
+            port = service.port(internal_port)
+            url = port.in_format(url_format)
+            try:
+                with urllib.request.urlopen(url, timeout=request_timeout_seconds) as resp:
+                    if resp.status in statuses:
+                        return True, f"status={resp.status}"
+                    return False, (f"status={resp.status} not in {sorted(statuses)} (url={url})")
+            except urllib.error.HTTPError as exc:
+                if exc.code in statuses:
+                    return True, f"status={exc.code}"
+                return False, (f"status={exc.code} not in {sorted(statuses)} (url={url})")
+            except (urllib.error.URLError, ConnectionError, TimeoutError, OSError) as exc:
+                return False, f"connection error for {url}: {exc!r}"
+
+        return _check
+
+    @staticmethod
+    def to_have_ports_open(
+        *internal_ports: int,
+        connect_timeout_seconds: float = _DEFAULT_SOCKET_TIMEOUT_SECONDS,
+    ) -> ServiceWaitFn:
+        """Build a TCP-socket probe that succeeds once every listed port accepts a connection.
+
+        Mirrors ``docker-compose-rule``'s ``toHaveAllPortsOpen`` for the
+        set of ``internal_port``s the caller cares about. A 500 ms
+        connect timeout — matching the JUnit rule — keeps a not-yet-
+        listening port from blocking the poll loop.
+        """
+        if not internal_ports:
+            raise ValueError("at least one internal_port is required")
+        ports = tuple(internal_ports)
+
+        def _check(service: ServiceHandle) -> tuple[bool, str]:
+            for internal_port in ports:
+                docker_port = service.port(internal_port)
+                try:
+                    with socket.create_connection(
+                        (docker_port.host, docker_port.external_port),
+                        timeout=connect_timeout_seconds,
+                    ):
+                        pass
+                except OSError as exc:
+                    return False, (
+                        f"internal_port={internal_port} "
+                        f"external={docker_port.host}:{docker_port.external_port}: {exc!r}"
+                    )
+            return True, f"internal_ports={list(ports)} open"
+
+        return _check

--- a/tests/integration/things_bridge/conftest.py
+++ b/tests/integration/things_bridge/conftest.py
@@ -21,7 +21,6 @@ shared compose file used by every per-service fixture in this tree).
 from __future__ import annotations
 
 import os
-import subprocess
 import uuid
 from collections.abc import Callable, Generator
 from dataclasses import dataclass
@@ -30,23 +29,28 @@ from typing import Any
 
 import pytest
 import yaml
-from testcontainers.compose import DockerCompose
 
 from tests.integration._support import (
+    COMPOSE_FILE,
     phase_timer,
-    render_compose_file,
     seed_empty_fixtures_dir,
-    wait_until_server_ready,
 )
 from tests.integration.conftest import (
+    AGENT_AUTH_INTERNAL_PORT,
     APPROVAL_PLUGINS,
     BASELINE_CONFIG,
     AgentAuthContainer,
+    _compose_image_env,
+    _test_failed,
+)
+from tests.integration.harness import (
+    DockerComposeCluster,
+    HealthChecks,
+    StartedCluster,
 )
 from things_bridge_client import ThingsBridgeClient
 
-AGENT_AUTH_PORT = 9100
-THINGS_BRIDGE_PORT = 9200
+THINGS_BRIDGE_INTERNAL_PORT = 9200
 
 
 @dataclass
@@ -55,19 +59,16 @@ class ThingsBridgeStack:
 
     The stack is exposed to tests through the bridge's host-mapped
     loopback port. ``agent_auth`` is the in-container handle used to
-    mint and revoke tokens.
-
-    ``compose_file`` is the per-test rendered compose file path; the
-    project name is baked into it (compose v2 ``name:`` field), so
-    callers that shell out to ``docker compose -f ...`` don't need any
-    env-var inheritance to address the right project.
+    mint and revoke tokens. ``cluster`` exposes the harness-level
+    compose controls (``exec``, ``stop_service``) so callers that need
+    cross-service behaviour — e.g. stopping ``agent-auth`` mid-test —
+    don't have to reach for ``subprocess.run`` directly.
     """
 
     base_url: str
-    bridge_compose: DockerCompose
+    cluster: StartedCluster
     agent_auth: AgentAuthContainer
     fixtures_dir: Path
-    compose_file: str
 
     def client(self) -> ThingsBridgeClient:
         """Return a :class:`ThingsBridgeClient` bound to this stack's bridge URL."""
@@ -90,18 +91,12 @@ class ThingsBridgeStack:
         the whole project, which is a no-op for already-stopped
         containers.
         """
-        subprocess.run(
-            ["docker", "compose", "-f", self.compose_file, "stop", "agent-auth"],
-            check=True,
-            capture_output=True,
-            timeout=30,
-        )
+        self.cluster.stop_service("agent-auth")
 
 
 def _write_agent_auth_config(
     config_dir: Path,
     *,
-    approval: str,
     access_token_ttl_seconds: int,
     refresh_token_ttl_seconds: int,
 ) -> None:
@@ -117,8 +112,8 @@ def _write_agent_auth_config(
         config = yaml.safe_load(f) or {}
     # Under #6 the notifier runs as a sidecar container; the URL is
     # fixed across tests and the approve/deny variant is chosen by the
-    # NOTIFIER_MODE placeholder substitution (see render_compose_file
-    # call below and APPROVAL_PLUGINS in tests/integration/conftest.py).
+    # NOTIFIER_MODE env var passed to docker compose (see
+    # APPROVAL_PLUGINS in tests/integration/conftest.py).
     config["notification_plugin_url"] = "http://notifier:9150/"
     config["access_token_ttl_seconds"] = access_token_ttl_seconds
     config["refresh_token_ttl_seconds"] = refresh_token_ttl_seconds
@@ -128,18 +123,66 @@ def _write_agent_auth_config(
     os.chmod(config_path, 0o644)
 
 
+def _things_bridge_cluster(
+    *,
+    project_name: str,
+    image_tags: dict[str, str],
+    config_dir: Path,
+    fixtures_dir: Path,
+    notifier_mode: str,
+    logs_dir: Path,
+) -> DockerComposeCluster:
+    """Build the per-test cluster definition with both service waits wired up.
+
+    Uses the same compose file as the agent-auth-only fixture, but adds
+    a readiness probe for the ``things-bridge`` service so the wait
+    loop blocks until both HTTP surfaces answer.
+    """
+    builder = (
+        DockerComposeCluster.builder()
+        .project_name(project_name)
+        .file(COMPOSE_FILE)
+        .env("AGENT_AUTH_TEST_CONFIG_DIR", str(config_dir))
+        .env("THINGS_BRIDGE_TEST_FIXTURES_DIR", str(fixtures_dir))
+        .env("NOTIFIER_MODE", notifier_mode)
+    )
+    for key, value in _compose_image_env(image_tags).items():
+        builder = builder.env(key, value)
+    return (
+        builder.waiting_for_service(
+            "agent-auth",
+            HealthChecks.to_respond_over_http(
+                internal_port=AGENT_AUTH_INTERNAL_PORT,
+                url_format="http://$HOST:$EXTERNAL_PORT/agent-auth/health",
+                accept_statuses={401, 403},
+            ),
+        )
+        .waiting_for_service(
+            "things-bridge",
+            HealthChecks.to_respond_over_http(
+                internal_port=THINGS_BRIDGE_INTERNAL_PORT,
+                url_format="http://$HOST:$EXTERNAL_PORT/things-bridge/health",
+                accept_statuses={401, 403},
+            ),
+        )
+        .save_logs_to(logs_dir, on_success=False)
+        .build()
+    )
+
+
 @pytest.fixture
 def things_bridge_stack_factory(
     _test_image_tags: dict[str, str],
     tmp_path_factory: pytest.TempPathFactory,
+    request: pytest.FixtureRequest,
 ) -> Generator[Callable[..., ThingsBridgeStack], None, None]:
     """Factory fixture — spin up the agent-auth + things-bridge pair.
 
     Each invocation starts a fresh Compose project (per-test UUID).
-    Teardown is registered on the fixture so every container is removed
+    Teardown is registered on the fixture so every cluster is stopped
     at the end of the test.
     """
-    started: list[tuple[str, DockerCompose]] = []
+    started: list[StartedCluster] = []
 
     def _factory(
         *,
@@ -156,10 +199,10 @@ def things_bridge_stack_factory(
         project_name = f"things-bridge-it-{uuid.uuid4().hex[:12]}"
         agent_auth_config_dir = tmp_path_factory.mktemp(f"aa-cfg-{project_name}")
         fixtures_dir = tmp_path_factory.mktemp(f"tb-fix-{project_name}")
+        logs_dir = tmp_path_factory.mktemp(f"logs-{project_name}")
 
         _write_agent_auth_config(
             agent_auth_config_dir,
-            approval=approval,
             access_token_ttl_seconds=access_token_ttl_seconds,
             refresh_token_ttl_seconds=refresh_token_ttl_seconds,
         )
@@ -167,61 +210,43 @@ def things_bridge_stack_factory(
         # before a test writes its own data.
         seed_empty_fixtures_dir(fixtures_dir)
 
-        rendered_compose = render_compose_file(
-            tmp_path_factory.mktemp(f"compose-{project_name}"),
-            COMPOSE_PROJECT_NAME=project_name,
-            AGENT_AUTH_TEST_IMAGE=_test_image_tags["agent-auth"],
-            THINGS_BRIDGE_TEST_IMAGE=_test_image_tags["things-bridge"],
-            THINGS_CLI_TEST_IMAGE=_test_image_tags["things-cli"],
-            AGENT_AUTH_TEST_CONFIG_DIR=str(agent_auth_config_dir),
-            THINGS_BRIDGE_TEST_FIXTURES_DIR=str(fixtures_dir),
-            NOTIFIER_MODE=APPROVAL_PLUGINS[approval],
+        cluster = _things_bridge_cluster(
+            project_name=project_name,
+            image_tags=_test_image_tags,
+            config_dir=agent_auth_config_dir,
+            fixtures_dir=fixtures_dir,
+            notifier_mode=APPROVAL_PLUGINS[approval],
+            logs_dir=logs_dir,
         )
-
-        compose = DockerCompose(
-            context=str(rendered_compose.parent),
-            compose_file_name=rendered_compose.name,
-        )
-        started.append((project_name, compose))
         with phase_timer("compose_start", project=project_name, service="things-bridge"):
-            compose.start()
+            running = cluster.start()
+        started.append(running)
 
-        bridge_host = compose.get_service_host("things-bridge", THINGS_BRIDGE_PORT)
-        bridge_port = compose.get_service_port("things-bridge", THINGS_BRIDGE_PORT)
-        base_url = f"http://{bridge_host}:{bridge_port}"
-        # /things-bridge/health requires a ``things-bridge:health`` token;
-        # an unauthenticated probe gets 401 (or 403 if the scope check
-        # ran), which is a positive "server is up" signal — same pattern
-        # as the agent-auth probe.
-        wait_until_server_ready(
-            f"{base_url}/things-bridge/health",
-            accept_status=(401, 403),
-        )
-
+        bridge_port = running.service("things-bridge").port(THINGS_BRIDGE_INTERNAL_PORT)
+        base_url = bridge_port.in_format("http://$HOST:$EXTERNAL_PORT")
         # Build an AgentAuthContainer handle so tests can mint tokens
         # via the in-container CLI. ``agent-auth`` is reached only
         # over the internal Compose network; no host-port mapping
         # for it is required.
         agent_auth = AgentAuthContainer(
             base_url="http://agent-auth:9100",  # internal only; CLI doesn't use it
-            compose=compose,
+            cluster=running,
             service="agent-auth",
         )
-
         return ThingsBridgeStack(
             base_url=base_url,
-            bridge_compose=compose,
+            cluster=running,
             agent_auth=agent_auth,
             fixtures_dir=fixtures_dir,
-            compose_file=str(rendered_compose),
         )
 
     yield _factory
 
-    for project_name, compose in started:
+    failed = _test_failed(request)
+    for running in started:
         try:
-            with phase_timer("compose_stop", project=project_name, service="things-bridge"):
-                compose.stop()
+            with phase_timer("compose_stop", project=running.project_name, service="things-bridge"):
+                running.stop(test_failed=failed)
         except Exception as e:
             print(f"warning: compose teardown failed: {e!r}")
 

--- a/tests/integration/things_cli/conftest.py
+++ b/tests/integration/things_cli/conftest.py
@@ -20,6 +20,14 @@ image: the credential store's ``file:``-backed path writes with
 tmpdir is created by the fixture with world-readable perms (the host
 test runner needs to read the rendered file back, but any secrets it
 contains were generated in-test and live and die with the fixture).
+
+Stack pinning: this fixture inherits its Compose topology from
+``docker/docker-compose.yaml`` via the imported ``ThingsBridgeStack`` —
+the ``things-cli`` service is defined alongside ``agent-auth`` and
+``things-bridge`` in that file and launched per-test via
+``docker compose run --rm things-cli``. ``StartedCluster.file_args()``
+and ``project_name`` are used to build the subprocess command so the
+project / compose-file wiring lives in one place.
 """
 
 from __future__ import annotations
@@ -45,13 +53,6 @@ from tests.integration.things_bridge.conftest import (  # noqa: F401
     things_bridge_stack_factory,
 )
 
-# Stack pinning: this fixture inherits its Compose topology from
-# ``docker/docker-compose.yaml`` via the imported ``ThingsBridgeStack``
-# — the ``things-cli`` service is defined alongside ``agent-auth`` and
-# ``things-bridge`` in that file and launched per-test via
-# ``docker compose run --rm things-cli``.
-
-
 # Credential file lives inside a per-test tmpdir that is bind-mounted
 # into the CLI container. ``_CREDS_FILENAME`` is written once per test
 # before the first ``run()`` call; the CLI re-writes it in-place under
@@ -60,6 +61,7 @@ from tests.integration.things_bridge.conftest import (  # noqa: F401
 # stable regardless of host-side path layout.
 _CREDS_FILENAME = "credentials.yaml"
 _CREDS_PATH_IN_CONTAINER = f"/tmp/things-cli-creds/{_CREDS_FILENAME}"
+_CLI_RUN_TIMEOUT_SECONDS = 30.0
 
 
 @dataclass
@@ -78,33 +80,41 @@ class ThingsCliInvoker:
         ``-T`` disables TTY allocation so stdout / stderr reach the
         subprocess verbatim without termios munging.
 
-        ``-f stack.compose_file`` points at the rendered, per-test
-        compose file (which carries the project name via compose v2's
-        ``name:`` field), so docker compose addresses the right project
-        without any env-var inheritance.
+        The command is built from ``StartedCluster.file_args()`` and
+        ``project_name`` so the compose-file and project-name wiring
+        the harness owns stays in one place. The env passed to
+        ``subprocess.run`` includes the harness's per-cluster env
+        (image tags, notifier mode, bind-mount paths) because
+        ``docker compose run`` re-parses the compose file and needs
+        every ``${VAR}`` interpolation to resolve.
         """
+        cluster = self.stack.cluster
+        argv = [
+            "docker",
+            "compose",
+            *cluster.file_args(),
+            "--project-name",
+            cluster.project_name,
+            "run",
+            "-T",
+            "--rm",
+            "--volume",
+            f"{self.creds_dir}:/tmp/things-cli-creds",
+            "things-cli",
+            "things-cli",
+            "--credential-store",
+            "file",
+            "--credentials-file",
+            _CREDS_PATH_IN_CONTAINER,
+            *args,
+        ]
+        env = {**os.environ, **cluster.env}
         result = subprocess.run(
-            [
-                "docker",
-                "compose",
-                "-f",
-                self.stack.compose_file,
-                "run",
-                "-T",
-                "--rm",
-                "--volume",
-                f"{self.creds_dir}:/tmp/things-cli-creds",
-                "things-cli",
-                "things-cli",
-                "--credential-store",
-                "file",
-                "--credentials-file",
-                _CREDS_PATH_IN_CONTAINER,
-                *args,
-            ],
+            argv,
+            env=env,
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=_CLI_RUN_TIMEOUT_SECONDS,
             check=False,
         )
         return result.returncode, result.stdout, result.stderr

--- a/tests/test_integration_harness.py
+++ b/tests/test_integration_harness.py
@@ -1,0 +1,561 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the in-tree Docker Compose harness.
+
+These run in the default (``--unit``) pytest invocation and never shell
+out to ``docker`` — ``subprocess.run`` is monkeypatched with a fake that
+records each call and returns canned output. The harness itself is
+pure Python glue plus subprocess choreography; covering the builder,
+wait loop, port parsing, and log capture here catches regressions
+without spending a CI minute on a docker pull.
+
+The Docker-backed end-to-end exercise of the harness lives in the
+integration suite: every agent-auth / things-bridge / things-cli
+integration test drives a full ``up → wait → exec → down`` cycle
+through this module.
+"""
+
+from __future__ import annotations
+
+import email.message
+import os
+import subprocess
+import urllib.error
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from tests.integration.harness import (
+    ClusterStartupTimeout,
+    DockerComposeCluster,
+    DockerComposeClusterBuilder,
+    DockerPort,
+    HealthChecks,
+    ServiceHandle,
+    StartedCluster,
+)
+
+# ---------------------------------------------------------------------------
+# DockerPort.in_format
+# ---------------------------------------------------------------------------
+
+
+def test_docker_port_in_format_substitutes_all_three_placeholders():
+    port = DockerPort(host="127.0.0.1", external_port=54321, internal_port=9100)
+
+    assert (
+        port.in_format("http://$HOST:$EXTERNAL_PORT/agent-auth/health")
+        == "http://127.0.0.1:54321/agent-auth/health"
+    )
+    assert port.in_format("$HOST:$EXTERNAL_PORT $INTERNAL_PORT") == "127.0.0.1:54321 9100"
+
+
+def test_docker_port_in_format_preserves_literal_dollar_outside_placeholders():
+    port = DockerPort(host="h", external_port=1, internal_port=2)
+    assert port.in_format("price=$5 at $HOST") == "price=$5 at h"
+
+
+def test_docker_port_in_format_leaves_template_unchanged_when_no_placeholders():
+    port = DockerPort(host="h", external_port=1, internal_port=2)
+    assert port.in_format("http://static.example/path") == "http://static.example/path"
+
+
+# ---------------------------------------------------------------------------
+# Builder — validation + accumulation
+# ---------------------------------------------------------------------------
+
+
+def test_builder_rejects_missing_project_name(tmp_path):
+    b = DockerComposeCluster.builder().file(tmp_path / "compose.yaml")
+    with pytest.raises(ValueError, match="project_name"):
+        b.build()
+
+
+def test_builder_rejects_missing_file():
+    b = DockerComposeCluster.builder().project_name("proj")
+    with pytest.raises(ValueError, match="file"):
+        b.build()
+
+
+def test_builder_accumulates_env_files_and_waits(tmp_path):
+    compose_a = tmp_path / "a.yaml"
+    compose_b = tmp_path / "b.yaml"
+    compose_a.write_text("")
+    compose_b.write_text("")
+
+    def _wait(svc: ServiceHandle) -> tuple[bool, str]:
+        return True, "ok"
+
+    cluster = (
+        DockerComposeCluster.builder()
+        .project_name("proj")
+        .file(compose_a)
+        .file(compose_b)
+        .env("IMAGE", "img:v1")
+        .env("MODE", "approve")
+        .waiting_for_service("svc-a", _wait)
+        .waiting_for_service("svc-b", _wait, label="svc-b-http")
+        .save_logs_to(tmp_path / "logs")
+        .start_timeout_seconds(7.5)
+        .poll_interval_seconds(0.05)
+        .build()
+    )
+    assert cluster.project_name == "proj"
+    assert cluster.files == (compose_a, compose_b)
+    assert cluster.env == {"IMAGE": "img:v1", "MODE": "approve"}
+    assert [w.service for w in cluster.waits] == ["svc-a", "svc-b"]
+    assert [w.label for w in cluster.waits] == ["svc-a", "svc-b-http"]
+    assert cluster.logs_dir == tmp_path / "logs"
+    assert cluster.start_timeout_seconds == pytest.approx(7.5)
+    assert cluster.poll_interval_seconds == pytest.approx(0.05)
+
+
+def test_builder_returns_self_from_every_setter(tmp_path):
+    b = DockerComposeCluster.builder()
+    # Exhaustively check chained returns, so IDE autocomplete and
+    # ``self``-return contract stay honest.
+    assert b.project_name("p") is b
+    assert b.file(tmp_path / "c.yaml") is b
+    assert b.env("k", "v") is b
+    assert b.waiting_for_service("svc", lambda _s: (True, "ok")) is b
+    assert b.save_logs_to(tmp_path / "logs") is b
+    assert b.start_timeout_seconds(1.0) is b
+    assert b.poll_interval_seconds(0.1) is b
+
+
+# ---------------------------------------------------------------------------
+# HealthChecks factory validation
+# ---------------------------------------------------------------------------
+
+
+def test_health_checks_http_rejects_empty_accept_statuses():
+    with pytest.raises(ValueError, match="accept_statuses"):
+        HealthChecks.to_respond_over_http(
+            internal_port=9100, url_format="http://$HOST", accept_statuses=[]
+        )
+
+
+def test_health_checks_ports_open_rejects_no_ports():
+    with pytest.raises(ValueError, match="internal_port"):
+        HealthChecks.to_have_ports_open()
+
+
+# ---------------------------------------------------------------------------
+# HealthChecks.to_respond_over_http — mocked HTTP layer
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeResponse:
+    status: int
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+def _stub_service(host: str = "127.0.0.1", external: int = 54321) -> ServiceHandle:
+    """Build a ServiceHandle whose .port() returns a fixed DockerPort.
+
+    Avoids spinning up a real StartedCluster — the only surface the
+    wait probe touches is ``service.port(internal_port)``.
+    """
+    fake_port = DockerPort(host=host, external_port=external, internal_port=9100)
+
+    class _StubCluster:
+        def resolve_port(self, service: str, internal_port: int) -> DockerPort:
+            return fake_port
+
+    return ServiceHandle(cluster=_StubCluster(), name="svc")  # type: ignore[arg-type]
+
+
+def test_http_wait_returns_true_on_accepted_status():
+    check = HealthChecks.to_respond_over_http(
+        internal_port=9100,
+        url_format="http://$HOST:$EXTERNAL_PORT/health",
+        accept_statuses={401, 403},
+    )
+    with patch("urllib.request.urlopen", return_value=_FakeResponse(status=401)):
+        ok, diag = check(_stub_service())
+    assert ok is True
+    assert "401" in diag
+
+
+def test_http_wait_returns_false_on_rejected_status():
+    check = HealthChecks.to_respond_over_http(
+        internal_port=9100,
+        url_format="http://$HOST:$EXTERNAL_PORT/health",
+        accept_statuses={200},
+    )
+    with patch("urllib.request.urlopen", return_value=_FakeResponse(status=503)):
+        ok, diag = check(_stub_service())
+    assert ok is False
+    assert "503" in diag
+    assert "not in" in diag
+
+
+def test_http_wait_treats_http_error_in_accept_set_as_healthy():
+    check = HealthChecks.to_respond_over_http(
+        internal_port=9100,
+        url_format="http://$HOST:$EXTERNAL_PORT/health",
+        accept_statuses={401},
+    )
+
+    def _raise(*_args: Any, **_kwargs: Any) -> None:
+        raise urllib.error.HTTPError(
+            url="http://x",
+            code=401,
+            msg="unauthorized",
+            hdrs=email.message.Message(),
+            fp=None,
+        )
+
+    with patch("urllib.request.urlopen", side_effect=_raise):
+        ok, diag = check(_stub_service())
+    assert ok is True
+    assert "401" in diag
+
+
+def test_http_wait_treats_connection_error_as_unhealthy():
+    check = HealthChecks.to_respond_over_http(
+        internal_port=9100,
+        url_format="http://$HOST:$EXTERNAL_PORT/health",
+        accept_statuses={200, 401},
+    )
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        ok, diag = check(_stub_service())
+    assert ok is False
+    assert "connection error" in diag
+
+
+# ---------------------------------------------------------------------------
+# StartedCluster subprocess wiring
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeCompletedProcess:
+    args: list[str]
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+    env: dict[str, str] | None = None
+
+
+class _SubprocessRecorder:
+    """Fake for ``subprocess.run`` that records every call.
+
+    The test assigns a ``handler`` that returns a :class:`_FakeCompletedProcess`
+    for the test's choice of inputs. All calls are accumulated for
+    inspection.
+    """
+
+    def __init__(
+        self, handler: Callable[[list[str], dict[str, str] | None], _FakeCompletedProcess]
+    ):
+        self.handler = handler
+        self.calls: list[_FakeCompletedProcess] = []
+
+    def __call__(self, argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        result = self.handler(argv, kwargs.get("env"))
+        record = _FakeCompletedProcess(
+            args=list(argv),
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            env=dict(kwargs["env"]) if kwargs.get("env") is not None else None,
+        )
+        self.calls.append(record)
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+
+
+def _make_started_cluster(
+    tmp_path: Path,
+    *,
+    env: dict[str, str] | None = None,
+    logs_dir: Path | None = None,
+) -> StartedCluster:
+    compose_file = tmp_path / "compose.yaml"
+    compose_file.write_text("services: {}")
+    return StartedCluster(
+        project_name="proj-123",
+        files=(compose_file,),
+        env=dict(env or {}),
+        logs_dir=logs_dir,
+        logs_on_success=False,
+        stop_timeout_seconds=5.0,
+    )
+
+
+def test_exec_passes_project_name_and_service_and_argv(tmp_path, monkeypatch):
+    cluster = _make_started_cluster(tmp_path, env={"IMAGE": "img:v1"})
+
+    def _handler(argv: list[str], env: dict[str, str] | None) -> _FakeCompletedProcess:
+        return _FakeCompletedProcess(args=argv, stdout="ok", returncode=0)
+
+    recorder = _SubprocessRecorder(_handler)
+    monkeypatch.setattr("tests.integration.harness._cluster.subprocess.run", recorder)
+
+    result = cluster.exec("agent-auth", ["agent-auth", "token", "list"])
+    assert result.stdout == "ok"
+    assert len(recorder.calls) == 1
+    argv = recorder.calls[0].args
+    assert argv[:2] == ["docker", "compose"]
+    assert "-f" in argv
+    assert "--project-name" in argv
+    assert argv[argv.index("--project-name") + 1] == "proj-123"
+    exec_idx = argv.index("exec")
+    assert argv[exec_idx : exec_idx + 3] == ["exec", "-T", "agent-auth"]
+    assert argv[exec_idx + 3 :] == ["agent-auth", "token", "list"]
+
+
+def test_exec_forwards_env_without_mutating_os_environ(tmp_path, monkeypatch):
+    monkeypatch.delenv("AGENT_AUTH_HARNESS_TEST_KEY", raising=False)
+    cluster = _make_started_cluster(tmp_path, env={"AGENT_AUTH_HARNESS_TEST_KEY": "marker"})
+
+    recorder = _SubprocessRecorder(lambda argv, env: _FakeCompletedProcess(args=argv, returncode=0))
+    monkeypatch.setattr("tests.integration.harness._cluster.subprocess.run", recorder)
+
+    cluster.exec("svc", ["echo", "hi"])
+    assert recorder.calls[0].env is not None
+    assert recorder.calls[0].env["AGENT_AUTH_HARNESS_TEST_KEY"] == "marker"
+    assert "AGENT_AUTH_HARNESS_TEST_KEY" not in os.environ
+
+
+def test_stop_service_issues_compose_stop(tmp_path, monkeypatch):
+    cluster = _make_started_cluster(tmp_path)
+    recorder = _SubprocessRecorder(lambda argv, env: _FakeCompletedProcess(args=argv, returncode=0))
+    monkeypatch.setattr("tests.integration.harness._cluster.subprocess.run", recorder)
+
+    cluster.stop_service("agent-auth")
+    argv = recorder.calls[0].args
+    assert argv[argv.index("--project-name") + 1] == "proj-123"
+    assert "stop" in argv
+    assert argv[-1] == "agent-auth"
+
+
+def test_stop_service_raises_on_nonzero_exit(tmp_path, monkeypatch):
+    cluster = _make_started_cluster(tmp_path)
+    recorder = _SubprocessRecorder(
+        lambda argv, env: _FakeCompletedProcess(args=argv, returncode=1, stderr="nope")
+    )
+    monkeypatch.setattr("tests.integration.harness._cluster.subprocess.run", recorder)
+    with pytest.raises(RuntimeError, match="stop"):
+        cluster.stop_service("svc")
+
+
+# ---------------------------------------------------------------------------
+# Port lookup parsing
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_port_parses_host_port_output(tmp_path, monkeypatch):
+    cluster = _make_started_cluster(tmp_path)
+    recorder = _SubprocessRecorder(
+        lambda argv, env: _FakeCompletedProcess(args=argv, stdout="127.0.0.1:54321\n", returncode=0)
+    )
+    monkeypatch.setattr("tests.integration.harness._cluster.subprocess.run", recorder)
+
+    port = cluster.resolve_port("agent-auth", 9100)
+    assert port == DockerPort(host="127.0.0.1", external_port=54321, internal_port=9100)
+
+
+def test_resolve_port_caches_result(tmp_path, monkeypatch):
+    cluster = _make_started_cluster(tmp_path)
+    recorder = _SubprocessRecorder(
+        lambda argv, env: _FakeCompletedProcess(args=argv, stdout="127.0.0.1:1234\n", returncode=0)
+    )
+    monkeypatch.setattr("tests.integration.harness._cluster.subprocess.run", recorder)
+
+    first = cluster.resolve_port("svc", 9100)
+    second = cluster.resolve_port("svc", 9100)
+    assert first == second
+    # Only one subprocess call despite two lookups.
+    assert len(recorder.calls) == 1
+
+
+def test_resolve_port_raises_on_unparseable_output(tmp_path, monkeypatch):
+    cluster = _make_started_cluster(tmp_path)
+    recorder = _SubprocessRecorder(
+        lambda argv, env: _FakeCompletedProcess(
+            args=argv, stdout="garbage-no-colon\n", returncode=0
+        )
+    )
+    monkeypatch.setattr("tests.integration.harness._cluster.subprocess.run", recorder)
+    with pytest.raises(RuntimeError, match="could not parse"):
+        cluster.resolve_port("svc", 9100)
+
+
+def test_resolve_port_raises_on_nonzero_exit(tmp_path, monkeypatch):
+    cluster = _make_started_cluster(tmp_path)
+    recorder = _SubprocessRecorder(
+        lambda argv, env: _FakeCompletedProcess(
+            args=argv, stdout="", stderr="no such service", returncode=1
+        )
+    )
+    monkeypatch.setattr("tests.integration.harness._cluster.subprocess.run", recorder)
+    with pytest.raises(RuntimeError, match="could not resolve"):
+        cluster.resolve_port("nope", 9100)
+
+
+# ---------------------------------------------------------------------------
+# Wait loop — timeout behaviour and parallelism under a shared deadline
+# ---------------------------------------------------------------------------
+
+
+def test_wait_loop_fires_timeout_when_probe_never_succeeds(tmp_path, monkeypatch):
+    cluster = _make_started_cluster(tmp_path)
+
+    def _never(service: ServiceHandle) -> tuple[bool, str]:
+        return False, "still sad"
+
+    from tests.integration.harness._cluster import _ServiceWait
+
+    waits = (_ServiceWait(service="svc", check=_never, label="svc"),)
+    # Use a small deadline and patch sleep to speed the loop up.
+    monkeypatch.setattr("tests.integration.harness._cluster.time.sleep", lambda _s: None)
+
+    with pytest.raises(ClusterStartupTimeout) as exc_info:
+        cluster._wait_for_all_services(
+            waits=waits, deadline_seconds=0.05, poll_interval_seconds=0.01
+        )
+    assert "still sad" in str(exc_info.value)
+    assert "svc" in str(exc_info.value)
+
+
+def test_wait_loop_returns_when_probe_succeeds(tmp_path, monkeypatch):
+    cluster = _make_started_cluster(tmp_path)
+    attempts = {"count": 0}
+
+    def _succeeds_second_try(service: ServiceHandle) -> tuple[bool, str]:
+        attempts["count"] += 1
+        if attempts["count"] >= 2:
+            return True, "ready"
+        return False, "warming up"
+
+    monkeypatch.setattr("tests.integration.harness._cluster.time.sleep", lambda _s: None)
+    from tests.integration.harness._cluster import _ServiceWait
+
+    waits = (_ServiceWait(service="svc", check=_succeeds_second_try, label="svc"),)
+    # Should not raise.
+    cluster._wait_for_all_services(waits=waits, deadline_seconds=1.0, poll_interval_seconds=0.01)
+    assert attempts["count"] >= 2
+
+
+# ---------------------------------------------------------------------------
+# Log capture on teardown
+# ---------------------------------------------------------------------------
+
+
+def test_save_logs_writes_one_file_per_service(tmp_path, monkeypatch):
+    logs_dir = tmp_path / "logs-out"
+    cluster = _make_started_cluster(tmp_path, logs_dir=logs_dir)
+
+    def _handler(argv: list[str], env: dict[str, str] | None) -> _FakeCompletedProcess:
+        if "config" in argv and "--services" in argv:
+            return _FakeCompletedProcess(
+                args=argv, stdout="agent-auth\nthings-bridge\nnotifier\n", returncode=0
+            )
+        if "logs" in argv:
+            service = argv[-1]
+            return _FakeCompletedProcess(
+                args=argv, stdout=f"log lines for {service}\n", returncode=0
+            )
+        if "down" in argv:
+            return _FakeCompletedProcess(args=argv, returncode=0)
+        return _FakeCompletedProcess(args=argv, returncode=0)
+
+    recorder = _SubprocessRecorder(_handler)
+    monkeypatch.setattr("tests.integration.harness._cluster.subprocess.run", recorder)
+
+    cluster.stop(test_failed=True)
+    assert (logs_dir / "agent-auth.log").read_text() == "log lines for agent-auth\n"
+    assert (logs_dir / "things-bridge.log").read_text() == ("log lines for things-bridge\n")
+    assert (logs_dir / "notifier.log").read_text() == "log lines for notifier\n"
+    # And ``docker compose down`` was invoked at teardown.
+    assert any("down" in call.args for call in recorder.calls)
+
+
+def test_save_logs_skipped_on_success_when_on_success_is_false(tmp_path, monkeypatch):
+    logs_dir = tmp_path / "logs-out"
+    cluster = _make_started_cluster(tmp_path, logs_dir=logs_dir)
+
+    recorder = _SubprocessRecorder(lambda argv, env: _FakeCompletedProcess(args=argv, returncode=0))
+    monkeypatch.setattr("tests.integration.harness._cluster.subprocess.run", recorder)
+
+    cluster.stop(test_failed=False)
+    assert not logs_dir.exists()
+    # Down still ran.
+    assert any("down" in call.args for call in recorder.calls)
+
+
+def test_save_logs_falls_back_to_combined_when_config_services_fails(tmp_path, monkeypatch):
+    logs_dir = tmp_path / "logs-out"
+    cluster = _make_started_cluster(tmp_path, logs_dir=logs_dir)
+
+    def _handler(argv: list[str], env: dict[str, str] | None) -> _FakeCompletedProcess:
+        if "config" in argv and "--services" in argv:
+            return _FakeCompletedProcess(
+                args=argv, stdout="", stderr="compose file broken", returncode=1
+            )
+        if "logs" in argv:
+            return _FakeCompletedProcess(args=argv, stdout="combined log\n", returncode=0)
+        if "down" in argv:
+            return _FakeCompletedProcess(args=argv, returncode=0)
+        return _FakeCompletedProcess(args=argv, returncode=0)
+
+    monkeypatch.setattr(
+        "tests.integration.harness._cluster.subprocess.run",
+        _SubprocessRecorder(_handler),
+    )
+
+    cluster.stop(test_failed=True)
+    assert (logs_dir / "combined.log").read_text() == "combined log\n"
+
+
+def test_stop_is_idempotent(tmp_path, monkeypatch):
+    cluster = _make_started_cluster(tmp_path)
+    recorder = _SubprocessRecorder(lambda argv, env: _FakeCompletedProcess(args=argv, returncode=0))
+    monkeypatch.setattr("tests.integration.harness._cluster.subprocess.run", recorder)
+    cluster.stop(test_failed=False)
+    first_count = len(recorder.calls)
+    cluster.stop(test_failed=False)
+    # Second call should be a no-op.
+    assert len(recorder.calls) == first_count
+
+
+# ---------------------------------------------------------------------------
+# Builder is re-usable as a factory (no accidental freezing)
+# ---------------------------------------------------------------------------
+
+
+def test_builder_build_returns_new_cluster_per_call(tmp_path):
+    compose = tmp_path / "c.yaml"
+    compose.write_text("")
+    builder = DockerComposeCluster.builder().project_name("p").file(compose)
+    c1 = builder.build()
+    c2 = builder.build()
+    # Separate objects, same structural content.
+    assert c1 is not c2
+    assert c1.project_name == c2.project_name == "p"
+
+
+def test_builder_type_round_trips(tmp_path):
+    """Builder and cluster types remain in the public re-export surface."""
+    assert isinstance(DockerComposeCluster.builder(), DockerComposeClusterBuilder)

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,6 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "reuse" },
-    { name = "testcontainers" },
 ]
 
 [package.dev-dependencies]
@@ -91,7 +90,6 @@ requires-dist = [
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "reuse", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "testcontainers", extras = ["compose"], marker = "extra == 'dev'", specifier = ">=4" },
 ]
 provides-extras = ["dev"]
 
@@ -550,20 +548,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
-]
-
-[[package]]
-name = "docker"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "requests" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -1645,25 +1629,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pywin32"
-version = "311"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
-    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
-    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
-    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
-]
-
-[[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2031,22 +1996,6 @@ wheels = [
 ]
 
 [[package]]
-name = "testcontainers"
-version = "4.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docker" },
-    { name = "python-dotenv" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
-]
-
-[[package]]
 name = "textual"
 version = "8.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2212,81 +2161,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
-]
-
-[[package]]
-name = "wrapt"
-version = "2.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666, upload-time = "2026-03-06T02:52:58.934Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601, upload-time = "2026-03-06T02:53:00.487Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057, upload-time = "2026-03-06T02:52:44.08Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099, upload-time = "2026-03-06T02:54:56.74Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457, upload-time = "2026-03-06T02:53:52.842Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351, upload-time = "2026-03-06T02:53:32.684Z" },
-    { url = "https://files.pythonhosted.org/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748, upload-time = "2026-03-06T02:53:08.455Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783, upload-time = "2026-03-06T02:53:02.02Z" },
-    { url = "https://files.pythonhosted.org/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977, upload-time = "2026-03-06T02:53:27.844Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336, upload-time = "2026-03-06T02:54:28.104Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756, upload-time = "2026-03-06T02:53:16.319Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
-    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
-    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
-    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
-    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
-    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
-    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
-    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
-    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
-    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
-    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
-    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
-    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
-    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
-    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
-    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
-    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
-    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
-    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
-    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
-    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
-    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
-    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
-    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace `testcontainers-python` in the integration-test fixtures with a fluent in-tree builder under `tests/integration/harness/` (inspired by [`palantir/docker-compose-rule`](https://github.com/palantir/docker-compose-rule)).
- Every `docker compose` action (config, up, port, exec, stop, logs, down) is a direct subprocess invocation — `os.environ` is never mutated and the project name is passed on `--project-name`.
- Readiness declared per service via `HealthChecks.to_respond_over_http` / `to_have_ports_open`; waits run in parallel under a shared deadline. `wait_until_server_ready` is gone.
- `DockerPort.in_format("http://$HOST:$EXTERNAL_PORT")` replaces hand-rolled URL concatenation.
- `save_logs_to(dir, on_success=False)` dumps `docker compose logs <service>` per service into `tmp_path` on failure so CI can upload an artefact.
- `docker/docker-compose.yaml` moves from Python `{{ placeholder }}` rendering to native `${VAR}` interpolation fed via `subprocess env=`; `render_compose_file` is deleted.
- `testcontainers[compose]` is removed from the `dev` extra, the mypy overrides, and `uv.lock`.
- ADR 0031 supersedes the `testcontainers-python` implementation choices from ADR 0004 and 0005 while keeping the per-test Compose-project shape, shared `Dockerfile.test`, and single `docker-compose.yaml` unchanged.

## Conftest impact

- `tests/integration/conftest.py` rewritten on the harness; `exec_cli` / port resolution go through `StartedCluster.exec` and `ServiceHandle.port`.
- `tests/integration/things_bridge/conftest.py` rewritten on the same harness; `stop_agent_auth` now goes through `StartedCluster.stop_service`.
- `tests/integration/things_cli/conftest.py` funnels `docker compose exec` through `StartedCluster.exec` so the project/compose-file/env wiring lives in one place.
- `scripts/verify-integration-isolation.sh` skips the shared `harness/` support package.

## Test plan

- [x] 29 new unit tests in `tests/test_integration_harness.py` exercise builder validation, wait-loop timeout/parallelism, `DockerPort.in_format` substitution, subprocess argv / env wiring for `exec` / `stop_service` / port lookup, and `save_logs_to` per-service log capture — no Docker required, `subprocess.run` is monkeypatched.
- [x] `./scripts/test.sh --unit` — 534 passed, 3 skipped; coverage 75 % (floor 74 %).
- [x] `./scripts/typecheck.sh` — mypy + pyright clean across 140 source files.
- [x] `./scripts/verify-integration-isolation.sh` — passes on the new `harness/` layout.
- [x] `./scripts/verify-standards.sh`, `./scripts/reuse-lint.sh`, `./scripts/verify-function-tests.sh`, `./scripts/verify-dependencies.sh` — all green.
- [x] Integration suite (`./scripts/test.sh --integration`) needs a Docker host — the environment this branch was authored in doesn't have one; CI exercises all four per-service slices end-to-end.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)