### PR TITLE
refactor(things): define TodoId/ProjectId/AreaId NewTypes

### DIFF
--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -38,6 +38,9 @@
 #   2e. .github/renovate.json exists and targets
 #      .github/tool-versions.yaml via customManagers — the auto-bump
 #      channel for every CI tool (see ADR 0031 and issue #205).
+#   2f. src/things_models/models.py defines TodoId, ProjectId, AreaId
+#      via typing.NewType so Things entity ids aren't interchangeable
+#      strings at the type checker's boundary (see issue #34).
 #   3. Bash gating (shellcheck, shfmt) is wired into CI, treefmt, and
 #      lefthook per .claude/instructions/bash.md.
 #   4. Markdown (mdformat) and TOML (taplo) formatters are wired into
@@ -405,6 +408,34 @@ if ! grep -qF ".github/tool-versions.yaml" "${RENOVATE_CONFIG}"; then
 fi
 
 echo "verify-standards: ${RENOVATE_CONFIG} is present and targets ${TOOL_VERSIONS_MANIFEST}."
+
+# ---------------------------------------------------------------------------
+# Semantic types for Things entity identifiers.
+# ---------------------------------------------------------------------------
+# .claude/instructions/coding-standards.md § "Types and safety" requires
+# newtypes at semantic boundaries. Every Things entity id must be a
+# typing.NewType alias so a TodoId and ProjectId aren't interchangeable
+# from the type checker's perspective. See issue #34.
+ID_TYPES_FILE="src/things_models/models.py"
+if [[ ! -f "${ID_TYPES_FILE}" ]]; then
+  echo "verify-standards: ${ID_TYPES_FILE} is missing." >&2
+  exit 1
+fi
+
+id_newtype_missing=0
+for id_name in TodoId ProjectId AreaId; do
+  if ! grep -qE "^${id_name}[[:space:]]*=[[:space:]]*NewType\(" "${ID_TYPES_FILE}"; then
+    echo "verify-standards: ${ID_TYPES_FILE} does not define ${id_name} via typing.NewType." >&2
+    id_newtype_missing=1
+  fi
+done
+
+if [[ ${id_newtype_missing} -ne 0 ]]; then
+  echo "  See .claude/instructions/coding-standards.md § Types and safety and issue #34." >&2
+  exit 1
+fi
+
+echo "verify-standards: ${ID_TYPES_FILE} defines TodoId / ProjectId / AreaId via typing.NewType."
 
 # Bash tooling: shellcheck + shfmt must be wired into CI, treefmt, and
 # lefthook per .claude/instructions/bash.md. Strip comments before

--- a/src/things_bridge/server.py
+++ b/src/things_bridge/server.py
@@ -38,6 +38,7 @@ from things_bridge.errors import (
 )
 from things_bridge.metrics import ThingsBridgeMetrics, build_registry
 from things_models.client import ThingsClient
+from things_models.models import AreaId, ProjectId, TodoId
 
 READ_SCOPE = "things:read"
 HEALTH_SCOPE = "things-bridge:health"
@@ -279,11 +280,13 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
             self._route_template = path
             if not self._validate(token, READ_SCOPE, "List Things todos"):
                 return
+            project_filter = _first(params, "project")
+            area_filter = _first(params, "area")
             try:
                 todos = things.list_todos(
                     list_id=_first(params, "list"),
-                    project_id=_first(params, "project"),
-                    area_id=_first(params, "area"),
+                    project_id=ProjectId(project_filter) if project_filter is not None else None,
+                    area_id=AreaId(area_filter) if area_filter is not None else None,
                     tag=_first(params, "tag"),
                     status=_first(params, "status"),
                 )
@@ -295,10 +298,11 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
 
         if path.startswith("/things-bridge/v1/todos/"):
             self._route_template = "/things-bridge/v1/todos/{id}"
-            todo_id = _safe_id(path[len("/things-bridge/v1/todos/") :])
-            if todo_id is None:
+            safe_todo_id = _safe_id(path[len("/things-bridge/v1/todos/") :])
+            if safe_todo_id is None:
                 self._send_json(404, {"error": "not_found"})
                 return
+            todo_id = TodoId(safe_todo_id)
             if not self._validate(token, READ_SCOPE, f"Read Things todo {todo_id}"):
                 return
             try:
@@ -313,8 +317,13 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
             self._route_template = path
             if not self._validate(token, READ_SCOPE, "List Things projects"):
                 return
+            project_area_filter = _first(params, "area")
             try:
-                projects = things.list_projects(area_id=_first(params, "area"))
+                projects = things.list_projects(
+                    area_id=AreaId(project_area_filter)
+                    if project_area_filter is not None
+                    else None,
+                )
             except ThingsError as exc:
                 self._send_things_error_response(exc)
                 return
@@ -323,10 +332,11 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
 
         if path.startswith("/things-bridge/v1/projects/"):
             self._route_template = "/things-bridge/v1/projects/{id}"
-            project_id = _safe_id(path[len("/things-bridge/v1/projects/") :])
-            if project_id is None:
+            safe_project_id = _safe_id(path[len("/things-bridge/v1/projects/") :])
+            if safe_project_id is None:
                 self._send_json(404, {"error": "not_found"})
                 return
+            project_id = ProjectId(safe_project_id)
             if not self._validate(token, READ_SCOPE, f"Read Things project {project_id}"):
                 return
             try:
@@ -351,10 +361,11 @@ class ThingsBridgeHandler(BaseHTTPRequestHandler):
 
         if path.startswith("/things-bridge/v1/areas/"):
             self._route_template = "/things-bridge/v1/areas/{id}"
-            area_id = _safe_id(path[len("/things-bridge/v1/areas/") :])
-            if area_id is None:
+            safe_area_id = _safe_id(path[len("/things-bridge/v1/areas/") :])
+            if safe_area_id is None:
                 self._send_json(404, {"error": "not_found"})
                 return
+            area_id = AreaId(safe_area_id)
             if not self._validate(token, READ_SCOPE, f"Read Things area {area_id}"):
                 return
             try:

--- a/src/things_bridge/things_client.py
+++ b/src/things_bridge/things_client.py
@@ -23,7 +23,7 @@ from things_models.errors import (
     ThingsNotFoundError,
     ThingsPermissionError,
 )
-from things_models.models import Area, Project, Todo
+from things_models.models import Area, AreaId, Project, ProjectId, Todo, TodoId
 
 STDERR_TAIL_MAX_CHARS = 64 * 1024
 """Upper bound on the stderr tail retained for diagnostic messages.
@@ -57,8 +57,8 @@ class ThingsSubprocessClient:
         self,
         *,
         list_id: str | None = None,
-        project_id: str | None = None,
-        area_id: str | None = None,
+        project_id: ProjectId | None = None,
+        area_id: AreaId | None = None,
         tag: str | None = None,
         status: str | None = None,
     ) -> list[Todo]:
@@ -76,18 +76,18 @@ class ThingsSubprocessClient:
         payload = self._invoke(argv)
         return [Todo.from_json(t) for t in payload.get("todos", [])]
 
-    def get_todo(self, todo_id: str) -> Todo:
+    def get_todo(self, todo_id: TodoId) -> Todo:
         payload = self._invoke(["todos", "show", todo_id])
         return Todo.from_json(payload["todo"])
 
-    def list_projects(self, *, area_id: str | None = None) -> list[Project]:
+    def list_projects(self, *, area_id: AreaId | None = None) -> list[Project]:
         argv = ["projects", "list"]
         if area_id is not None:
             argv.extend(["--area", area_id])
         payload = self._invoke(argv)
         return [Project.from_json(p) for p in payload.get("projects", [])]
 
-    def get_project(self, project_id: str) -> Project:
+    def get_project(self, project_id: ProjectId) -> Project:
         payload = self._invoke(["projects", "show", project_id])
         return Project.from_json(payload["project"])
 
@@ -95,7 +95,7 @@ class ThingsSubprocessClient:
         payload = self._invoke(["areas", "list"])
         return [Area.from_json(a) for a in payload.get("areas", [])]
 
-    def get_area(self, area_id: str) -> Area:
+    def get_area(self, area_id: AreaId) -> Area:
         payload = self._invoke(["areas", "show", area_id])
         return Area.from_json(payload["area"])
 

--- a/src/things_bridge_client/client.py
+++ b/src/things_bridge_client/client.py
@@ -27,6 +27,7 @@ from things_bridge_client.errors import (
     ThingsBridgeUnauthorizedError,
     ThingsBridgeUnavailableError,
 )
+from things_models.models import AreaId, ProjectId, TodoId
 
 
 class ThingsBridgeClient:
@@ -73,7 +74,7 @@ class ThingsBridgeClient:
         """GET ``/things-bridge/v1/todos``, optionally filtered by query params."""
         return self._get_json("/things-bridge/v1/todos", access_token, params=params)
 
-    def get_todo(self, access_token: str | None, todo_id: str) -> dict[str, Any]:
+    def get_todo(self, access_token: str | None, todo_id: TodoId) -> dict[str, Any]:
         """GET ``/things-bridge/v1/todos/{id}``."""
         return self._get_json(f"/things-bridge/v1/todos/{quote(todo_id, safe='')}", access_token)
 
@@ -86,7 +87,7 @@ class ThingsBridgeClient:
         """GET ``/things-bridge/v1/projects``, optionally filtered by query params."""
         return self._get_json("/things-bridge/v1/projects", access_token, params=params)
 
-    def get_project(self, access_token: str | None, project_id: str) -> dict[str, Any]:
+    def get_project(self, access_token: str | None, project_id: ProjectId) -> dict[str, Any]:
         """GET ``/things-bridge/v1/projects/{id}``."""
         return self._get_json(
             f"/things-bridge/v1/projects/{quote(project_id, safe='')}", access_token
@@ -96,7 +97,7 @@ class ThingsBridgeClient:
         """GET ``/things-bridge/v1/areas``."""
         return self._get_json("/things-bridge/v1/areas", access_token)
 
-    def get_area(self, access_token: str | None, area_id: str) -> dict[str, Any]:
+    def get_area(self, access_token: str | None, area_id: AreaId) -> dict[str, Any]:
         """GET ``/things-bridge/v1/areas/{id}``."""
         return self._get_json(f"/things-bridge/v1/areas/{quote(area_id, safe='')}", access_token)
 

--- a/src/things_cli/cli.py
+++ b/src/things_cli/cli.py
@@ -23,6 +23,7 @@ from things_cli.errors import (
     CredentialsBackendError,
     CredentialsNotFoundError,
 )
+from things_models.models import AreaId, ProjectId, TodoId
 
 
 def _default_file_path() -> str:
@@ -98,7 +99,7 @@ def handle_todos_list(args: argparse.Namespace) -> int:
 
 def handle_todo_show(args: argparse.Namespace) -> int:
     client = _load_client(args)
-    data = client.get_todo(args.id)
+    data = client.get_todo(TodoId(args.id))
     output.print_todo(data["todo"], as_json=args.json)
     return 0
 
@@ -115,7 +116,7 @@ def handle_projects_list(args: argparse.Namespace) -> int:
 
 def handle_project_show(args: argparse.Namespace) -> int:
     client = _load_client(args)
-    data = client.get_project(args.id)
+    data = client.get_project(ProjectId(args.id))
     output.print_project(data["project"], as_json=args.json)
     return 0
 
@@ -129,7 +130,7 @@ def handle_areas_list(args: argparse.Namespace) -> int:
 
 def handle_area_show(args: argparse.Namespace) -> int:
     client = _load_client(args)
-    data = client.get_area(args.id)
+    data = client.get_area(AreaId(args.id))
     output.print_area(data["area"], as_json=args.json)
     return 0
 

--- a/src/things_cli/client.py
+++ b/src/things_cli/client.py
@@ -41,6 +41,7 @@ from things_bridge_client import (
     ThingsBridgeUnavailableError,
 )
 from things_cli.credentials import Credentials, CredentialStore
+from things_models.models import AreaId, ProjectId, TodoId
 
 
 class BridgeClient:
@@ -81,19 +82,19 @@ class BridgeClient:
     def list_todos(self, params: dict[str, str] | None = None) -> dict[str, Any]:
         return self._with_retry(lambda token: self._bridge.list_todos(token, params=params))
 
-    def get_todo(self, todo_id: str) -> dict[str, Any]:
+    def get_todo(self, todo_id: TodoId) -> dict[str, Any]:
         return self._with_retry(lambda token: self._bridge.get_todo(token, todo_id))
 
     def list_projects(self, params: dict[str, str] | None = None) -> dict[str, Any]:
         return self._with_retry(lambda token: self._bridge.list_projects(token, params=params))
 
-    def get_project(self, project_id: str) -> dict[str, Any]:
+    def get_project(self, project_id: ProjectId) -> dict[str, Any]:
         return self._with_retry(lambda token: self._bridge.get_project(token, project_id))
 
     def list_areas(self) -> dict[str, Any]:
         return self._with_retry(lambda token: self._bridge.list_areas(token))
 
-    def get_area(self, area_id: str) -> dict[str, Any]:
+    def get_area(self, area_id: AreaId) -> dict[str, Any]:
         return self._with_retry(lambda token: self._bridge.get_area(token, area_id))
 
     # -- internal --

--- a/src/things_client_applescript/things.py
+++ b/src/things_client_applescript/things.py
@@ -22,7 +22,7 @@ from things_models.errors import (
     ThingsNotFoundError,
     ThingsPermissionError,
 )
-from things_models.models import Area, Project, Todo
+from things_models.models import Area, AreaId, Project, ProjectId, Todo, TodoId
 from things_models.status import validate_status
 
 TAB_PLACEHOLDER = "\u241e"
@@ -504,14 +504,16 @@ def _parse_rows(output: str, expected_cols: int) -> list[list[str]]:
 
 def _row_to_todo(row: list[str]) -> Todo:
     cols = dict(zip(_TODO_FIELDS, row, strict=False))
+    project_id_raw = _field(cols["project_id"])
+    area_id_raw = _field(cols["area_id"])
     return Todo(
-        id=_field(cols["id"]) or "",
+        id=TodoId(_field(cols["id"]) or ""),
         name=_field(cols["name"]) or "",
         notes=_field(cols["notes"]) or "",
         status=_field(cols["status"]) or "open",
-        project_id=_field(cols["project_id"]),
+        project_id=ProjectId(project_id_raw) if project_id_raw is not None else None,
         project_name=_field(cols["project_name"]),
-        area_id=_field(cols["area_id"]),
+        area_id=AreaId(area_id_raw) if area_id_raw is not None else None,
         area_name=_field(cols["area_name"]),
         tag_names=_tag_list(cols["tag_names"]),
         due_date=_field(cols["due_date"]),
@@ -525,12 +527,13 @@ def _row_to_todo(row: list[str]) -> Todo:
 
 def _row_to_project(row: list[str]) -> Project:
     cols = dict(zip(_PROJECT_FIELDS, row, strict=False))
+    area_id_raw = _field(cols["area_id"])
     return Project(
-        id=_field(cols["id"]) or "",
+        id=ProjectId(_field(cols["id"]) or ""),
         name=_field(cols["name"]) or "",
         notes=_field(cols["notes"]) or "",
         status=_field(cols["status"]) or "open",
-        area_id=_field(cols["area_id"]),
+        area_id=AreaId(area_id_raw) if area_id_raw is not None else None,
         area_name=_field(cols["area_name"]),
         tag_names=_tag_list(cols["tag_names"]),
         due_date=_field(cols["due_date"]),
@@ -545,7 +548,7 @@ def _row_to_project(row: list[str]) -> Project:
 def _row_to_area(row: list[str]) -> Area:
     cols = dict(zip(_AREA_FIELDS, row, strict=False))
     return Area(
-        id=_field(cols["id"]) or "",
+        id=AreaId(_field(cols["id"]) or ""),
         name=_field(cols["name"]) or "",
         tag_names=_tag_list(cols["tag_names"]),
     )

--- a/src/things_models/client.py
+++ b/src/things_models/client.py
@@ -10,7 +10,7 @@ bridge's subprocess client (which delegates to it through JSON).
 
 from typing import Protocol
 
-from things_models.models import Area, Project, Todo
+from things_models.models import Area, AreaId, Project, ProjectId, Todo, TodoId
 
 
 class ThingsClient(Protocol):
@@ -20,18 +20,18 @@ class ThingsClient(Protocol):
         self,
         *,
         list_id: str | None = None,
-        project_id: str | None = None,
-        area_id: str | None = None,
+        project_id: ProjectId | None = None,
+        area_id: AreaId | None = None,
         tag: str | None = None,
         status: str | None = None,
     ) -> list[Todo]: ...
 
-    def get_todo(self, todo_id: str) -> Todo: ...
+    def get_todo(self, todo_id: TodoId) -> Todo: ...
 
-    def list_projects(self, *, area_id: str | None = None) -> list[Project]: ...
+    def list_projects(self, *, area_id: AreaId | None = None) -> list[Project]: ...
 
-    def get_project(self, project_id: str) -> Project: ...
+    def get_project(self, project_id: ProjectId) -> Project: ...
 
     def list_areas(self) -> list[Area]: ...
 
-    def get_area(self, area_id: str) -> Area: ...
+    def get_area(self, area_id: AreaId) -> Area: ...

--- a/src/things_models/models.py
+++ b/src/things_models/models.py
@@ -7,15 +7,29 @@
 Shared between the bridge (which parses subprocess JSON back into these
 dataclasses before re-serialising for HTTP responses) and the client
 CLIs (which build and emit them).
+
+Entity identifiers use ``typing.NewType`` wrappers so a ``TodoId`` and
+a ``ProjectId`` are not interchangeable from the type checker's
+perspective. See ``.claude/instructions/coding-standards.md`` § *Types
+and safety*.
 """
 
 from dataclasses import asdict, dataclass
-from typing import Any
+from typing import Any, NewType
+
+TodoId = NewType("TodoId", str)
+"""Stable identifier for a :class:`Todo`."""
+
+ProjectId = NewType("ProjectId", str)
+"""Stable identifier for a :class:`Project`."""
+
+AreaId = NewType("AreaId", str)
+"""Stable identifier for an :class:`Area`."""
 
 
 @dataclass
 class Area:
-    id: str
+    id: AreaId
     name: str
     tag_names: list[str]
 
@@ -25,7 +39,7 @@ class Area:
     @classmethod
     def from_json(cls, data: dict[str, Any]) -> "Area":
         return cls(
-            id=data["id"],
+            id=AreaId(data["id"]),
             name=data["name"],
             tag_names=list(data.get("tag_names") or []),
         )
@@ -33,11 +47,11 @@ class Area:
 
 @dataclass
 class Project:
-    id: str
+    id: ProjectId
     name: str
     notes: str
     status: str  # "open" | "completed" | "canceled"
-    area_id: str | None
+    area_id: AreaId | None
     area_name: str | None
     tag_names: list[str]
     due_date: str | None  # ISO 8601 date (YYYY-MM-DD) or None
@@ -52,12 +66,13 @@ class Project:
 
     @classmethod
     def from_json(cls, data: dict[str, Any]) -> "Project":
+        raw_area_id = data.get("area_id")
         return cls(
-            id=data["id"],
+            id=ProjectId(data["id"]),
             name=data["name"],
             notes=data.get("notes", ""),
             status=data.get("status", "open"),
-            area_id=data.get("area_id"),
+            area_id=AreaId(raw_area_id) if raw_area_id is not None else None,
             area_name=data.get("area_name"),
             tag_names=list(data.get("tag_names") or []),
             due_date=data.get("due_date"),
@@ -71,13 +86,13 @@ class Project:
 
 @dataclass
 class Todo:
-    id: str
+    id: TodoId
     name: str
     notes: str
     status: str  # "open" | "completed" | "canceled"
-    project_id: str | None
+    project_id: ProjectId | None
     project_name: str | None
-    area_id: str | None
+    area_id: AreaId | None
     area_name: str | None
     tag_names: list[str]
     due_date: str | None
@@ -92,14 +107,16 @@ class Todo:
 
     @classmethod
     def from_json(cls, data: dict[str, Any]) -> "Todo":
+        raw_project_id = data.get("project_id")
+        raw_area_id = data.get("area_id")
         return cls(
-            id=data["id"],
+            id=TodoId(data["id"]),
             name=data["name"],
             notes=data.get("notes", ""),
             status=data.get("status", "open"),
-            project_id=data.get("project_id"),
+            project_id=ProjectId(raw_project_id) if raw_project_id is not None else None,
             project_name=data.get("project_name"),
-            area_id=data.get("area_id"),
+            area_id=AreaId(raw_area_id) if raw_area_id is not None else None,
             area_name=data.get("area_name"),
             tag_names=list(data.get("tag_names") or []),
             due_date=data.get("due_date"),

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -6,12 +6,12 @@
 
 from typing import Any
 
-from things_models.models import Area, Project, Todo
+from things_models.models import Area, AreaId, Project, ProjectId, Todo, TodoId
 
 
 def make_todo(**overrides: Any) -> Todo:
     defaults: dict[str, Any] = dict(
-        id="t1",
+        id=TodoId("t1"),
         name="",
         notes="",
         status="open",
@@ -33,7 +33,7 @@ def make_todo(**overrides: Any) -> Todo:
 
 def make_project(**overrides: Any) -> Project:
     defaults: dict[str, Any] = dict(
-        id="p1",
+        id=ProjectId("p1"),
         name="",
         notes="",
         status="open",
@@ -52,6 +52,6 @@ def make_project(**overrides: Any) -> Project:
 
 
 def make_area(**overrides: Any) -> Area:
-    defaults: dict[str, Any] = dict(id="a1", name="", tag_names=[])
+    defaults: dict[str, Any] = dict(id=AreaId("a1"), name="", tag_names=[])
     defaults.update(overrides)
     return Area(**defaults)

--- a/tests/test_things_bridge_client.py
+++ b/tests/test_things_bridge_client.py
@@ -27,6 +27,7 @@ from things_bridge_client import (
     ThingsBridgeUnauthorizedError,
     ThingsBridgeUnavailableError,
 )
+from things_models.models import TodoId
 
 
 class _StubHandler(BaseHTTPRequestHandler):
@@ -116,7 +117,7 @@ def test_403_maps_to_forbidden(bridge_server):
     _StubHandler.body = {"error": "scope_denied"}
     client = ThingsBridgeClient(url, timeout_seconds=2.0)
     with pytest.raises(ThingsBridgeForbiddenError, match="scope_denied"):
-        client.get_todo("aa_abc", "t1")
+        client.get_todo("aa_abc", TodoId("t1"))
 
 
 def test_404_maps_to_not_found(bridge_server):
@@ -125,7 +126,7 @@ def test_404_maps_to_not_found(bridge_server):
     _StubHandler.body = {"error": "not_found"}
     client = ThingsBridgeClient(url, timeout_seconds=2.0)
     with pytest.raises(ThingsBridgeNotFoundError, match="not_found"):
-        client.get_todo("aa_abc", "missing")
+        client.get_todo("aa_abc", TodoId("missing"))
 
 
 def test_429_surfaces_retry_after(bridge_server):

--- a/tests/test_things_bridge_server.py
+++ b/tests/test_things_bridge_server.py
@@ -30,7 +30,7 @@ from things_bridge.errors import (
 )
 from things_bridge.metrics import build_registry as build_bridge_registry
 from things_bridge.server import ThingsBridgeServer, _HealthChecker
-from things_models.models import Area
+from things_models.models import Area, AreaId
 
 
 class FakeAuthz(AgentAuthClient):
@@ -466,14 +466,14 @@ def test_get_project_by_id(bridge):
 
 
 def test_get_areas_list(bridge):
-    bridge["store"].areas = [Area(id="a1", name="Personal", tag_names=[])]
+    bridge["store"].areas = [Area(id=AreaId("a1"), name="Personal", tag_names=[])]
     status, data = _get(f"{bridge['url']}/things-bridge/v1/areas")
     assert status == 200
     assert data["areas"][0]["id"] == "a1"
 
 
 def test_get_area_by_id(bridge):
-    bridge["store"].areas = [Area(id="a1", name="Personal", tag_names=["home"])]
+    bridge["store"].areas = [Area(id=AreaId("a1"), name="Personal", tag_names=["home"])]
     status, data = _get(f"{bridge['url']}/things-bridge/v1/areas/a1")
     assert status == 200
     assert data["area"]["tag_names"] == ["home"]

--- a/tests/test_things_cli_client.py
+++ b/tests/test_things_cli_client.py
@@ -24,6 +24,7 @@ from things_bridge_client import (
 )
 from things_cli.client import BridgeClient
 from things_cli.credentials import Credentials, FileStore
+from things_models.models import TodoId
 
 # -- Fake bridge --
 
@@ -224,7 +225,7 @@ def test_404_surfaces_as_not_found(servers, tmp_path):
     _BridgeHandler.queued_responses = [(404, {"error": "not_found"}, None)]
     client, _ = _make_client(servers, tmp_path)
     with pytest.raises(ThingsBridgeNotFoundError):
-        client.get_todo("unknown")
+        client.get_todo(TodoId("unknown"))
 
 
 def test_502_surfaces_as_unavailable(servers, tmp_path):

--- a/tests/test_things_client_fake.py
+++ b/tests/test_things_client_fake.py
@@ -14,7 +14,7 @@ from tests.things_client_fake.store import (
     load_fake_store,
 )
 from things_models.errors import ThingsError, ThingsNotFoundError
-from things_models.models import Area
+from things_models.models import Area, AreaId, ProjectId, TodoId
 
 
 def test_list_todos_returns_all_without_filters():
@@ -32,7 +32,7 @@ def test_list_todos_filters_by_project_id():
         ]
     )
     client = FakeThingsClient(store)
-    assert [t.id for t in client.list_todos(project_id="p1")] == ["t1", "t3"]
+    assert [t.id for t in client.list_todos(project_id=ProjectId("p1"))] == ["t1", "t3"]
 
 
 def test_list_todos_filters_by_area_id():
@@ -43,7 +43,7 @@ def test_list_todos_filters_by_area_id():
         ]
     )
     client = FakeThingsClient(store)
-    assert [t.id for t in client.list_todos(area_id="a2")] == ["t2"]
+    assert [t.id for t in client.list_todos(area_id=AreaId("a2"))] == ["t2"]
 
 
 def test_list_todos_filters_by_tag():
@@ -104,20 +104,20 @@ def test_list_todos_combines_filters():
         ]
     )
     client = FakeThingsClient(store)
-    result = client.list_todos(project_id="p1", status="open", tag="A")
+    result = client.list_todos(project_id=ProjectId("p1"), status="open", tag="A")
     assert [t.id for t in result] == ["t1"]
 
 
 def test_get_todo_returns_match():
     store = FakeThingsStore(todos=[_todo(id="t1"), _todo(id="t2")])
     client = FakeThingsClient(store)
-    assert client.get_todo("t2").id == "t2"
+    assert client.get_todo(TodoId("t2")).id == "t2"
 
 
 def test_get_todo_raises_on_miss():
     client = FakeThingsClient(FakeThingsStore())
     with pytest.raises(ThingsNotFoundError):
-        client.get_todo("nope")
+        client.get_todo(TodoId("nope"))
 
 
 def test_list_projects_filters_by_area():
@@ -128,23 +128,23 @@ def test_list_projects_filters_by_area():
         ]
     )
     client = FakeThingsClient(store)
-    assert [p.id for p in client.list_projects(area_id="a2")] == ["p2"]
+    assert [p.id for p in client.list_projects(area_id=AreaId("a2"))] == ["p2"]
 
 
 def test_get_project_raises_on_miss():
     client = FakeThingsClient(FakeThingsStore())
     with pytest.raises(ThingsNotFoundError):
-        client.get_project("nope")
+        client.get_project(ProjectId("nope"))
 
 
 def test_list_areas_and_get_area():
-    area = Area(id="a1", name="Personal", tag_names=["home"])
+    area = Area(id=AreaId("a1"), name="Personal", tag_names=["home"])
     store = FakeThingsStore(areas=[area])
     client = FakeThingsClient(store)
     assert [a.id for a in client.list_areas()] == ["a1"]
-    assert client.get_area("a1").tag_names == ["home"]
+    assert client.get_area(AreaId("a1")).tag_names == ["home"]
     with pytest.raises(ThingsNotFoundError):
-        client.get_area("missing")
+        client.get_area(AreaId("missing"))
 
 
 def test_load_fake_store_reads_full_fixture(tmp_path):

--- a/tests/test_things_models.py
+++ b/tests/test_things_models.py
@@ -4,18 +4,18 @@
 
 """Tests for the shared Things dataclass models."""
 
-from things_models.models import Area, Project, Todo
+from things_models.models import Area, AreaId, Project, ProjectId, Todo, TodoId
 
 
 def test_todo_to_json_round_trips_all_fields():
     todo = Todo(
-        id="abc",
+        id=TodoId("abc"),
         name="Buy milk",
         notes="2L",
         status="open",
         project_id=None,
         project_name=None,
-        area_id="area-1",
+        area_id=AreaId("area-1"),
         area_name="Personal",
         tag_names=["Errand", "P1"],
         due_date="2026-05-01",
@@ -35,7 +35,7 @@ def test_todo_to_json_round_trips_all_fields():
 
 def test_project_to_json_handles_missing_area():
     project = Project(
-        id="p1",
+        id=ProjectId("p1"),
         name="Q2 Planning",
         notes="",
         status="open",
@@ -55,5 +55,5 @@ def test_project_to_json_handles_missing_area():
 
 
 def test_area_to_json_minimal():
-    area = Area(id="a1", name="Personal", tag_names=["home"])
+    area = Area(id=AreaId("a1"), name="Personal", tag_names=["home"])
     assert area.to_json() == {"id": "a1", "name": "Personal", "tag_names": ["home"]}

--- a/tests/things_client_fake/store.py
+++ b/tests/things_client_fake/store.py
@@ -18,7 +18,7 @@ from typing import Any
 import yaml
 
 from things_models.errors import ThingsError, ThingsNotFoundError
-from things_models.models import Area, Project, Todo
+from things_models.models import Area, AreaId, Project, ProjectId, Todo, TodoId
 from things_models.status import VALID_STATUSES, validate_status
 
 _ALLOWED_TOP_LEVEL_KEYS = {"areas", "projects", "todos", "list_memberships"}
@@ -50,8 +50,8 @@ class FakeThingsClient:
         self,
         *,
         list_id: str | None = None,
-        project_id: str | None = None,
-        area_id: str | None = None,
+        project_id: ProjectId | None = None,
+        area_id: AreaId | None = None,
         tag: str | None = None,
         status: str | None = None,
     ) -> list[Todo]:
@@ -73,18 +73,18 @@ class FakeThingsClient:
 
         return results
 
-    def get_todo(self, todo_id: str) -> Todo:
+    def get_todo(self, todo_id: TodoId) -> Todo:
         for todo in self._store.todos:
             if todo.id == todo_id:
                 return todo
         raise ThingsNotFoundError(f"todo {todo_id!r} not found")
 
-    def list_projects(self, *, area_id: str | None = None) -> list[Project]:
+    def list_projects(self, *, area_id: AreaId | None = None) -> list[Project]:
         if area_id is None:
             return list(self._store.projects)
         return [p for p in self._store.projects if p.area_id == area_id]
 
-    def get_project(self, project_id: str) -> Project:
+    def get_project(self, project_id: ProjectId) -> Project:
         for project in self._store.projects:
             if project.id == project_id:
                 return project
@@ -93,7 +93,7 @@ class FakeThingsClient:
     def list_areas(self) -> list[Area]:
         return list(self._store.areas)
 
-    def get_area(self, area_id: str) -> Area:
+    def get_area(self, area_id: AreaId) -> Area:
         for area in self._store.areas:
             if area.id == area_id:
                 return area


### PR DESCRIPTION
## Summary

Introduce `TodoId`, `ProjectId`, and `AreaId` as `typing.NewType` aliases in `things_models/models.py` and thread them end-to-end so Things entity ids aren't interchangeable `str` at the type-checker boundary.

## Why

`.claude/instructions/coding-standards.md` § "Types and safety" mandates newtypes at semantic boundaries. Before this PR a todo id and a project id were indistinguishable to pyright/mypy — swapping them would be a silent bug.

Changes:
- dataclass fields on `Todo` / `Project` / `Area` use the new types
- `from_json` wraps ids as it decodes JSON
- `ThingsClient` Protocol, `ThingsSubprocessClient`, `ThingsBridgeClient`, and the things-cli `BridgeClient` signatures updated
- `ThingsBridgeServer` handlers wrap `_safe_id` results and `?project` / `?area` query params at the subprocess boundary
- `things_cli` command handlers wrap `args.id` at the argparse boundary
- `FakeThingsClient` and shared test factories wrap ids at construction
- `scripts/verify-standards.sh` asserts the three NewTypes remain defined

Tags are keyed by name throughout the codebase, so no `TagId` NewType is needed.

## Test plan

- [x] `task typecheck` — 139 files, 0 errors (pyright strict + mypy strict).
- [x] Full test suite (`pytest tests/`) — 509 passed, 67 skipped.
- [x] `bash scripts/verify-standards.sh` — passes and logs "models.py defines TodoId / ProjectId / AreaId via typing.NewType".
- [x] Lefthook pre-commit (ruff, treefmt, test-fast) — clean.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)