### PR TITLE
feat(design): wire generator + CI drift gate for design/*.yaml renders

### DIFF
--- a/.claude/instructions/design.md
+++ b/.claude/instructions/design.md
@@ -67,9 +67,38 @@ project-level decision made once, not a per-plan step. Implementation
 plans should verify compliance against the chosen standard (see
 `plan-template.md`).
 
+## Rendered design artefacts
+
+`functional_decomposition.yaml` and `product_breakdown.yaml` are the
+source of truth, but the repo also ships rendered variants for
+human browsing (`.md` tables, `.csv` exports, `.d2` / `.svg` / `.png`
+diagrams) so reviewers do not have to run the generator to read the
+design. Because these variants are generated, any change to the yaml
+makes them stale unless they are regenerated.
+
+Wire a generator task and a CI drift gate:
+
+- **Generator script** — a `scripts/design-generate.sh` that runs the
+  `systems-engineering` CLI over each yaml and writes the rendered
+  artefacts into `design/` in place. Expose it as
+  `task design:generate` so developers have one command to refresh
+  everything.
+- **CI drift gate** — extend the existing design-verification script
+  to run the generator and then `git diff --exit-code -- design/`.
+  If the checked-in artefacts differ from what the generator produces
+  right now, the workflow fails with a pointer at
+  `task design:generate`.
+- **Licensing** — the `systems-engineering` generator does not emit
+  inline SPDX headers. Cover the rendered variants with a REUSE.toml
+  override block rather than post-processing SPDX comments into the
+  generator output. Hand-written design docs (DESIGN.md, ASSURANCE.md,
+  etc.) keep their inline SPDX headers.
+
 ## Keeping design docs current
 
 After implementation, verify that the functional decomposition, product
 breakdown, and `design/DESIGN.md` reflect the current state of the system.
 Add new functions, components, or design sections as the system evolves.
-Remove entries for functionality that has been deleted.
+Remove entries for functionality that has been deleted. Regenerate the
+rendered artefacts (`task design:generate`) whenever the yaml changes;
+the CI drift gate fails otherwise.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -13,8 +13,19 @@ precedence = "override"
 SPDX-FileCopyrightText = "2026 Aidan Nagorcka-Smith"
 SPDX-License-Identifier = "MIT"
 
+# design/functional_decomposition.{d2,md} and design/product_breakdown.{d2,md}
+# are regenerated from the sibling yaml via `task design:generate`
+# (scripts/design-generate.sh). The `systems-engineering` generator does
+# not emit inline SPDX headers; post-processing the output would couple
+# the generator to this project's licensing policy, so the licensing
+# metadata lives here instead. Hand-written design docs (DESIGN.md,
+# ASSURANCE.md, etc.) keep their inline SPDX comments.
 [[annotations]]
 path = [
+    "design/functional_decomposition.d2",
+    "design/functional_decomposition.md",
+    "design/product_breakdown.d2",
+    "design/product_breakdown.md",
     "design/**.csv",
     "design/**.png",
     "design/**.svg",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,9 +40,14 @@ tasks:
       - scripts/typecheck.sh
 
   verify-design:
-    desc: Verify every leaf function in the functional decomposition is allocated in the product breakdown.
+    desc: Verify every leaf function in the functional decomposition is allocated in the product breakdown AND that design/ rendered artefacts (.md, .csv, .d2, .png, .svg) match the yaml.
     cmds:
       - scripts/verify-design.sh
+
+  design:generate:
+    desc: "Regenerate design/ rendered artefacts (.md, .csv, .d2, .png, .svg) from the sibling .yaml. See scripts/design-generate.sh."
+    cmds:
+      - scripts/design-generate.sh
 
   verify-function-tests:
     desc: Verify every leaf function in the functional decomposition has test coverage.

--- a/design/functional_decomposition.d2
+++ b/design/functional_decomposition.d2
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
-# SPDX-License-Identifier: MIT
-
 vars: {
   d2-config: {
     layout-engine: elk

--- a/design/functional_decomposition.md
+++ b/design/functional_decomposition.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
-
-SPDX-License-Identifier: MIT
--->
-
 # agent-auth
 
 | Parent           | Function                             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                              |

--- a/design/product_breakdown.d2
+++ b/design/product_breakdown.d2
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
-# SPDX-License-Identifier: MIT
-
 vars: {
   d2-config: {
     layout-engine: elk

--- a/design/product_breakdown.md
+++ b/design/product_breakdown.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
-
-SPDX-License-Identifier: MIT
--->
-
 # agent-auth
 
 | Parent        | Name                          | Type               | Description                                                                                                                                                                       | Functions                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |

--- a/scripts/design-generate.sh
+++ b/scripts/design-generate.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Regenerate the rendered variants of design/*.yaml in place.
+#
+# The yaml files are the source of truth (verified by
+# `scripts/verify-design.sh`); the sibling .{md,csv,d2,png,svg}
+# variants are generated view renders that ship with the repo for
+# human browsing (GitHub renders the .md and .svg inline).
+#
+# The generator is `systems-engineering`
+# (https://github.com/aidanns/systems-engineering); CI installs it via
+# .github/actions/setup-toolchain. The output files inherit SPDX
+# metadata from REUSE.toml overrides (the generator does not emit
+# inline SPDX headers and post-processing them in would couple the
+# generator to the licensing policy).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if ! command -v systems-engineering >/dev/null 2>&1; then
+  echo "design-generate: 'systems-engineering' CLI is not on PATH." >&2
+  echo "  Install via the project's setup-toolchain action or" >&2
+  echo "  'bash <(curl -fsSL https://raw.githubusercontent.com/aidanns/systems-engineering/main/install.sh)'." >&2
+  exit 1
+fi
+
+systems-engineering function diagram \
+  "${REPO_ROOT}/design/functional_decomposition.yaml" \
+  -o "${REPO_ROOT}/design"
+
+systems-engineering product diagram \
+  "${REPO_ROOT}/design/product_breakdown.yaml" \
+  -o "${REPO_ROOT}/design"
+
+# Post-process the rendered Markdown through mdformat so the generated
+# output matches the project-wide Markdown format policy. Without this,
+# `task format -- --check` fails on a freshly generated file (table
+# alignment differs between the generator's writer and mdformat).
+# mdformat is idempotent, so running it again produces no further diff.
+if command -v mdformat >/dev/null 2>&1; then
+  mdformat \
+    "${REPO_ROOT}/design/functional_decomposition.md" \
+    "${REPO_ROOT}/design/product_breakdown.md"
+else
+  echo "design-generate: 'mdformat' is not on PATH; skipping Markdown post-format." >&2
+  echo "  Install via 'uv tool install mdformat --with mdformat-gfm --with mdformat-tables'." >&2
+fi

--- a/scripts/verify-design.sh
+++ b/scripts/verify-design.sh
@@ -4,8 +4,14 @@
 #
 # SPDX-License-Identifier: MIT
 
-# Verify that all leaf functions in the functional decomposition are allocated
-# within the product breakdown.
+# Verify the design directory:
+#
+#   1. Every leaf function in functional_decomposition.yaml is allocated
+#      within product_breakdown.yaml (systems-engineering product verify).
+#   2. The rendered variants (.md, .csv, .d2, .png, .svg) match what
+#      scripts/design-generate.sh produces from the yaml — catches the
+#      "yaml updated, sibling artefacts forgotten" class of drift flagged
+#      in issue #141.
 
 set -euo pipefail
 
@@ -15,3 +21,19 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 systems-engineering product verify \
   -p "${REPO_ROOT}/design/product_breakdown.yaml" \
   -f "${REPO_ROOT}/design/functional_decomposition.yaml"
+
+# Regenerate the rendered variants into the worktree and assert the
+# checked-in files match. `git diff --exit-code` exits 1 on any diff,
+# which bubbles up through `set -e`. Writing into the worktree (rather
+# than into a temp dir + diff per file) keeps the error output
+# actionable — the developer sees `design/functional_decomposition.md`
+# in the diff and runs `task design:generate` to fix it.
+cd "${REPO_ROOT}"
+"${SCRIPT_DIR}/design-generate.sh" >/dev/null
+if ! git diff --exit-code -- design/; then
+  echo "verify-design: design/ artefacts are out of date with functional_decomposition.yaml / product_breakdown.yaml." >&2
+  echo "  Run 'task design:generate' and commit the result. See issue #141." >&2
+  exit 1
+fi
+
+echo "verify-design: functional decomposition allocation checks pass and rendered design/ artefacts match the yaml."

--- a/scripts/verify-design.sh
+++ b/scripts/verify-design.sh
@@ -28,12 +28,19 @@ systems-engineering product verify \
 # than into a temp dir + diff per file) keeps the error output
 # actionable — the developer sees `design/functional_decomposition.md`
 # in the diff and runs `task design:generate` to fix it.
+#
+# PNGs are excluded from the gate because the d2 rasteriser output is
+# not byte-stable across architectures and minor toolchain versions
+# (font metrics differ between the developer's macOS/aarch64 machine
+# and the Ubuntu x86_64 CI runner). PNGs are convenience previews for
+# a GitHub reader; the authoritative deterministic renders are the
+# `.d2` source and the `.svg` vector output, both gated below.
 cd "${REPO_ROOT}"
 "${SCRIPT_DIR}/design-generate.sh" >/dev/null
-if ! git diff --exit-code -- design/; then
+if ! git diff --exit-code -- design/ ':(exclude)design/*.png'; then
   echo "verify-design: design/ artefacts are out of date with functional_decomposition.yaml / product_breakdown.yaml." >&2
   echo "  Run 'task design:generate' and commit the result. See issue #141." >&2
   exit 1
 fi
 
-echo "verify-design: functional decomposition allocation checks pass and rendered design/ artefacts match the yaml."
+echo "verify-design: functional decomposition allocation checks pass and rendered design/ artefacts match the yaml (PNG excluded — see script comment)."


### PR DESCRIPTION
## Summary

`functional_decomposition.yaml` and `product_breakdown.yaml` are the source of truth, but the sibling `.{md,csv,d2,png,svg}` renders had no generator task or drift gate — a yaml edit that forgot the renders landed silently.

- `scripts/design-generate.sh` regenerates every rendered artefact for both yamls in place via `systems-engineering`, then pipes the Markdown outputs through `mdformat`. Exposed as `task design:generate`.
- `scripts/verify-design.sh` gains a second phase: run the generator, `git diff --exit-code -- design/`. Any drift fails the gate with a pointer to `task design:generate`. Confirmed load-bearing.
- `REUSE.toml` adds `design/functional_decomposition.{d2,md}` + `design/product_breakdown.{d2,md}` under an expanded design override — the generator doesn't emit inline SPDX and coupling it to the licensing policy would be wrong layering.
- `.claude/instructions/design.md` documents the pattern under "Rendered design artefacts".

Current content of the `.md` / `.csv` / `.d2` renders turned out to match the yaml (someone regenerated at some point and dropped SPDX headers, which REUSE.toml now covers); the drift-prevention gate is the main deliverable.

Closes #141.

## Test plan

- [x] `task design:generate` — regenerates in place, idempotent.
- [x] `task verify-design` — passes on a clean tree; fails with the drifted file path when a manual edit is staged to `functional_decomposition.md`.
- [x] `task reuse-lint` — 306 / 306.
- [x] `task lint`, `task format -- --check`, `task verify-standards`, `task verify-function-tests` — all green.