### PR TITLE
ci: cache per-service Dockerfile layers via buildx + GHA cache

### DIFF
--- a/.github/actions/build-integration-test-image/action.yml
+++ b/.github/actions/build-integration-test-image/action.yml
@@ -10,11 +10,17 @@ description: |
   bundled into the test step) so the GHA step-timing UI shows the
   build cost split out from test wall-time.
 
+  Uses ``docker/setup-buildx-action`` with ``install: true`` to alias
+  ``docker build`` onto ``docker buildx build`` so the build commands
+  below can read and write the GitHub Actions cache (``type=gha``).
+  Each service gets its own cache scope so a Dockerfile change on one
+  service does not evict the other services' cache.
+
   The step builds every image every time the action is invoked; jobs
-  that only exercise a subset still pay the full build cost, but this
-  keeps the invocation contract trivial and consistent with the local
-  test harness that builds all images up front. Selective builds are
-  tracked under the caching work in issue #129.
+  that only exercise a subset still pay the full (cache-assisted)
+  build cost, but this keeps the invocation contract trivial and
+  consistent with the local test harness that builds all images up
+  front. Selective builds are an out-of-scope follow-up.
 
 inputs:
   session:
@@ -24,6 +30,14 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      with:
+        # Alias ``docker build`` onto ``docker buildx build`` so the
+        # plain-docker invocation below picks up the buildx builder
+        # without the action needing to know it's a buildx build.
+        install: true
+
     - name: docker build (all services)
       shell: bash
       env:
@@ -31,7 +45,16 @@ runs:
       run: |
         set -euo pipefail
         for service in agent-auth things-bridge things-cli things-client-applescript; do
+          # --load imports the built image into the local Docker
+          # daemon so ``docker compose`` can find it downstream; by
+          # default buildx leaves the image in its internal cache and
+          # only the cache layer would be visible to the daemon.
+          # Each service gets its own GHA cache scope so a Dockerfile
+          # edit on one service doesn't invalidate the others.
           docker build \
+            --cache-from "type=gha,scope=${service}-test" \
+            --cache-to "type=gha,mode=max,scope=${service}-test" \
+            --load \
             -f "docker/Dockerfile.${service}.test" \
             -t "${service}-test:${SESSION}" \
             .

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -221,6 +221,7 @@ PINNED_ACTIONS=(
   # keep-sorted start
   actions/checkout
   astral-sh/setup-uv
+  docker/setup-buildx-action
   # keep-sorted end
 )
 

--- a/tests/integration/_support.py
+++ b/tests/integration/_support.py
@@ -175,12 +175,24 @@ def build_test_image(dockerfile: Path, tag: str) -> None:
 
     Raises ``RuntimeError`` with build output on a non-zero exit so
     pytest tracebacks show why the build failed.
+
+    When ``AGENT_AUTH_DOCKER_CACHE=gha`` is set, the build opts in to
+    GitHub Actions cache via buildx (``--cache-from`` /
+    ``--cache-to type=gha``) under a per-service scope derived from
+    the Dockerfile name (``Dockerfile.<service>.test`` →
+    ``<service>-test``). The CI integration jobs go through
+    ``.github/actions/build-integration-test-image`` today, so this
+    branch is primarily a local-dev / non-CI-script escape hatch. Any
+    other value of the env var falls back to classic ``docker build``
+    so local runs without buildx don't pay the setup cost.
     """
+    cache_args = _gha_cache_args(dockerfile)
     with phase_timer("build_test_image", dockerfile=dockerfile.name, tag=tag):
         result = subprocess.run(
             [
                 "docker",
                 "build",
+                *cache_args,
                 "-f",
                 str(dockerfile),
                 "-t",
@@ -197,3 +209,39 @@ def build_test_image(dockerfile: Path, tag: str) -> None:
             f"`docker build` failed for {tag} ({dockerfile.name}): "
             f"stdout={result.stdout!r} stderr={result.stderr!r}"
         )
+
+
+def _gha_cache_args(dockerfile: Path) -> list[str]:
+    """Return buildx cache flags appropriate for the ambient env.
+
+    Caller sets ``AGENT_AUTH_DOCKER_CACHE=gha`` to opt in. The cache
+    scope is derived from the Dockerfile's per-service suffix so a
+    Dockerfile edit on one service doesn't evict the cache for the
+    others. Returns ``[]`` when caching is disabled; callers splat
+    the result into their ``docker build`` argv with ``*``.
+    """
+    if os.environ.get("AGENT_AUTH_DOCKER_CACHE") != "gha":
+        return []
+    scope = _cache_scope_for_dockerfile(dockerfile)
+    return [
+        "--cache-from",
+        f"type=gha,scope={scope}",
+        "--cache-to",
+        f"type=gha,mode=max,scope={scope}",
+        "--load",
+    ]
+
+
+def _cache_scope_for_dockerfile(dockerfile: Path) -> str:
+    """Return the cache scope string for ``dockerfile``.
+
+    Matches the scope used by
+    ``.github/actions/build-integration-test-image`` so a local run
+    under ``AGENT_AUTH_DOCKER_CACHE=gha`` shares the same cache key
+    space as CI — useful for anyone driving a GHA-cache-backed
+    buildx builder locally.
+    """
+    # ``Dockerfile.things-bridge.test`` → scope ``things-bridge-test``.
+    stem = dockerfile.stem  # ``Dockerfile.things-bridge``
+    service = stem.removeprefix("Dockerfile.")
+    return f"{service}-test"

--- a/tests/test_integration_support.py
+++ b/tests/test_integration_support.py
@@ -6,8 +6,9 @@
 image-tag resolution branch of ``tests.integration.conftest``.
 
 The docker-driving helpers require a live daemon and are exercised by
-the integration suite; the pieces tested here (``phase_timer`` and the
-``AGENT_AUTH_TEST_IMAGE_SESSION`` short-circuit) are the plumbing that
+the integration suite; the pieces tested here (``phase_timer``, the
+``AGENT_AUTH_TEST_IMAGE_SESSION`` short-circuit, and the
+``AGENT_AUTH_DOCKER_CACHE`` build-arg synthesis) are the plumbing that
 runs on the host, not in a container.
 """
 
@@ -15,9 +16,14 @@ from __future__ import annotations
 
 import logging
 import time
+from pathlib import Path
 
 from tests.integration import conftest as integration_conftest
-from tests.integration._support import phase_timer
+from tests.integration._support import (
+    _cache_scope_for_dockerfile,
+    _gha_cache_args,
+    phase_timer,
+)
 
 
 def test_phase_timer_logs_phase_name_and_elapsed_seconds(caplog):
@@ -124,3 +130,54 @@ def test_resolve_test_image_tags_mints_fresh_session_per_call(monkeypatch):
     second, _ = integration_conftest._resolve_test_image_tags()
 
     assert first != second
+
+
+# ``AGENT_AUTH_DOCKER_CACHE=gha`` opts the build into buildx-backed
+# GitHub Actions caching. CI drives its own caching path via
+# .github/actions/build-integration-test-image, so these tests pin the
+# local / manual-opt-in contract: the env var is read at build time
+# (not import time), the scope is derived from the per-service
+# Dockerfile name, and disabling the env var yields no extra argv.
+
+
+def test_gha_cache_args_returns_empty_list_when_env_unset(monkeypatch):
+    monkeypatch.delenv("AGENT_AUTH_DOCKER_CACHE", raising=False)
+    assert _gha_cache_args(Path("docker/Dockerfile.agent-auth.test")) == []
+
+
+def test_gha_cache_args_returns_empty_list_when_env_not_gha(monkeypatch):
+    # Any value other than ``gha`` is treated as "no cache". Pins the
+    # contract against a future expansion adding other cache backends
+    # — a typo / wrong value must not silently enable buildx caching.
+    monkeypatch.setenv("AGENT_AUTH_DOCKER_CACHE", "local")
+    assert _gha_cache_args(Path("docker/Dockerfile.agent-auth.test")) == []
+
+
+def test_gha_cache_args_emits_buildx_cache_and_load_flags(monkeypatch):
+    monkeypatch.setenv("AGENT_AUTH_DOCKER_CACHE", "gha")
+
+    args = _gha_cache_args(Path("docker/Dockerfile.things-bridge.test"))
+
+    assert args == [
+        "--cache-from",
+        "type=gha,scope=things-bridge-test",
+        "--cache-to",
+        "type=gha,mode=max,scope=things-bridge-test",
+        # ``--load`` imports the built image into the local Docker
+        # daemon; omitting it leaves the image in buildx's internal
+        # cache and downstream ``docker compose`` can't find it.
+        "--load",
+    ]
+
+
+def test_cache_scope_strips_dockerfile_prefix_only():
+    # ``Dockerfile.<service>.test`` → ``<service>-test``. The suffix
+    # ``.test`` is preserved so the scope doesn't collide with a
+    # hypothetical non-test Dockerfile named ``Dockerfile.<svc>``.
+    assert (
+        _cache_scope_for_dockerfile(Path("docker/Dockerfile.agent-auth.test")) == "agent-auth-test"
+    )
+    assert (
+        _cache_scope_for_dockerfile(Path("docker/Dockerfile.things-client-applescript.test"))
+        == "things-client-applescript-test"
+    )


### PR DESCRIPTION
## Summary

- Install `docker/setup-buildx-action@v4` (sha-pinned) with `install: true` in the `build-integration-test-image` composite action so `docker build` goes through buildx and can read/write the GitHub Actions cache.
- Each per-service build now passes `--cache-from type=gha,scope=<svc>-test` and `--cache-to type=gha,mode=max,scope=<svc>-test` with `--load` so the image lands in the local Docker daemon where `docker compose` downstream expects it. Per-service scopes keep a Dockerfile edit on one service from evicting the others.
- Add an `AGENT_AUTH_DOCKER_CACHE=gha` opt-in to `tests/integration/_support.build_test_image` so a dev driving a GHA-cache-backed buildx builder locally shares the CI cache keyspace.
- Add `docker/setup-buildx-action` to the `PINNED_ACTIONS` list in `scripts/verify-standards.sh`.

Selective per-job builds remain out of scope (every job still builds every image; the cache hit makes that cheap).

Closes #129.

## Test plan

- [x] `uv run pytest tests/test_integration_support.py` — 11 passed, new tests cover the `AGENT_AUTH_DOCKER_CACHE` contract.
- [x] `uv run pytest tests/ --ignore=tests/integration` — 509 passed, coverage 75.09%.
- [x] `uv run ruff check`, `uv run mypy`, `uv run pyright`, `scripts/verify-standards.sh`, `scripts/verify-integration-isolation.sh` — all clean.
- [ ] Confirm on the second CI run that the per-service build logs show `importing cache manifest from gha:<scope>` (requires one prior run to populate the cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)