### PR TITLE
refactor(things-applescript): switch row parser zips to strict=True

### DIFF
--- a/src/things_client_applescript/things.py
+++ b/src/things_client_applescript/things.py
@@ -503,7 +503,12 @@ def _parse_rows(output: str, expected_cols: int) -> list[list[str]]:
 
 
 def _row_to_todo(row: list[str]) -> Todo:
-    cols = dict(zip(_TODO_FIELDS, row, strict=False))
+    # strict=True enforces the column-count invariant at the helper
+    # boundary as a belt-and-braces complement to ``_parse_rows``'s
+    # length check. A future direct caller that skips _parse_rows gets
+    # a hard ValueError instead of a silent dict-key lookup failure on
+    # the first missing column. See issue #76.
+    cols = dict(zip(_TODO_FIELDS, row, strict=True))
     project_id_raw = _field(cols["project_id"])
     area_id_raw = _field(cols["area_id"])
     return Todo(
@@ -526,7 +531,9 @@ def _row_to_todo(row: list[str]) -> Todo:
 
 
 def _row_to_project(row: list[str]) -> Project:
-    cols = dict(zip(_PROJECT_FIELDS, row, strict=False))
+    # See _row_to_todo: strict=True guards against a direct caller
+    # bypassing _parse_rows.
+    cols = dict(zip(_PROJECT_FIELDS, row, strict=True))
     area_id_raw = _field(cols["area_id"])
     return Project(
         id=ProjectId(_field(cols["id"]) or ""),
@@ -546,7 +553,9 @@ def _row_to_project(row: list[str]) -> Project:
 
 
 def _row_to_area(row: list[str]) -> Area:
-    cols = dict(zip(_AREA_FIELDS, row, strict=False))
+    # See _row_to_todo: strict=True guards against a direct caller
+    # bypassing _parse_rows.
+    cols = dict(zip(_AREA_FIELDS, row, strict=True))
     return Area(
         id=AreaId(_field(cols["id"]) or ""),
         name=_field(cols["name"]) or "",

--- a/tests/test_things_client_applescript_things.py
+++ b/tests/test_things_client_applescript_things.py
@@ -28,6 +28,9 @@ from things_client_applescript.things import (
     TAB_PLACEHOLDER,
     AppleScriptRunner,
     ThingsApplescriptClient,
+    _row_to_area,
+    _row_to_project,
+    _row_to_todo,
 )
 from things_models.errors import ThingsError, ThingsNotFoundError
 
@@ -391,6 +394,44 @@ def test_malformed_row_raises_things_error():
     client = ThingsApplescriptClient(runner)
     with pytest.raises(ThingsError):
         client.list_todos()
+
+
+# The zip(strict=True) in each _row_to_* helper guards against a future
+# direct caller that skips _parse_rows: without it, a mismatched row
+# would silently truncate to the shorter sequence and then explode on
+# the first missing cols[...] lookup. Exercise both the too-short and
+# too-long cases per helper so a regression to strict=False is
+# immediately visible.
+
+
+def test_row_to_todo_rejects_too_few_cols():
+    with pytest.raises(ValueError):
+        _row_to_todo(["t1"] + [""] * (len(_TODO_FIELDS) - 2))
+
+
+def test_row_to_todo_rejects_too_many_cols():
+    with pytest.raises(ValueError):
+        _row_to_todo(["t1"] + [""] * len(_TODO_FIELDS))
+
+
+def test_row_to_project_rejects_too_few_cols():
+    with pytest.raises(ValueError):
+        _row_to_project(["p1"] + [""] * (len(_PROJECT_FIELDS) - 2))
+
+
+def test_row_to_project_rejects_too_many_cols():
+    with pytest.raises(ValueError):
+        _row_to_project(["p1"] + [""] * len(_PROJECT_FIELDS))
+
+
+def test_row_to_area_rejects_too_few_cols():
+    with pytest.raises(ValueError):
+        _row_to_area(["a1"] + [""] * (len(_AREA_FIELDS) - 2))
+
+
+def test_row_to_area_rejects_too_many_cols():
+    with pytest.raises(ValueError):
+        _row_to_area(["a1"] + [""] * len(_AREA_FIELDS))
 
 
 # -- AppleScript injection guards --


### PR DESCRIPTION
## Summary

- Switch `zip(..., strict=False)` to `strict=True` in the three row-parser helpers in `src/things_client_applescript/things.py` (`_row_to_todo`, `_row_to_project`, `_row_to_area`). Belt-and-braces guard against a future direct caller that skips `_parse_rows`.
- Keep the existing length check in `_parse_rows` — it's the primary guard and produces a clean `ThingsError` for the common (malformed AppleScript output) case. `strict=True` in the helpers fires only if that primary guard is ever bypassed.
- Add six dedicated tests: too-few-cols + too-many-cols per helper. The existing `test_malformed_row_raises_things_error` already covers the `_parse_rows` boundary.

## Why

PR #74 (ruff adoption) added `strict=False` to silence `B905` while explicitly deferring the behavioural question to this issue. `strict=True` makes the column-count invariant explicit at the helper boundary and catches any future direct caller that forgets `_parse_rows`.

## Test plan

- [x] `task typecheck` — 0 errors.
- [x] `pytest tests/` — 517 passed (6 new), 67 skipped.
- [x] `bash scripts/verify-standards.sh` — passes.
- [x] Lefthook pre-commit (ruff, treefmt, test-fast) — clean.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)