### PR TITLE
refactor(things-bridge): ThingsClientCommand newtype at config/subprocess boundary

### DIFF
--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -48,6 +48,10 @@
 #   2h. src/things_bridge/server.py defines a ``SafeId`` NewType that
 #      ``_safe_id`` returns, so validated ids carry a distinct type
 #      at the trust boundary (see issue #36).
+#   2i. src/things_bridge/types.py defines ``ThingsClientCommand`` as a
+#      typing.NewType plus a factory that enforces the non-empty /
+#      all-str invariant at the config / subprocess boundary (see
+#      issue #70).
 #   3. Bash gating (shellcheck, shfmt) is wired into CI, treefmt, and
 #      lefthook per .claude/instructions/bash.md.
 #   4. Markdown (mdformat) and TOML (taplo) formatters are wired into
@@ -461,6 +465,27 @@ if ! grep -qE "^SafeId[[:space:]]*=[[:space:]]*NewType\(" src/things_bridge/serv
 fi
 
 echo "verify-standards: src/things_bridge/server.py defines SafeId via typing.NewType."
+
+# ---------------------------------------------------------------------------
+# ThingsClientCommand NewType at the config / subprocess boundary.
+# ---------------------------------------------------------------------------
+# .claude/instructions/coding-standards.md § "Newtypes at security /
+# trust boundaries" and the PR #66 standards-review checkpoint both
+# committed to a ThingsClientCommand newtype wrapping the argv list.
+# See issue #70. The check asserts the NewType + its factory are still
+# defined; mypy/pyright catch misuse at call sites.
+if ! grep -qE "^ThingsClientCommand[[:space:]]*=[[:space:]]*NewType\(" src/things_bridge/types.py; then
+  echo "verify-standards: src/things_bridge/types.py does not define ThingsClientCommand via typing.NewType." >&2
+  echo "  See .claude/instructions/coding-standards.md § Types and safety and issue #70." >&2
+  exit 1
+fi
+if ! grep -qE "^def make_things_client_command\(" src/things_bridge/types.py; then
+  echo "verify-standards: src/things_bridge/types.py does not expose make_things_client_command()." >&2
+  echo "  The factory centralises the non-empty / all-str invariant; see issue #70." >&2
+  exit 1
+fi
+
+echo "verify-standards: src/things_bridge/types.py defines ThingsClientCommand + make_things_client_command."
 
 # ---------------------------------------------------------------------------
 # Numeric names carry their unit (AST audit).

--- a/src/things_bridge/config.py
+++ b/src/things_bridge/config.py
@@ -15,6 +15,8 @@ from typing import Any, cast
 
 import yaml
 
+from things_bridge.types import ThingsClientCommand, make_things_client_command
+
 
 def _xdg_dir(env_var: str, fallback_segments: tuple[str, ...]) -> str:
     base = os.environ.get(env_var) or os.path.join(os.path.expanduser("~"), *fallback_segments)
@@ -29,8 +31,8 @@ def _default_state_dir() -> str:
     return _xdg_dir("XDG_STATE_HOME", (".local", "state"))
 
 
-def _default_things_client_command() -> list[str]:
-    return ["things-client-cli-applescript"]
+def _default_things_client_command() -> ThingsClientCommand:
+    return make_things_client_command(["things-client-cli-applescript"])
 
 
 @dataclass
@@ -41,7 +43,9 @@ class Config:
     # Argv prefix for the Things client subprocess. The bridge appends the
     # request-specific sub-command (``todos list --status open``, etc.)
     # before invoking. Tests override this to point at the in-tree fake.
-    things_client_command: list[str] = field(default_factory=_default_things_client_command)
+    things_client_command: ThingsClientCommand = field(
+        default_factory=_default_things_client_command
+    )
     # Kept above the shipped CLI's own 30s osascript timeout so the child can
     # surface a structured timeout envelope before the bridge kills it.
     request_timeout_seconds: float = 35.0
@@ -98,4 +102,11 @@ def load_config() -> Config:
         raw = yaml.safe_load(f)
     data: dict[str, Any] = cast(dict[str, Any], raw) if isinstance(raw, dict) else {}
     kwargs = {k: v for k, v in data.items() if k in valid_fields}
+    # YAML loads ``things_client_command`` as ``list[str]``; validate and
+    # wrap at this one edge so downstream consumers receive the NewType
+    # and don't have to re-check the shape.
+    if "things_client_command" in kwargs:
+        kwargs["things_client_command"] = make_things_client_command(
+            kwargs["things_client_command"]
+        )
     return Config(**kwargs)

--- a/src/things_bridge/server.py
+++ b/src/things_bridge/server.py
@@ -37,6 +37,7 @@ from things_bridge.errors import (
     ThingsPermissionError,
 )
 from things_bridge.metrics import ThingsBridgeMetrics, build_registry
+from things_bridge.types import ThingsClientCommand
 from things_models.client import ThingsClient
 from things_models.models import AreaId, ProjectId, TodoId
 
@@ -88,12 +89,15 @@ class _HealthChecker:
 
     def __init__(
         self,
-        things_client_command: list[str],
+        things_client_command: ThingsClientCommand,
         *,
         cache_ttl_seconds: float = _HEALTH_THINGS_CLIENT_CACHE_TTL_SECONDS,
         clock: Callable[[], float] = time.monotonic,
         resolver: Callable[[str], str | None] = shutil.which,
     ):
+        # ThingsClientCommand NewType guarantees non-empty + all-str;
+        # the defensive check stays as a belt-and-braces guard against
+        # a raw list slipping past the type checker.
         if not things_client_command:
             raise ValueError("_HealthChecker: things_client_command must not be empty")
         self._executable = things_client_command[0]

--- a/src/things_bridge/things_client.py
+++ b/src/things_bridge/things_client.py
@@ -18,6 +18,7 @@ import sys
 import threading
 from typing import IO, Any, cast
 
+from things_bridge.types import ThingsClientCommand
 from things_models.errors import (
     ThingsError,
     ThingsNotFoundError,
@@ -38,19 +39,25 @@ writing a structured error.
 class ThingsSubprocessClient:
     """Invoke a configured Things client CLI as a subprocess per request.
 
-    ``command`` is the argv prefix (e.g. ``["things-client-cli-applescript"]``
-    or ``[sys.executable, "-m", "tests.things_client_fake", "--fixtures", P]``);
-    sub-commands matching the request are appended. ``timeout_seconds`` caps
-    the per-call wall clock. Subprocess stderr is forwarded to the bridge's
-    own stderr line-by-line as the child writes it, so a misbehaving client
-    cannot pin bridge memory by streaming multi-megabyte diagnostics. The
-    HTTP response body never contains subprocess output.
+    ``command`` is a validated argv prefix (e.g.
+    ``make_things_client_command(["things-client-cli-applescript"])`` or
+    ``make_things_client_command([sys.executable, "-m",
+    "tests.things_client_fake", "--fixtures", P])``); sub-commands
+    matching the request are appended. ``timeout_seconds`` caps the
+    per-call wall clock. Subprocess stderr is forwarded to the bridge's
+    own stderr line-by-line as the child writes it, so a misbehaving
+    client cannot pin bridge memory by streaming multi-megabyte
+    diagnostics. The HTTP response body never contains subprocess
+    output.
     """
 
-    def __init__(self, command: list[str], timeout_seconds: float = 35.0):
+    def __init__(self, command: ThingsClientCommand, timeout_seconds: float = 35.0):
+        # The NewType invariant guarantees non-empty + all-str; no
+        # re-validation needed here. Keep the defensive check cheap so
+        # a raw list slipping past the type checker still fails loud.
         if not command:
             raise ValueError("ThingsSubprocessClient: command must not be empty")
-        self._command = list(command)
+        self._command = command
         self._timeout_seconds = timeout_seconds
 
     def list_todos(

--- a/src/things_bridge/types.py
+++ b/src/things_bridge/types.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Types at the things-bridge config / subprocess boundary.
+
+``ThingsClientCommand`` is the argv prefix used to invoke the Things
+client CLI (default ``things-client-cli-applescript``). The NewType
+wrapper plus :func:`make_things_client_command` constructor centralise
+the "non-empty sequence of strings" invariant so every consumer
+(``Config``, ``ThingsSubprocessClient``, ``_HealthChecker``) can accept
+the validated value by type and doesn't have to re-check the shape.
+
+See ``.claude/instructions/coding-standards.md`` § *Newtypes at
+security/trust boundaries* and issue #70 (itself a follow-up on
+``plans/things-client-cli-split.md`` standards-review checkpoint).
+"""
+
+from collections.abc import Iterable
+from typing import NewType, cast
+
+ThingsClientCommand = NewType("ThingsClientCommand", tuple[str, ...])
+
+
+def make_things_client_command(argv: Iterable[object]) -> ThingsClientCommand:
+    """Validate ``argv`` and wrap it as a :data:`ThingsClientCommand`.
+
+    Accepts any iterable (YAML delivers ``list[Any]`` with no element-
+    type guarantee; callers inside the codebase pass properly-typed
+    sequences). Rejects empty sequences and non-string elements —
+    silently accepting either would turn into an obscure
+    ``FileNotFoundError`` later when ``ThingsSubprocessClient`` reaches
+    ``subprocess.Popen``. ``argv`` is declared ``Iterable[object]`` so
+    the ``isinstance`` narrowing is meaningful to the type checker.
+    """
+    argv_tuple = tuple(argv)
+    if not argv_tuple:
+        raise ValueError("ThingsClientCommand must be a non-empty sequence of strings")
+    for i, element in enumerate(argv_tuple):
+        if not isinstance(element, str):
+            raise TypeError(
+                f"ThingsClientCommand element {i} must be a str, got {type(element).__name__}"
+            )
+    # The isinstance loop above ensures every element is str; the cast
+    # narrows the tuple-of-object we built to a tuple-of-str for the
+    # NewType constructor.
+    return ThingsClientCommand(cast(tuple[str, ...], argv_tuple))
+
+
+__all__ = ["ThingsClientCommand", "make_things_client_command"]

--- a/tests/fault/test_things_applescript_failure.py
+++ b/tests/fault/test_things_applescript_failure.py
@@ -16,11 +16,14 @@ import pytest
 
 from things_bridge.errors import ThingsError
 from things_bridge.things_client import ThingsSubprocessClient
+from things_bridge.types import make_things_client_command
 
 
 def test_missing_binary_raises_things_error() -> None:
     """A non-existent client command surfaces as ThingsError, not FileNotFoundError."""
-    client = ThingsSubprocessClient(command=["/nonexistent/things-client"], timeout_seconds=1.0)
+    client = ThingsSubprocessClient(
+        command=make_things_client_command(["/nonexistent/things-client"]), timeout_seconds=1.0
+    )
     with pytest.raises(ThingsError, match="things client not found"):
         client.list_todos()
 
@@ -30,7 +33,9 @@ def test_subprocess_timeout_raises_things_error(tmp_path) -> None:
     script = tmp_path / "hang.sh"
     script.write_text("#!/usr/bin/env bash\nsleep 30\n")
     script.chmod(0o755)
-    client = ThingsSubprocessClient(command=[str(script)], timeout_seconds=0.3)
+    client = ThingsSubprocessClient(
+        command=make_things_client_command([str(script)]), timeout_seconds=0.3
+    )
     with pytest.raises(ThingsError, match="timed out"):
         client.list_todos()
 
@@ -40,7 +45,9 @@ def test_subprocess_nonzero_exit_without_payload_raises_things_error(tmp_path) -
     script = tmp_path / "fail.sh"
     script.write_text('#!/usr/bin/env bash\necho "boom" >&2\nexit 2\n')
     script.chmod(0o755)
-    client = ThingsSubprocessClient(command=[str(script)], timeout_seconds=2.0)
+    client = ThingsSubprocessClient(
+        command=make_things_client_command([str(script)]), timeout_seconds=2.0
+    )
     with pytest.raises(ThingsError, match="rc=2"):
         client.list_todos()
 
@@ -50,6 +57,8 @@ def test_subprocess_non_json_stdout_raises_things_error(tmp_path) -> None:
     script = tmp_path / "junk.sh"
     script.write_text('#!/usr/bin/env bash\necho "<html>not json</html>"\n')
     script.chmod(0o755)
-    client = ThingsSubprocessClient(command=[str(script)], timeout_seconds=2.0)
+    client = ThingsSubprocessClient(
+        command=make_things_client_command([str(script)]), timeout_seconds=2.0
+    )
     with pytest.raises(ThingsError, match="non-JSON"):
         client.list_todos()

--- a/tests/test_things_bridge_server.py
+++ b/tests/test_things_bridge_server.py
@@ -30,6 +30,7 @@ from things_bridge.errors import (
 )
 from things_bridge.metrics import build_registry as build_bridge_registry
 from things_bridge.server import ThingsBridgeServer, _HealthChecker
+from things_bridge.types import ThingsClientCommand, make_things_client_command
 from things_models.models import Area, AreaId
 
 
@@ -220,7 +221,9 @@ def _stop_bridge(handle: dict[str, Any]) -> None:
 @pytest.mark.covers_function("Serve Bridge Health Endpoint")
 def test_health_returns_503_when_things_client_unresolvable():
     resolver = _ResolverStub(resolves=False)
-    checker = _HealthChecker(["things-client-cli-applescript"], resolver=resolver)
+    checker = _HealthChecker(
+        make_things_client_command(["things-client-cli-applescript"]), resolver=resolver
+    )
     handle = _bridge_with_health_checker(checker)
     try:
         status, data = _get(f"{handle['url']}/things-bridge/health")
@@ -234,7 +237,9 @@ def test_health_returns_503_when_things_client_unresolvable():
 @pytest.mark.covers_function("Serve Bridge Health Endpoint")
 def test_health_returns_200_when_things_client_resolvable():
     resolver = _ResolverStub(resolves=True)
-    checker = _HealthChecker(["things-client-cli-applescript"], resolver=resolver)
+    checker = _HealthChecker(
+        make_things_client_command(["things-client-cli-applescript"]), resolver=resolver
+    )
     handle = _bridge_with_health_checker(checker)
     try:
         status, data = _get(f"{handle['url']}/things-bridge/health")
@@ -252,7 +257,7 @@ def test_health_checker_caches_resolution_within_ttl():
     now = [100.0]
     resolver = _ResolverStub(resolves=True)
     checker = _HealthChecker(
-        ["things-client-cli-applescript"],
+        make_things_client_command(["things-client-cli-applescript"]),
         cache_ttl_seconds=30.0,
         clock=lambda: now[0],
         resolver=resolver,
@@ -271,7 +276,7 @@ def test_health_checker_requeries_after_ttl_expires():
     now = [100.0]
     resolver = _ResolverStub(resolves=True)
     checker = _HealthChecker(
-        ["things-client-cli-applescript"],
+        make_things_client_command(["things-client-cli-applescript"]),
         cache_ttl_seconds=30.0,
         clock=lambda: now[0],
         resolver=resolver,
@@ -286,8 +291,10 @@ def test_health_checker_requeries_after_ttl_expires():
 def test_health_checker_rejects_empty_command():
     # Defensive: an empty ``things_client_command`` is a config bug.
     # Fail loud at construction rather than silently reporting healthy.
+    # The NewType permits an empty tuple cast; _HealthChecker still
+    # rejects it at runtime as a belt-and-braces guard.
     with pytest.raises(ValueError):
-        _HealthChecker([])
+        _HealthChecker(ThingsClientCommand(()))
 
 
 # -- /metrics ---------------------------------------------------------------

--- a/tests/test_things_subprocess_client.py
+++ b/tests/test_things_subprocess_client.py
@@ -20,6 +20,7 @@ from typing import Any
 import pytest
 
 from things_bridge.things_client import STDERR_TAIL_MAX_CHARS, ThingsSubprocessClient
+from things_bridge.types import ThingsClientCommand, make_things_client_command
 from things_models.errors import (
     ThingsError,
     ThingsNotFoundError,
@@ -67,7 +68,9 @@ class _FakePopen:
 
 @pytest.fixture
 def client() -> ThingsSubprocessClient:
-    return ThingsSubprocessClient(command=["fake-client"], timeout_seconds=1.0)
+    return ThingsSubprocessClient(
+        command=make_things_client_command(["fake-client"]), timeout_seconds=1.0
+    )
 
 
 def _patch_popen(monkeypatch, **fake_kwargs) -> list[list[str]]:
@@ -84,8 +87,22 @@ def _patch_popen(monkeypatch, **fake_kwargs) -> list[list[str]]:
 
 @pytest.mark.covers_function("Fetch Things Data")
 def test_empty_command_rejected():
+    # An empty tuple can still be cast to the NewType — the defensive
+    # check inside ThingsSubprocessClient catches that belt-and-braces.
     with pytest.raises(ValueError):
-        ThingsSubprocessClient(command=[], timeout_seconds=1.0)
+        ThingsSubprocessClient(command=ThingsClientCommand(()), timeout_seconds=1.0)
+
+
+@pytest.mark.covers_function("Fetch Things Data")
+def test_make_things_client_command_rejects_empty():
+    with pytest.raises(ValueError):
+        make_things_client_command([])
+
+
+@pytest.mark.covers_function("Fetch Things Data")
+def test_make_things_client_command_rejects_non_string_element():
+    with pytest.raises(TypeError):
+        make_things_client_command(["things-client-cli-applescript", 42])
 
 
 @pytest.mark.covers_function("Fetch Things Data")


### PR DESCRIPTION
## Summary

- Add `src/things_bridge/types.py` with `ThingsClientCommand = NewType("ThingsClientCommand", tuple[str, ...])` + `make_things_client_command()` factory that enforces the "non-empty, all-str" invariant once.
- `Config.things_client_command` is typed `ThingsClientCommand`; `load_config()` wraps the YAML-loaded value at the one edge that parses untrusted input.
- `ThingsSubprocessClient.__init__` and `_HealthChecker.__init__` accept `ThingsClientCommand` instead of `list[str]`. The defensive runtime empty-check stays as belt-and-braces for a raw list that slips past the type checker.
- Tests that constructed commands inline now go through the factory; new coverage pins the factory rejects empty and non-string input.
- `scripts/verify-standards.sh` asserts the NewType + factory remain defined in `src/things_bridge/types.py`.

## Why

`plans/things-client-cli-split.md` (PR #66) committed to this refactor in its post-implementation standards-review section; the implementation shipped with raw `list[str]` throughout. The newtype gives the bridge a single place to enforce the invariant and makes the config / subprocess boundary explicit at the type-checker level.

## Test plan

- [x] `task typecheck` — 0 errors (140 files).
- [x] `pytest tests/` — 511 passed, 67 skipped.
- [x] `bash scripts/verify-standards.sh` — passes; logs "defines ThingsClientCommand + make_things_client_command".
- [x] Lefthook pre-commit (ruff, treefmt, test-fast) — clean.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)