### PR TITLE
docs: retire stale root src/ references after workspace split

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Every repeatable operation is exposed through the task runner. Run
 | `task benchmark`                           | Run the pytest-benchmark suite under `benchmarks/` (scheduled weekly in CI; see `benchmarks/README.md`).                                                  |
 | `task lint`                                | Run all configured linters (shellcheck, ruff check, keep-sorted).                                                                                         |
 | `task format`                              | Run all configured formatters (shfmt, ruff format, mdformat, taplo). Pass `-- --check` for diff-only mode (CI uses this).                                 |
-| `task typecheck`                           | Run mypy + pyright (strict) on `src/` and `tests/`.                                                                                                       |
+| `task typecheck`                           | Run mypy + pyright (strict) on every `packages/<svc>/src/` tree and `tests/`.                                                                             |
 | `task build`                               | Build sdist and wheel distributions into `dist/`.                                                                                                         |
 | `task install-hooks`                       | Install project git hooks (lefthook).                                                                                                                     |
 | `task verify-design`                       | Verify every leaf function in the functional decomposition is allocated in the product breakdown.                                                         |
@@ -114,7 +114,7 @@ floor ratchets upward per
 - **`--fast` and `--integration` modes** run without coverage collection
   (`--no-cov`). The floor is measured against `--unit` only —
   integration tests exercise Docker-backed service interactions that
-  don't map cleanly onto `src/` line coverage.
+  don't map cleanly onto `packages/*/src/` line coverage.
 
 ### Mutation score
 
@@ -152,13 +152,13 @@ gate every PR. Rationale and baseline-refresh procedure in
 ### Schema migrations
 
 The token store's SQLite schema is managed by a hand-rolled
-numbered-SQL runner in `src/agent_auth/migrations/`. Alembic /
+numbered-SQL runner in `packages/agent-auth/src/agent_auth/migrations/`. Alembic /
 yoyo would be disproportionate for a single-family schema and
 would add a runtime dependency the project intentionally keeps
 out (CLAUDE.md § Conventions). Rules:
 
 - **Never modify an applied migration in place.** Each entry in
-  `src/agent_auth/migrations/_catalogue.py::CATALOGUE` is a
+  `packages/agent-auth/src/agent_auth/migrations/_catalogue.py::CATALOGUE` is a
   pinned version. Changes land as a new `Migration(version=N+1, …)`
   tuple.
 - **Every migration must be reversible.** Both `up_sql` and a
@@ -167,7 +167,7 @@ out (CLAUDE.md § Conventions). Rules:
   `down_sql` blocks the whole roll-back path.
 - **No `CREATE TABLE` / `ALTER TABLE` in application code.**
   Schema DDL lives exclusively in `_catalogue.py`;
-  `scripts/verify-standards.sh` greps `src/agent_auth/store.py`
+  `scripts/verify-standards.sh` greps `packages/agent-auth/src/agent_auth/store.py`
   to enforce this.
 - **Test up-then-down.** `tests/test_migrations.py` asserts that
   every declared migration can be applied and rolled back cleanly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -194,20 +194,20 @@ standard. The five control families below are in scope because each maps to a
 specific component of the current implementation:
 
 - **AC — Access Control**: the three-tier scope model (`allow`/`prompt`/`deny`)
-  and the per-family scope set enforced in `src/agent_auth/scopes.py` and the
+  and the per-family scope set enforced in `packages/agent-auth/src/agent_auth/scopes.py` and the
   [Check Scope Authorization](design/functional_decomposition.yaml#L28) and
   [Resolve Access Tier](design/functional_decomposition.yaml#L30) leaf
   functions.
 - **AU — Audit and Accountability**: the append-only audit log in
-  `src/agent_auth/audit.py`, fed by every token lifecycle event and
+  `packages/agent-auth/src/agent_auth/audit.py`, fed by every token lifecycle event and
   authorization decision.
 - **IA — Identification and Authentication**: HMAC-SHA256 signed tokens with
-  per-family revocation (`src/agent_auth/tokens.py`) and the agent-auth
+  per-family revocation (`packages/agent-auth/src/agent_auth/tokens.py`) and the agent-auth
   server as the sole validation authority
-  (`src/agent_auth/server.py` — the `/validate` endpoint).
+  (`packages/agent-auth/src/agent_auth/server.py` — the `/validate` endpoint).
 - **SC — System and Communications Protection**: AES-256-GCM field encryption
-  (`src/agent_auth/crypto.py`) and the signing/encryption keys held in the
-  system keyring (`src/agent_auth/keys.py`). Transport protection: both HTTP
+  (`packages/agent-auth/src/agent_auth/crypto.py`) and the signing/encryption keys held in the
+  system keyring (`packages/agent-auth/src/agent_auth/keys.py`). Transport protection: both HTTP
   servers bind `127.0.0.1` by default (loopback-only satisfies SC-8 on a
   single host) and accept an optional TLS listener via
   `tls_cert_path` / `tls_key_path` when the trust boundary extends beyond
@@ -215,7 +215,7 @@ specific component of the current implementation:
   [ADR 0025](design/decisions/0025-tls-for-devcontainer-host-traffic.md).
 - **SI — System and Information Integrity**: request-body size caps and
   schema-validated parameters before subprocess argv construction
-  (`src/things_bridge/server.py`).
+  (`packages/things-bridge/src/things_bridge/server.py`).
 
 Controls outside these families are out of scope for the current codebase; the
 product is a local, single-user authorization system and does not cover

--- a/examples/fake-things.yaml
+++ b/examples/fake-things.yaml
@@ -6,7 +6,7 @@
 #
 # Used to stand up the full agent-auth + things-bridge + things-cli stack in
 # a Linux devcontainer without osascript or a real Things 3 installation.
-# The schema is documented in src/things_bridge/fake.py::load_fake_store.
+# The schema is documented in tests/things_client_fake/store.py::load_fake_store.
 
 areas:
   - id: a1

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -6,10 +6,10 @@
 
 # Run the pytest-benchmark suite under benchmarks/ inside the project
 # virtualenv. Override the pyproject.toml addopts (which wire
-# --cov=src --cov-fail-under=74 for the test suite) so coverage does
-# not run against the benchmark tree — benchmarks measure performance
-# and exercise only a thin slice of src/, so the unit-test coverage
-# floor would always fail.
+# --cov=packages --cov-fail-under=74 for the test suite) so coverage
+# does not run against the benchmark tree — benchmarks measure
+# performance and exercise only a thin slice of packages/*/src/, so
+# the unit-test coverage floor would always fail.
 #
 # Arguments after the script name are forwarded to pytest, e.g.
 #   scripts/benchmark.sh --benchmark-save=ci-linux-x86_64

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -91,17 +91,18 @@ case "${mode}" in
     ;;
   fast)
     # Disable coverage collection: --fast runs a curated smoke subset
-    # that only exercises ~6% of src/, so the --cov-fail-under=74 floor
-    # configured in pyproject.toml would always fail. The floor is
-    # measured against --unit (the authoritative gate).
+    # that only exercises ~6% of packages/*/src/, so the
+    # --cov-fail-under=74 floor configured in pyproject.toml would
+    # always fail. The floor is measured against --unit (the
+    # authoritative gate).
     exec uv run --no-sync pytest --no-cov "${FAST_TESTS[@]}" "$@"
     ;;
   integration)
     # Same rationale as --fast: integration tests exercise a different
-    # surface than src/ (Docker lifecycle, cross-service contracts),
-    # so the unit-based floor doesn't apply. Integration coverage is
-    # tracked separately; see plans/pytest-cov-threshold.md "Out of
-    # scope".
+    # surface than packages/*/src/ (Docker lifecycle, cross-service
+    # contracts), so the unit-based floor doesn't apply. Integration
+    # coverage is tracked separately; see
+    # plans/pytest-cov-threshold.md "Out of scope".
     integration_path="tests/integration/"
     if [[ -n "${service}" ]]; then
       integration_path="${SERVICE_PATHS[${service}]}"

--- a/scripts/typecheck.sh
+++ b/scripts/typecheck.sh
@@ -4,9 +4,9 @@
 #
 # SPDX-License-Identifier: MIT
 
-# Run the Python type checkers (mypy + pyright) against src/ and tests/.
-# Both ship as dev dependencies and are invoked through uv so the
-# project venv is used.
+# Run the Python type checkers (mypy + pyright) against every
+# packages/<svc>/src/ tree and tests/. Both ship as dev dependencies
+# and are invoked through uv so the project venv is used.
 
 set -euo pipefail
 

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -42,9 +42,9 @@
 #      via typing.NewType so Things entity ids aren't interchangeable
 #      strings at the type checker's boundary (see issue #34).
 #   2g. Numeric parameters, dataclass fields, and module constants
-#      under src/ carry a unit suffix (_seconds, _bytes, _count, ...)
-#      per .claude/instructions/coding-standards.md § Units in names
-#      (AST audit; see issue #35).
+#      under packages/*/src/ carry a unit suffix (_seconds, _bytes,
+#      _count, ...) per .claude/instructions/coding-standards.md §
+#      Units in names (AST audit; see issue #35).
 #   2h. packages/things-bridge/src/things_bridge/server.py defines a ``SafeId`` NewType that
 #      ``_safe_id`` returns, so validated ids carry a distinct type
 #      at the trust boundary (see issue #36).
@@ -493,7 +493,7 @@ echo "verify-standards: packages/things-bridge/src/things_bridge/types.py define
 # .claude/instructions/coding-standards.md § "Units in names" requires
 # numeric parameters, dataclass fields, and module constants to encode
 # their unit in the name (`timeout_seconds`, `buffer_size_bytes`,
-# `max_retries_count`). Enforced via AST walk over src/; the allow-list
+# `max_retries_count`). Enforced via AST walk over packages/*/src/; the allow-list
 # below covers stdlib-override conventions (HTTP status/code, signal
 # handler signum, Prometheus amount/value, etc.) that cannot or should
 # not be renamed. See issue #35.
@@ -1170,25 +1170,18 @@ for override in pyproject.get("tool", {}).get("mypy", {}).get("overrides", []):
 
 def module_to_path(mod: str) -> str:
     path = mod.replace(".", "/")
-    # ``packages/*/src/<mod>`` covers the per-subproject workspace
-    # layout from #105; the pre-split ``src/<mod>`` path is kept as a
-    # fallback so historical pyrightconfig.json entries still resolve
-    # during the migration.
+    # ``packages/*/src/<mod>`` is the per-subproject workspace layout
+    # from #105. Fall through to a bare module path so pyright-style
+    # entries that aren't rooted in ``packages/*/src`` still resolve.
     candidates: list[str] = []
     for pkg_src in sorted(pathlib.Path("packages").glob("*/src")):
         candidates.append(f"{pkg_src}/{path}.py")
         candidates.append(f"{pkg_src}/{path}")
-    candidates.extend(
-        [
-            f"src/{path}.py",
-            f"src/{path}",
-            f"{path}",
-        ]
-    )
+    candidates.append(f"{path}")
     for c in candidates:
         if pathlib.Path(c).exists():
             return c
-    return f"src/{path}"
+    return path
 
 
 expected_pyright_ignore = {module_to_path(m) for m in mypy_ignore_modules}


### PR DESCRIPTION
## Summary

- Retire references to the pre-split root `src/` tree (deleted in #257) across `CONTRIBUTING.md`, `SECURITY.md`, helper script comments, and the `verify-standards.sh` `module_to_path` fallback.
- Point schema-migration, audit, mutation, and security-control callouts at their new `packages/agent-auth/src/agent_auth/…` and `packages/things-bridge/src/things_bridge/…` paths.
- Update the `examples/fake-things.yaml` schema pointer to the real source of `load_fake_store` (`tests/things_client_fake/store.py`).

The root `src/` tree is already gone from version control — every file under it was `__pycache__/` or `*.egg-info/`, which `.gitignore` has covered for a while. No files are deleted in this PR; it's purely documentation and a cleanup of the one-line fallback in the standards script.

Closes #266

## Test plan

- [x] `task verify-standards`
- [x] `task typecheck`
- [x] `task test` (unit, 590 passed, coverage 75.12%)
- [x] `git grep -nE '(^|[^/a-zA-Z])src/'` shows no stale root-tree references remaining in top-level docs or scripts