### PR TITLE
feat(things-bridge): restrict subprocess env to minimal allowlist

### DIFF
--- a/design/decisions/0003-things-client-cli-split.md
+++ b/design/decisions/0003-things-client-cli-split.md
@@ -168,9 +168,18 @@ only disambiguates success from failure when the envelope is absent.
 - **New subprocess trust relationship.** The bridge now trusts the
   stdout of a process it spawned from a command line it controls. The
   `things_client_command` is validated at config load time and cannot
-  be set from HTTP. The subprocess inherits the bridge's environment
-  but runs as the same local user, so no privilege boundary is
-  crossed.
+  be set from HTTP. The subprocess runs as the same local user, so no
+  privilege boundary is crossed.
+- **Subprocess environment is allowlisted.** The client CLI is spawned
+  with an explicit `env=` built from `SUBPROCESS_ENV_EXACT_ALLOWLIST`
+  (`PATH`, `HOME`, `LANG`, `TZ`) and `SUBPROCESS_ENV_PREFIX_ALLOWLIST`
+  (`LC_*`, `THINGS_CLIENT_*`). Secrets the operator has in the bridge
+  env — agent-auth bearer tokens, unrelated API keys, future
+  signing-key env fallbacks — therefore never reach the child. The
+  allowlist is tested in `test_things_subprocess_client.py`; extending
+  it (e.g. `TMPDIR`, `__CFPREFERENCES_*`) requires evidence that an
+  osascript execution path actually needs the variable, not
+  speculative inclusion. Tracked in #68.
 - **Information disclosure.** Subprocess stderr continues to be
   scrubbed from HTTP response bodies and only forwarded to the
   bridge's own stderr for operator diagnostics. The bridge never

--- a/packages/things-bridge/src/things_bridge/things_client.py
+++ b/packages/things-bridge/src/things_bridge/things_client.py
@@ -13,9 +13,11 @@ subprocess protocol.
 
 import contextlib
 import json
+import os
 import subprocess
 import sys
 import threading
+from collections.abc import Mapping
 from typing import IO, Any, cast
 
 from things_bridge.types import ThingsClientCommand
@@ -34,6 +36,56 @@ buffered indefinitely in memory. The tail only exists so the timeout
 diagnostic can include a last-gasp excerpt when the child hung before
 writing a structured error.
 """
+
+SUBPROCESS_ENV_EXACT_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "LANG",
+        "TZ",
+    }
+)
+"""Environment variable names passed through to the client subprocess verbatim.
+
+The bridge process may hold secrets in its environment — agent-auth
+bearer tokens the operator sets via ``AGENT_AUTH_*``, future signing-key
+env fallbacks, unrelated API keys a shell happened to export. The
+client CLI runs as the same local user, so no privilege boundary is
+crossed by the spawn, but a buggy or rogue client binary inherits read
+access to any env var it was handed. Starting from an empty env and
+adding only what the shipped client documents it reads prevents that
+quiet disclosure. Anything outside this set plus the prefix allowlist
+is dropped.
+"""
+
+SUBPROCESS_ENV_PREFIX_ALLOWLIST: tuple[str, ...] = (
+    "LC_",
+    "THINGS_CLIENT_",
+)
+"""Prefix families forwarded to the client subprocess.
+
+``LC_*`` covers every locale category (``LC_ALL``, ``LC_CTYPE``, …) in
+one rule so a user with a non-default locale doesn't see surprise
+mojibake in the child's output. ``THINGS_CLIENT_*`` is the documented
+knob surface of ``things-client-cli-applescript`` (e.g.
+``THINGS_CLIENT_OSASCRIPT_PATH``, ``THINGS_CLIENT_TIMEOUT_SECONDS``) —
+stripping these would silently break operator overrides.
+"""
+
+
+def build_subprocess_env(parent_env: Mapping[str, str]) -> dict[str, str]:
+    """Return the env dict the client subprocess should see.
+
+    Callers pass the parent environment (typically ``os.environ``); the
+    returned dict is a fresh copy containing only allowlisted names.
+    """
+    env: dict[str, str] = {}
+    for name, value in parent_env.items():
+        if name in SUBPROCESS_ENV_EXACT_ALLOWLIST or name.startswith(
+            SUBPROCESS_ENV_PREFIX_ALLOWLIST
+        ):
+            env[name] = value
+    return env
 
 
 class ThingsSubprocessClient:
@@ -114,6 +166,7 @@ class ThingsSubprocessClient:
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                env=build_subprocess_env(os.environ),
                 text=True,
                 bufsize=1,
             )
@@ -252,4 +305,9 @@ def _error_from_payload(payload: dict[str, Any]) -> ThingsError:
     return ThingsError(message)
 
 
-__all__ = ["ThingsSubprocessClient"]
+__all__ = [
+    "SUBPROCESS_ENV_EXACT_ALLOWLIST",
+    "SUBPROCESS_ENV_PREFIX_ALLOWLIST",
+    "ThingsSubprocessClient",
+    "build_subprocess_env",
+]

--- a/tests/test_things_subprocess_client.py
+++ b/tests/test_things_subprocess_client.py
@@ -19,7 +19,13 @@ from typing import Any
 
 import pytest
 
-from things_bridge.things_client import STDERR_TAIL_MAX_CHARS, ThingsSubprocessClient
+from things_bridge.things_client import (
+    STDERR_TAIL_MAX_CHARS,
+    SUBPROCESS_ENV_EXACT_ALLOWLIST,
+    SUBPROCESS_ENV_PREFIX_ALLOWLIST,
+    ThingsSubprocessClient,
+    build_subprocess_env,
+)
 from things_bridge.types import ThingsClientCommand, make_things_client_command
 from things_models.errors import (
     ThingsError,
@@ -79,6 +85,18 @@ def _patch_popen(monkeypatch, **fake_kwargs) -> list[list[str]]:
 
     def _popen(argv, **kwargs):
         recorded.append(argv)
+        return _FakePopen(argv, **fake_kwargs)
+
+    monkeypatch.setattr(subprocess, "Popen", _popen)
+    return recorded
+
+
+def _patch_popen_capture_kwargs(monkeypatch, **fake_kwargs) -> list[dict[str, Any]]:
+    """Record each ``subprocess.Popen`` kwargs dict and return a ``_FakePopen``."""
+    recorded: list[dict[str, Any]] = []
+
+    def _popen(argv, **kwargs):
+        recorded.append(kwargs)
         return _FakePopen(argv, **fake_kwargs)
 
     monkeypatch.setattr(subprocess, "Popen", _popen)
@@ -346,3 +364,98 @@ def test_timeout_diagnostic_tail_is_bounded(monkeypatch, capfd, client):
     # split on ": " after the numeric timeout to isolate the excerpt.
     excerpt = diagnostic.rsplit(": ", 1)[-1]
     assert len(excerpt) <= STDERR_TAIL_MAX_CHARS
+
+
+@pytest.mark.covers_function("Fetch Things Data")
+def test_build_subprocess_env_keeps_only_allowlisted_names():
+    parent = {
+        "PATH": "/usr/bin:/bin",
+        "HOME": "/Users/operator",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US.UTF-8",
+        "LC_CTYPE": "en_US.UTF-8",
+        "TZ": "UTC",
+        "THINGS_CLIENT_OSASCRIPT_PATH": "/usr/bin/osascript",
+        "THINGS_CLIENT_TIMEOUT_SECONDS": "30",
+        "AGENT_AUTH_BEARER": "super-secret",
+        "OPENAI_API_KEY": "sk-secret",
+        "AWS_SESSION_TOKEN": "shhh",
+        "SHELL": "/bin/bash",
+    }
+    env = build_subprocess_env(parent)
+    assert env == {
+        "PATH": "/usr/bin:/bin",
+        "HOME": "/Users/operator",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US.UTF-8",
+        "LC_CTYPE": "en_US.UTF-8",
+        "TZ": "UTC",
+        "THINGS_CLIENT_OSASCRIPT_PATH": "/usr/bin/osascript",
+        "THINGS_CLIENT_TIMEOUT_SECONDS": "30",
+    }
+
+
+def test_build_subprocess_env_drops_prefix_lookalikes():
+    # Names that merely contain an allowlisted substring (``SHELL`` has
+    # ``ELL``; ``ALC_FOO`` has ``LC_`` but not as a prefix) must not
+    # sneak through. The allowlist is strictly prefix- or exact-match.
+    parent = {
+        "PATHOLOGICAL": "not /usr/bin",
+        "MY_LANG_PREF": "nope",
+        "ALC_FOO": "nope",
+        "MY_THINGS_CLIENT_VAR": "nope",
+        "TZDATA": "nope",
+    }
+    assert build_subprocess_env(parent) == {}
+
+
+def test_build_subprocess_env_returns_fresh_dict():
+    # Caller must be able to mutate the returned dict without reaching
+    # back into ``os.environ`` or the caller's map.
+    parent = {"PATH": "/usr/bin"}
+    env = build_subprocess_env(parent)
+    env["EXTRA"] = "x"
+    assert parent == {"PATH": "/usr/bin"}
+
+
+def test_allowlist_constants_are_non_overlapping():
+    # Regression guard: any prefix family that was also listed as an
+    # exact name would be redundant and hint at drift between the two
+    # constants.
+    for prefix in SUBPROCESS_ENV_PREFIX_ALLOWLIST:
+        for name in SUBPROCESS_ENV_EXACT_ALLOWLIST:
+            assert not name.startswith(
+                prefix
+            ), f"exact-match {name!r} is already covered by prefix {prefix!r}"
+
+
+@pytest.mark.covers_function("Fetch Things Data")
+def test_subprocess_receives_restricted_env(monkeypatch, client):
+    # The bridge env may hold unrelated secrets (agent-auth bearer,
+    # third-party API keys, future signing-key env fallbacks). A buggy
+    # or rogue client binary must not inherit them. Set a sentinel on
+    # the parent environment, invoke the client, and assert the env
+    # handed to ``subprocess.Popen`` does not contain it.
+    monkeypatch.setenv("AGENT_AUTH_BRIDGE_SECRET_SENTINEL", "do-not-leak")
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    recorded = _patch_popen_capture_kwargs(monkeypatch, stdout='{"todos": []}')
+    client.list_todos()
+    assert len(recorded) == 1
+    env = recorded[0].get("env")
+    assert env is not None, "subprocess must be spawned with an explicit env="
+    assert "AGENT_AUTH_BRIDGE_SECRET_SENTINEL" not in env
+    assert env.get("PATH") == "/usr/bin:/bin"
+
+
+def test_subprocess_env_forwards_things_client_knobs(monkeypatch, client):
+    # Operators override the shipped CLI's behaviour via the documented
+    # ``THINGS_CLIENT_*`` env knobs. Stripping them would silently break
+    # operator config; keep them in the allowlist and the passthrough
+    # tested.
+    monkeypatch.setenv("THINGS_CLIENT_OSASCRIPT_PATH", "/opt/osascript")
+    monkeypatch.setenv("THINGS_CLIENT_TIMEOUT_SECONDS", "45")
+    recorded = _patch_popen_capture_kwargs(monkeypatch, stdout='{"todos": []}')
+    client.list_todos()
+    env = recorded[0]["env"]
+    assert env["THINGS_CLIENT_OSASCRIPT_PATH"] == "/opt/osascript"
+    assert env["THINGS_CLIENT_TIMEOUT_SECONDS"] == "45"


### PR DESCRIPTION
## Summary

- Spawn the Things client CLI with an explicit `env=` built from an allowlist (`PATH`, `HOME`, `LANG`, `TZ`, `LC_*`, `THINGS_CLIENT_*`) rather than inheriting the bridge's full environment. Bridge-held secrets (agent-auth bearer tokens, unrelated API keys, future signing-key env fallbacks) no longer leak to the child.
- Update ADR 0003's Security section: drop the "subprocess inherits the bridge's environment" caveat and document the new allowlist plus the evidence-before-extension stance for additions like `TMPDIR` or `__CFPREFERENCES_*` on macOS.
- Add unit tests: a sentinel env var on the parent is asserted absent from `subprocess.Popen`'s `env=`; `build_subprocess_env` is covered directly for the allowlist semantics and for name-lookalikes that must not sneak through.

## Test plan

- [x] `uv run pytest tests/` — 625 passed, 67 skipped
- [x] `task check` (lint/format/integration isolation)
- [x] `task typecheck` (pyright, 180 files, 0 errors)
- [x] `task verify-standards`
- [x] `task verify-function-tests` (60/60)
- [ ] **macOS smoke test (not done in this PR):** run `things-bridge` + `things-client-cli-applescript` against a live Things 3 and confirm `/things-bridge/todos` still answers, no new osascript permission prompts or automation breakage. If an osascript path turns out to need an extra var (`TMPDIR`, `__CFPREFERENCES_*`, etc.), extend the allowlist with evidence from that run.

## Notes on scope decisions

- **External comment on the issue:** issue #68 has a comment from a non-collaborator suggesting an expanded allowlist (`USER`, `LOGNAME`, `TMPDIR`, `SHELL`, argued against dropping `__CFPREFERENCES_*`). I did **not** fold that in: it's from a user with no association to the project and folding third-party guidance into a security-relevant allowlist without evidence would invert the threat model. The issue body's allowlist is the baseline; extensions wait on evidence from the macOS smoke test.
- **Smoke test deferred, not dropped.** The acceptance item stays unchecked above; run it before closing #68 and extend the allowlist if you see breakage.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)