### PR TITLE
feat(taskfile): per-package namespaces via Taskfile includes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,16 @@ Each task dispatches to a script under `scripts/*.sh`; the scripts are
 the single source of truth and can also be invoked directly if
 `go-task` is not installed.
 
+Per-package dev loops are also available under each service's
+namespace: `task <svc>:test`, `task <svc>:lint`, `task <svc>:typecheck`,
+`task <svc>:format`, and `task <svc>:check` narrow to a single
+workspace member under `packages/<svc>/`. `task <svc>` (no suffix)
+resolves to the namespace default and still runs the service CLI where
+one exists (e.g. `task agent-auth -- serve`). Namespaces are declared
+in the workspace-root `Taskfile.yml`; the root-level sweepers above
+stay authoritative until #270 relocates the monolithic `tests/` and
+`benchmarks/` trees into per-package subdirectories.
+
 ### Coverage
 
 `task test` (unit mode, the default) collects line and branch coverage

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,8 +3,37 @@
 # SPDX-License-Identifier: MIT
 
 # Run `task --list` to see every repeatable operation. See CONTRIBUTING.md.
+#
+# Structure: each packages/<svc>/Taskfile.yml is included as a
+# namespace below so per-service dev loops are runnable directly
+# (e.g. `task agent-auth:test`, `task things-bridge:lint`). The
+# namespace `default` task in each included file preserves the
+# service's existing CLI entry: `task agent-auth -- serve` still
+# resolves to scripts/agent-auth.sh via the agent-auth namespace
+# default. Root-level tasks below are the workspace-wide gates —
+# `test`, `lint`, `typecheck`, `format`, `check` keep calling the
+# scripts/*.sh sweepers because those also cover repo-root files
+# (scripts/, tests/, benchmarks/, top-level *.md/*.toml) that no
+# per-package namespace owns. They will convert to fan-outs over the
+# namespaces once #270 relocates tests and benchmarks into per-package
+# trees.
 
 version: "3"
+
+includes:
+  # Namespace name matches the service's existing `task <svc>` entry
+  # (so `task things-client-applescript` and `task gpg-backend-host`
+  # keep working against the longer package directory names).
+  # keep-sorted start
+  agent-auth-common: ./packages/agent-auth-common/Taskfile.yml
+  agent-auth: ./packages/agent-auth/Taskfile.yml
+  gpg-backend-host: ./packages/gpg-backend-cli-host/Taskfile.yml
+  gpg-bridge: ./packages/gpg-bridge/Taskfile.yml
+  gpg-cli: ./packages/gpg-cli/Taskfile.yml
+  things-bridge: ./packages/things-bridge/Taskfile.yml
+  things-cli: ./packages/things-cli/Taskfile.yml
+  things-client-applescript: ./packages/things-client-cli-applescript/Taskfile.yml
+  # keep-sorted end
 
 tasks:
   test:
@@ -100,38 +129,3 @@ tasks:
     desc: "Cut a release. With no args (task release), the next version is derived from conventional commits since the last v* tag (major/minor/patch from BREAKING/feat/fix). Pass an explicit version (task release -- 1.2.3) to override. The resolved version must match a ## [X.Y.Z] section in CHANGELOG.md. The script creates and pushes the tag vX.Y.Z and publishes the GitHub release."
     cmds:
       - scripts/release.sh {{.CLI_ARGS}}
-
-  agent-auth:
-    desc: Run the agent-auth CLI (e.g. `task agent-auth -- serve`).
-    cmds:
-      - scripts/agent-auth.sh {{.CLI_ARGS}}
-
-  things-bridge:
-    desc: Run the things-bridge CLI (e.g. `task things-bridge -- serve`).
-    cmds:
-      - scripts/things-bridge.sh {{.CLI_ARGS}}
-
-  things-cli:
-    desc: Run the things-cli client (e.g. `task things-cli -- todos list`).
-    cmds:
-      - scripts/things-cli.sh {{.CLI_ARGS}}
-
-  things-client-applescript:
-    desc: Run the things-client-cli-applescript CLI (macOS-only; e.g. `task things-client-applescript -- todos list`).
-    cmds:
-      - scripts/things-client-applescript.sh {{.CLI_ARGS}}
-
-  gpg-bridge:
-    desc: Run the gpg-bridge CLI (e.g. `task gpg-bridge -- serve`).
-    cmds:
-      - scripts/gpg-bridge.sh {{.CLI_ARGS}}
-
-  gpg-cli:
-    desc: Run the devcontainer gpg-cli (e.g. `task gpg-cli -- --version`).
-    cmds:
-      - scripts/gpg-cli.sh {{.CLI_ARGS}}
-
-  gpg-backend-host:
-    desc: Run the host gpg backend CLI directly (e.g. `task gpg-backend-host -- sign --local-user ...`).
-    cmds:
-      - scripts/gpg-backend-host.sh {{.CLI_ARGS}}

--- a/packages/agent-auth-common/Taskfile.yml
+++ b/packages/agent-auth-common/Taskfile.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Per-package tasks for packages/agent-auth-common. Included as the
+# `agent-auth-common` namespace from the workspace-root Taskfile.yml.
+# agent-auth-common is a library (no CLI entry point), so there is no
+# `default` run task — dev-loop operations only.
+
+version: "3"
+
+tasks:
+  test:
+    desc: Run the agent-auth-common package's pytest suite in isolation.
+    cmds:
+      - scripts/pkg-test.sh agent-auth-common {{.CLI_ARGS}}
+
+  lint:
+    desc: Lint shell and Python files under packages/agent-auth-common/.
+    cmds:
+      - scripts/pkg-lint.sh agent-auth-common
+
+  typecheck:
+    desc: Run mypy + pyright against packages/agent-auth-common/src.
+    cmds:
+      - scripts/pkg-typecheck.sh agent-auth-common
+
+  format:
+    desc: Format files under packages/agent-auth-common/. Pass `-- --check` for diff-only mode.
+    cmds:
+      - scripts/pkg-format.sh agent-auth-common {{.CLI_ARGS}}
+
+  check:
+    desc: Lint and assert formatting for packages/agent-auth-common/.
+    cmds:
+      - scripts/pkg-lint.sh agent-auth-common
+      - scripts/pkg-format.sh agent-auth-common --check

--- a/packages/agent-auth/Taskfile.yml
+++ b/packages/agent-auth/Taskfile.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Per-package tasks for packages/agent-auth. Included as the
+# `agent-auth` namespace from the workspace-root Taskfile.yml, so the
+# service's existing `task agent-auth -- …` CLI entry remains valid
+# (it resolves to the `default` task below) and each dev-loop
+# operation is also available under the namespace (`task
+# agent-auth:test`, `:lint`, `:typecheck`, `:format`, `:check`).
+
+version: "3"
+
+tasks:
+  default:
+    desc: Run the agent-auth CLI (e.g. `task agent-auth -- serve`).
+    cmds:
+      - scripts/agent-auth.sh {{.CLI_ARGS}}
+
+  test:
+    desc: Run the agent-auth package's pytest suite in isolation.
+    cmds:
+      - scripts/pkg-test.sh agent-auth {{.CLI_ARGS}}
+
+  lint:
+    desc: Lint shell and Python files under packages/agent-auth/.
+    cmds:
+      - scripts/pkg-lint.sh agent-auth
+
+  typecheck:
+    desc: Run mypy + pyright against packages/agent-auth/src.
+    cmds:
+      - scripts/pkg-typecheck.sh agent-auth
+
+  format:
+    desc: Format files under packages/agent-auth/. Pass `-- --check` for diff-only mode.
+    cmds:
+      - scripts/pkg-format.sh agent-auth {{.CLI_ARGS}}
+
+  check:
+    desc: Lint and assert formatting for packages/agent-auth/.
+    cmds:
+      - scripts/pkg-lint.sh agent-auth
+      - scripts/pkg-format.sh agent-auth --check

--- a/packages/gpg-backend-cli-host/Taskfile.yml
+++ b/packages/gpg-backend-cli-host/Taskfile.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Per-package tasks for packages/gpg-backend-cli-host. Included as the
+# `gpg-backend-host` namespace from the workspace-root Taskfile.yml —
+# the namespace preserves the existing `task gpg-backend-host -- …`
+# CLI entry (it resolves to the `default` task below), while
+# dev-loop operations are available under that same namespace
+# (`task gpg-backend-host:test`, `:lint`, `:typecheck`, `:format`,
+# `:check`).
+
+version: "3"
+
+tasks:
+  default:
+    desc: Run the host gpg backend CLI directly (e.g. `task gpg-backend-host -- sign --local-user ...`).
+    cmds:
+      - scripts/gpg-backend-host.sh {{.CLI_ARGS}}
+
+  test:
+    desc: Run the gpg-backend-cli-host package's pytest suite in isolation.
+    cmds:
+      - scripts/pkg-test.sh gpg-backend-cli-host {{.CLI_ARGS}}
+
+  lint:
+    desc: Lint shell and Python files under packages/gpg-backend-cli-host/.
+    cmds:
+      - scripts/pkg-lint.sh gpg-backend-cli-host
+
+  typecheck:
+    desc: Run mypy + pyright against packages/gpg-backend-cli-host/src.
+    cmds:
+      - scripts/pkg-typecheck.sh gpg-backend-cli-host
+
+  format:
+    desc: Format files under packages/gpg-backend-cli-host/. Pass `-- --check` for diff-only mode.
+    cmds:
+      - scripts/pkg-format.sh gpg-backend-cli-host {{.CLI_ARGS}}
+
+  check:
+    desc: Lint and assert formatting for packages/gpg-backend-cli-host/.
+    cmds:
+      - scripts/pkg-lint.sh gpg-backend-cli-host
+      - scripts/pkg-format.sh gpg-backend-cli-host --check

--- a/packages/gpg-bridge/Taskfile.yml
+++ b/packages/gpg-bridge/Taskfile.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Per-package tasks for packages/gpg-bridge. Included as the
+# `gpg-bridge` namespace from the workspace-root Taskfile.yml, so the
+# service's existing `task gpg-bridge -- …` CLI entry remains valid
+# (it resolves to the `default` task below) and dev-loop operations
+# are available under the namespace (`task gpg-bridge:test`, `:lint`,
+# `:typecheck`, `:format`, `:check`).
+
+version: "3"
+
+tasks:
+  default:
+    desc: Run the gpg-bridge CLI (e.g. `task gpg-bridge -- serve`).
+    cmds:
+      - scripts/gpg-bridge.sh {{.CLI_ARGS}}
+
+  test:
+    desc: Run the gpg-bridge package's pytest suite in isolation.
+    cmds:
+      - scripts/pkg-test.sh gpg-bridge {{.CLI_ARGS}}
+
+  lint:
+    desc: Lint shell and Python files under packages/gpg-bridge/.
+    cmds:
+      - scripts/pkg-lint.sh gpg-bridge
+
+  typecheck:
+    desc: Run mypy + pyright against packages/gpg-bridge/src.
+    cmds:
+      - scripts/pkg-typecheck.sh gpg-bridge
+
+  format:
+    desc: Format files under packages/gpg-bridge/. Pass `-- --check` for diff-only mode.
+    cmds:
+      - scripts/pkg-format.sh gpg-bridge {{.CLI_ARGS}}
+
+  check:
+    desc: Lint and assert formatting for packages/gpg-bridge/.
+    cmds:
+      - scripts/pkg-lint.sh gpg-bridge
+      - scripts/pkg-format.sh gpg-bridge --check

--- a/packages/gpg-cli/Taskfile.yml
+++ b/packages/gpg-cli/Taskfile.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Per-package tasks for packages/gpg-cli. Included as the `gpg-cli`
+# namespace from the workspace-root Taskfile.yml, so the service's
+# existing `task gpg-cli -- …` CLI entry remains valid (it resolves
+# to the `default` task below) and dev-loop operations are available
+# under the namespace (`task gpg-cli:test`, `:lint`, `:typecheck`,
+# `:format`, `:check`).
+
+version: "3"
+
+tasks:
+  default:
+    desc: Run the devcontainer gpg-cli (e.g. `task gpg-cli -- --version`).
+    cmds:
+      - scripts/gpg-cli.sh {{.CLI_ARGS}}
+
+  test:
+    desc: Run the gpg-cli package's pytest suite in isolation.
+    cmds:
+      - scripts/pkg-test.sh gpg-cli {{.CLI_ARGS}}
+
+  lint:
+    desc: Lint shell and Python files under packages/gpg-cli/.
+    cmds:
+      - scripts/pkg-lint.sh gpg-cli
+
+  typecheck:
+    desc: Run mypy + pyright against packages/gpg-cli/src.
+    cmds:
+      - scripts/pkg-typecheck.sh gpg-cli
+
+  format:
+    desc: Format files under packages/gpg-cli/. Pass `-- --check` for diff-only mode.
+    cmds:
+      - scripts/pkg-format.sh gpg-cli {{.CLI_ARGS}}
+
+  check:
+    desc: Lint and assert formatting for packages/gpg-cli/.
+    cmds:
+      - scripts/pkg-lint.sh gpg-cli
+      - scripts/pkg-format.sh gpg-cli --check

--- a/packages/things-bridge/Taskfile.yml
+++ b/packages/things-bridge/Taskfile.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Per-package tasks for packages/things-bridge. Included as the
+# `things-bridge` namespace from the workspace-root Taskfile.yml, so
+# the service's existing `task things-bridge -- …` CLI entry remains
+# valid (it resolves to the `default` task below) and dev-loop
+# operations are available under the namespace
+# (`task things-bridge:test`, `:lint`, `:typecheck`, `:format`,
+# `:check`).
+
+version: "3"
+
+tasks:
+  default:
+    desc: Run the things-bridge CLI (e.g. `task things-bridge -- serve`).
+    cmds:
+      - scripts/things-bridge.sh {{.CLI_ARGS}}
+
+  test:
+    desc: Run the things-bridge package's pytest suite in isolation.
+    cmds:
+      - scripts/pkg-test.sh things-bridge {{.CLI_ARGS}}
+
+  lint:
+    desc: Lint shell and Python files under packages/things-bridge/.
+    cmds:
+      - scripts/pkg-lint.sh things-bridge
+
+  typecheck:
+    desc: Run mypy + pyright against packages/things-bridge/src.
+    cmds:
+      - scripts/pkg-typecheck.sh things-bridge
+
+  format:
+    desc: Format files under packages/things-bridge/. Pass `-- --check` for diff-only mode.
+    cmds:
+      - scripts/pkg-format.sh things-bridge {{.CLI_ARGS}}
+
+  check:
+    desc: Lint and assert formatting for packages/things-bridge/.
+    cmds:
+      - scripts/pkg-lint.sh things-bridge
+      - scripts/pkg-format.sh things-bridge --check

--- a/packages/things-cli/Taskfile.yml
+++ b/packages/things-cli/Taskfile.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Per-package tasks for packages/things-cli. Included as the
+# `things-cli` namespace from the workspace-root Taskfile.yml, so the
+# service's existing `task things-cli -- …` CLI entry remains valid
+# (it resolves to the `default` task below) and dev-loop operations
+# are available under the namespace (`task things-cli:test`,
+# `:lint`, `:typecheck`, `:format`, `:check`).
+
+version: "3"
+
+tasks:
+  default:
+    desc: Run the things-cli client (e.g. `task things-cli -- todos list`).
+    cmds:
+      - scripts/things-cli.sh {{.CLI_ARGS}}
+
+  test:
+    desc: Run the things-cli package's pytest suite in isolation.
+    cmds:
+      - scripts/pkg-test.sh things-cli {{.CLI_ARGS}}
+
+  lint:
+    desc: Lint shell and Python files under packages/things-cli/.
+    cmds:
+      - scripts/pkg-lint.sh things-cli
+
+  typecheck:
+    desc: Run mypy + pyright against packages/things-cli/src.
+    cmds:
+      - scripts/pkg-typecheck.sh things-cli
+
+  format:
+    desc: Format files under packages/things-cli/. Pass `-- --check` for diff-only mode.
+    cmds:
+      - scripts/pkg-format.sh things-cli {{.CLI_ARGS}}
+
+  check:
+    desc: Lint and assert formatting for packages/things-cli/.
+    cmds:
+      - scripts/pkg-lint.sh things-cli
+      - scripts/pkg-format.sh things-cli --check

--- a/packages/things-client-cli-applescript/Taskfile.yml
+++ b/packages/things-client-cli-applescript/Taskfile.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Per-package tasks for packages/things-client-cli-applescript.
+# Included as the `things-client-applescript` namespace from the
+# workspace-root Taskfile.yml — the namespace preserves the existing
+# `task things-client-applescript -- …` CLI entry (it resolves to the
+# `default` task below), while dev-loop operations are available
+# under that same namespace (`task things-client-applescript:test`,
+# `:lint`, `:typecheck`, `:format`, `:check`).
+
+version: "3"
+
+tasks:
+  default:
+    desc: Run the things-client-cli-applescript CLI (macOS-only; e.g. `task things-client-applescript -- todos list`).
+    cmds:
+      - scripts/things-client-applescript.sh {{.CLI_ARGS}}
+
+  test:
+    desc: Run the things-client-cli-applescript package's pytest suite in isolation.
+    cmds:
+      - scripts/pkg-test.sh things-client-cli-applescript {{.CLI_ARGS}}
+
+  lint:
+    desc: Lint shell and Python files under packages/things-client-cli-applescript/.
+    cmds:
+      - scripts/pkg-lint.sh things-client-cli-applescript
+
+  typecheck:
+    desc: Run mypy + pyright against packages/things-client-cli-applescript/src.
+    cmds:
+      - scripts/pkg-typecheck.sh things-client-cli-applescript
+
+  format:
+    desc: Format files under packages/things-client-cli-applescript/. Pass `-- --check` for diff-only mode.
+    cmds:
+      - scripts/pkg-format.sh things-client-cli-applescript {{.CLI_ARGS}}
+
+  check:
+    desc: Lint and assert formatting for packages/things-client-cli-applescript/.
+    cmds:
+      - scripts/pkg-lint.sh things-client-cli-applescript
+      - scripts/pkg-format.sh things-client-cli-applescript --check

--- a/scripts/pkg-format.sh
+++ b/scripts/pkg-format.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Format a single workspace package's tracked files (*.sh, *.py, *.md,
+# *.toml) using the same toolchain as scripts/format.sh (shfmt, ruff
+# format, mdformat, taplo). Invoked from per-package Taskfiles via
+# `task <svc>:format`. Pass `-- --check` to run in diff-only mode.
+#
+# scripts/format.sh still owns the workspace-wide sweep (it also
+# covers repo-root files like CHANGELOG.md and uv.lock-adjacent
+# configuration). This helper is the per-service iteration path.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: scripts/pkg-format.sh <svc> [--check]" >&2
+  exit 2
+fi
+
+svc="$1"
+shift
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+pkg_dir="packages/${svc}"
+if [[ ! -d "${pkg_dir}" ]]; then
+  echo "pkg-format: unknown workspace package '${svc}' (no ${pkg_dir}/)" >&2
+  exit 2
+fi
+
+mode="write"
+for arg in "$@"; do
+  case "${arg}" in
+    --check) mode="check" ;;
+    *)
+      echo "pkg-format: unknown argument '${arg}'" >&2
+      echo "usage: scripts/pkg-format.sh <svc> [--check]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_tool() {
+  local tool="$1"
+  local install_hint="$2"
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "pkg-format: '${tool}' is not on PATH." >&2
+    echo "${install_hint}" >&2
+    exit 1
+  fi
+}
+
+require_tool shfmt \
+  "Install from https://github.com/mvdan/sh/releases or 'brew install shfmt' (macOS), then re-run."
+require_tool ruff \
+  "Install via 'uv tool install ruff' or from https://github.com/astral-sh/ruff/releases, then re-run."
+require_tool mdformat \
+  "Install via 'uv tool install mdformat --with mdformat-gfm --with mdformat-tables', then re-run."
+require_tool taplo \
+  "Install from https://github.com/tamasfe/taplo/releases or 'brew install taplo' (macOS), then re-run."
+
+list_tracked() {
+  local pattern="$1"
+  git ls-files "${pattern}"
+}
+
+shell_files_raw="$(list_tracked "${pkg_dir}/*.sh")"
+python_files_raw="$(list_tracked "${pkg_dir}/*.py")"
+markdown_files_raw="$(list_tracked "${pkg_dir}/*.md")"
+toml_files_raw="$(list_tracked "${pkg_dir}/*.toml")"
+
+format_group() {
+  local label="$1"
+  local files_raw="$2"
+  shift 2
+  if [[ -z "${files_raw}" ]]; then
+    echo "pkg-format: no ${label} files tracked under ${pkg_dir}; skipping."
+    return 0
+  fi
+  local files
+  mapfile -t files <<<"${files_raw}"
+  "$@" "${files[@]}"
+}
+
+if [[ "${mode}" == "check" ]]; then
+  format_group "*.sh" "${shell_files_raw}" shfmt -d
+  format_group "*.py" "${python_files_raw}" ruff format --check
+  format_group "*.md" "${markdown_files_raw}" mdformat --check
+  format_group "*.toml" "${toml_files_raw}" taplo format --check
+else
+  format_group "*.sh" "${shell_files_raw}" shfmt -w
+  format_group "*.py" "${python_files_raw}" ruff format
+  format_group "*.md" "${markdown_files_raw}" mdformat
+  format_group "*.toml" "${toml_files_raw}" taplo format
+fi

--- a/scripts/pkg-lint.sh
+++ b/scripts/pkg-lint.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Lint a single workspace package's *.py and *.sh files via ruff-check
+# and shellcheck-exec. Invoked from per-package Taskfiles via
+# ``task <svc>:lint``. The authoritative sweep lives in
+# scripts/lint.sh (which also runs keep-sorted over every tracked
+# file); this helper narrows ruff and shellcheck to the package
+# directory so a service can be iterated on without waiting for the
+# full sweep.
+#
+# Shell comment pitfall: placing ``shellcheck`` at the start of a
+# comment line triggers SC1073 because shellcheck itself scans for
+# ``# shellcheck <directive>`` markers. The wrapping above is
+# intentional — do not put ``shellcheck`` flush at the line start.
+#
+# keep-sorted deliberately stays workspace-only: its annotated blocks
+# cross-cut the tree (e.g. CHANGELOG, lockfiles, workflow matrices)
+# and partitioning them by package would produce misleading results.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: scripts/pkg-lint.sh <svc>" >&2
+  exit 2
+fi
+
+svc="$1"
+shift
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+pkg_dir="packages/${svc}"
+if [[ ! -d "${pkg_dir}" ]]; then
+  echo "pkg-lint: unknown workspace package '${svc}' (no ${pkg_dir}/)" >&2
+  exit 2
+fi
+
+require_tool() {
+  local tool="$1"
+  local install_hint="$2"
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "pkg-lint: '${tool}' is not on PATH." >&2
+    echo "${install_hint}" >&2
+    exit 1
+  fi
+}
+
+require_tool shellcheck \
+  "Install via 'apt-get install shellcheck' (Linux) or 'brew install shellcheck' (macOS), then re-run."
+require_tool ruff \
+  "Install via 'uv tool install ruff' or from https://github.com/astral-sh/ruff/releases, then re-run."
+
+# Same pattern as scripts/lint.sh: capture into a variable so `set -e`
+# catches a git failure (mapfile always succeeds and would otherwise
+# silently pass the gate outside a valid checkout).
+shell_files_raw="$(git ls-files "${pkg_dir}/*.sh")"
+python_files_raw="$(git ls-files "${pkg_dir}/*.py")"
+
+if [[ -n "${shell_files_raw}" ]]; then
+  mapfile -t shell_files <<<"${shell_files_raw}"
+  shellcheck "${shell_files[@]}"
+else
+  echo "pkg-lint: no *.sh files tracked under ${pkg_dir}; skipping shellcheck."
+fi
+
+if [[ -n "${python_files_raw}" ]]; then
+  mapfile -t python_files <<<"${python_files_raw}"
+  ruff check "${python_files[@]}"
+else
+  echo "pkg-lint: no *.py files tracked under ${pkg_dir}; skipping ruff check."
+fi

--- a/scripts/pkg-test.sh
+++ b/scripts/pkg-test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Run a single workspace package's pytest suite (packages/<svc>/tests/).
+# Invoked from per-package Taskfiles via `task <svc>:test`. The
+# workspace-wide suite is driven by scripts/test.sh — this helper
+# stays package-scoped so each service can be iterated on in
+# isolation. Extra arguments are forwarded to pytest.
+#
+# Coverage is disabled here: the workspace-level --cov-fail-under
+# floor only makes sense over the full suite (see
+# pyproject.toml [tool.pytest.ini_options]). Per-package floors are
+# tracked separately in #273.
+#
+# Until #270 relocates the monolithic tests/ tree into per-package
+# trees, packages/<svc>/tests/ does not yet exist. Rather than making
+# `task <svc>:test` fail on every package, we report the missing
+# directory and exit 0; once #270 lands each package will grow its
+# own tree and the helper becomes authoritative.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: scripts/pkg-test.sh <svc> [pytest-args...]" >&2
+  exit 2
+fi
+
+svc="$1"
+shift
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_bootstrap_venv.sh
+source "${SCRIPT_DIR}/_bootstrap_venv.sh"
+
+pkg_dir="packages/${svc}"
+if [[ ! -d "${pkg_dir}" ]]; then
+  echo "pkg-test: unknown workspace package '${svc}' (no ${pkg_dir}/)" >&2
+  exit 2
+fi
+
+tests_dir="${pkg_dir}/tests"
+if [[ ! -d "${tests_dir}" ]]; then
+  echo "pkg-test: ${tests_dir}/ does not exist; tests have not been relocated yet (tracked in #270)." >&2
+  echo "pkg-test: skipping. Run scripts/test.sh to exercise the monolithic suite." >&2
+  exit 0
+fi
+
+exec uv run --no-sync pytest "${tests_dir}" --no-cov "$@"

--- a/scripts/pkg-typecheck.sh
+++ b/scripts/pkg-typecheck.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Type-check a single workspace package's src/ tree with mypy and
+# pyright. Invoked from per-package Taskfiles via
+# `task <svc>:typecheck`. scripts/typecheck.sh runs the workspace
+# matrix (every packages/*/src + tests/ + benchmarks/) and remains
+# the authoritative CI gate; this helper narrows to one package for
+# per-service iteration speed.
+#
+# The mypy / pyright configurations in pyproject.toml and
+# pyrightconfig.json set the cross-workspace `mypy_path` / pyright
+# `extraPaths` so resolution of `agent-auth-common` imports works
+# even when we only feed one package's src tree on the CLI.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: scripts/pkg-typecheck.sh <svc>" >&2
+  exit 2
+fi
+
+svc="$1"
+shift
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_bootstrap_venv.sh
+source "${SCRIPT_DIR}/_bootstrap_venv.sh"
+
+pkg_dir="packages/${svc}"
+if [[ ! -d "${pkg_dir}" ]]; then
+  echo "pkg-typecheck: unknown workspace package '${svc}' (no ${pkg_dir}/)" >&2
+  exit 2
+fi
+
+src_dir="${pkg_dir}/src"
+if [[ ! -d "${src_dir}" ]]; then
+  echo "pkg-typecheck: ${src_dir}/ does not exist; nothing to check." >&2
+  exit 0
+fi
+
+uv run --no-sync mypy "${src_dir}"
+exec uv run --no-sync pyright "${src_dir}"


### PR DESCRIPTION
## Summary

- Each `packages/<svc>/Taskfile.yml` exposes `test`, `lint`, `typecheck`, `format`, `check`, and a `default` task for the service's run CLI where applicable.
- Workspace-root `Taskfile.yml` wires them up via `includes:` so `task agent-auth:test`, `task things-bridge:lint`, etc. narrow to one package, while `task agent-auth -- serve` still resolves via the namespace default alias.
- Shared helpers in `scripts/pkg-{test,lint,typecheck,format}.sh` take a package name so the per-package Taskfiles stay small and uniform.
- Root sweepers (`task test`, `task lint`, ...) keep calling `scripts/*.sh` — they also cover repo-root trees (scripts/, tests/, benchmarks/) that no per-package namespace owns. Converts to fan-out once #270 relocates the monolithic test tree.
- `task <svc>:test` gracefully skips when `packages/<svc>/tests/` does not yet exist, so the per-package structure lands without waiting on #270.

## Test plan

- [x] `task --list-all` shows root tasks + per-package namespaced tasks with `agent-auth:default (aliases: agent-auth)` etc.
- [x] `task agent-auth -- --help` still prints the CLI help (namespace default preserves UX).
- [x] `task agent-auth:lint`, `:typecheck`, `:check`, `:format -- --check` pass for every package.
- [x] `task agent-auth:test` reports "skipping" rather than failing because `packages/agent-auth/tests/` does not exist yet.
- [x] `scripts/lint.sh`, `scripts/format.sh --check`, `scripts/typecheck.sh`, `scripts/verify-standards.sh`, `scripts/reuse-lint.sh` all pass.
- [x] `scripts/test.sh --fast` still runs the curated smoke subset.

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)