### PR TITLE
ci(security): add Dependency Review Action as PR gate

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# PR-time dependency CVE gate. Uses the Dependency Graph diff between
+# base and head to reject PRs that introduce direct or transitive deps
+# carrying known HIGH or CRITICAL advisories (GHSA, same feed Dependabot
+# ingests).
+#
+# Together with Dependabot alerts (continuous, post-merge backstop) and
+# the Dependency Submission workflow that keeps CI-tool PURLs flowing
+# into the Dependency Graph (#205 / PR #251), this replaces the
+# PR-gating role pip-audit plays today. Removal of pip-audit is tracked
+# in #264; it stays in place until this gate is proven operational
+# (Dependency Graph enabled, this check added to required status
+# checks, Dependabot alerts firing).
+#
+# Requires Dependency Graph to be enabled on the repository
+# (Settings → Code security and analysis → Dependency graph). Without
+# it, the action fails closed on the Dep Graph diff call, same 404
+# surface the Dependency Submission workflow hits today.
+
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  # Read-only access to the Dependency Graph diff — this is the scanner input.
+  contents: read
+  # Required by comment-summary-in-pr so the action can post the inline
+  # findings summary on the PR conversation.
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Review PR dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          # HIGH/CRITICAL is the industry-standard gating bar and matches
+          # what Dependabot alerts prioritise for notification. Dropping to
+          # moderate produces a false-positive treadmill on transitive
+          # deps for a solo-maintained project — can be revisited if the
+          # noise/value trade flips.
+          fail-on-severity: high
+          # Post a human-readable summary on the PR so the action's
+          # findings are visible without clicking through to the check
+          # details page.
+          comment-summary-in-pr: always


### PR DESCRIPTION
## Summary

- New `.github/workflows/dependency-review.yml` runs `actions/dependency-review-action@v4` on PRs targeting `main`.
- Gates at `fail-on-severity: high` — blocks merges that introduce direct or transitive deps with known HIGH or CRITICAL CVEs (GHSA via the Dependency Graph diff, same feed Dependabot alerts use).
- Posts inline summary comment on the PR for visibility.
- Complements the Dependency Submission workflow from #205 (post-merge PURL snapshot → Dependabot alerts tab) and the planned pip-audit retirement in #264.

Closes nothing directly — this is the precondition for #264 (pip-audit removal) and the outcome of the #88 consolidation discussion.

## Prerequisites for this gate to actually block merges

- [x] **Dependency Graph** enabled in repo settings (Settings → Code security and analysis → Dependency graph). Without it, Dep Review and the existing Dependency Submission workflow both fail with a 404 — Dependency Submission has been 404'ing since #205 merged for exactly this reason.
- [x] **Dependabot alerts** enabled (same settings page) so the continuous backstop signal is live.
- [ ] **Add `review` check to required status checks** on the main ruleset. The status check name shows up as `Dependency Review / review` (workflow name + job name) after the first run of this workflow. Without this, the gate is advisory — a red check won't block merge.

Once all three are green, #264 (pip-audit removal) can proceed.

## Test plan

- [x] `task check` — lint/format/integration-isolation green.
- [x] Workflow syntax is valid YAML; CodeQL / `analyze (actions)` check on this PR will validate the GHA schema.
- [ ] On this PR's own CI run: confirm the `review` job appears and the summary comment posts. First-run behaviour before Dependency Graph is enabled: the action will fail (404 on Dep Graph endpoint). That failure is the expected signal that the repo toggle hasn't happened yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)