### PR TITLE
feat(ci): verify workspace dep graph against an explicit allowlist

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,11 +57,17 @@ tasks:
       - scripts/format.sh {{.CLI_ARGS}}
 
   check:
-    desc: Run all linters, assert formatting, and verify integration-test isolation.
+    desc: Run all linters, assert formatting, and verify integration-test isolation + workspace dep graph.
     cmds:
       - scripts/lint.sh
       - scripts/format.sh --check
       - scripts/verify-integration-isolation.sh
+      - scripts/verify_workspace_deps.py
+
+  verify-workspace-deps:
+    desc: Verify the workspace dep graph (packages/*/pyproject.toml) matches ADR 0036's allowlist.
+    cmds:
+      - scripts/verify_workspace_deps.py
 
   typecheck:
     desc: Run mypy + pyright on every packages/<svc>/src tree and tests/.

--- a/design/decisions/0036-workspace-dep-graph-allowlist.md
+++ b/design/decisions/0036-workspace-dep-graph-allowlist.md
@@ -1,0 +1,138 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# ADR 0036 — Workspace dep graph is an explicit allowlist verified in CI
+
+## Status
+
+Accepted — 2026-04-24.
+
+## Context
+
+ADR 0032 (#257) split the repository into a uv workspace of per-service
+packages under `packages/*/`. The workspace currently has eight
+members: `agent-auth-common` (shared library), `agent-auth`,
+`gpg-backend-cli-host`, `gpg-bridge`, `gpg-cli`, `things-bridge`,
+`things-cli`, and `things-client-cli-applescript`. Each service
+package is meant to lean on `agent-auth-common` for typed HTTP clients
+and shared models — nothing else.
+
+Eight packages is enough that cross-package edges are easy to
+introduce unintentionally. Three shapes of unintended edge would each
+be a regression rather than a refactor:
+
+- **Reverse deps into the library.** `agent-auth-common` picking up
+  `agent-auth` (or any service) as a runtime dependency would re-couple
+  the common library to the services it was extracted from and defeat
+  the whole reason for the split. This can happen via a misguided
+  `from agent_auth.config import ...` import landing in
+  `agent-auth-common/src/` plus an IDE "add missing dependency"
+  autofix.
+- **Service-to-service leaks.** `things-cli` picking up `things-bridge`
+  as a runtime dep, or `gpg-cli` picking up `gpg-bridge`, would make a
+  client pull in its server's dependency closure — exactly the coupling
+  #105 wanted to break.
+- **CLI-to-service-and-back cycles.** Any edge that creates a cycle in
+  the dep graph blocks the per-package release automation that ADR
+  0032 named as its load-bearing follow-up.
+
+Issue #274 observes that pyproject.toml review alone has not been
+enough to catch these — the graph is a product of the eight files, and
+a diff against any one of them doesn't surface the wider shape.
+
+## Considered alternatives
+
+### Rely on code review
+
+Keep the enforcement informal; trust that a reviewer spots an
+unintended workspace edge when a `pyproject.toml` diff lands.
+
+**Rejected** because:
+
+- Cross-package review is global: a `pyproject.toml` diff shows one
+  file while the invariant lives across eight. Reviewers don't
+  reliably hold the whole graph in their head.
+- The cost of a missed reverse dep is high — by the time it lands on
+  `main` the release-automation layering is already compromised and
+  the fix is a breaking change to the consumer graph.
+- Automated gates on similarly structural invariants (design artefact
+  drift via `scripts/verify-design.sh`, dependency ecosystem coverage
+  via `scripts/verify-standards.sh`) are already the project pattern;
+  an allowlist check slots into the same shape.
+
+### Derive the allowlist from directory layout
+
+Infer the allowed edges from some convention — e.g. "anything named
+`*-cli` may depend on anything named `*-bridge`" — rather than
+enumerate them.
+
+**Rejected** because:
+
+- The current graph has no such pattern: every service points at
+  `agent-auth-common` and nothing else. A naming-derived rule would
+  need to reject edges that happen to match the naming but are not
+  actually wanted today.
+- Any future edge beyond the shared library needs an ADR anyway (so
+  the reasoning is captured). Enumerating the ADR-blessed edges
+  directly is both clearer and strictly more restrictive — no surprise
+  edges slip through because they accidentally match a pattern.
+
+## Decision
+
+`scripts/verify_workspace_deps.py` parses every
+`packages/*/pyproject.toml`, extracts each package's
+`[project].dependencies` list, narrows to workspace-member names, and
+asserts the resulting edge set matches the allowlist baked into the
+script. Both unexpected edges and missing allowlisted edges fail the
+check — the allowlist must stay in sync with the pyproject.toml
+tree in both directions.
+
+The allowlist today is the seven "service → `agent-auth-common`" edges:
+
+- `agent-auth` → `agent-auth-common`
+- `gpg-backend-cli-host` → `agent-auth-common`
+- `gpg-bridge` → `agent-auth-common`
+- `gpg-cli` → `agent-auth-common`
+- `things-bridge` → `agent-auth-common`
+- `things-cli` → `agent-auth-common`
+- `things-client-cli-applescript` → `agent-auth-common`
+
+Adding a new edge — including a second "service → library" if a
+second shared library ever emerges — requires amending this ADR with
+the justification and extending `ALLOWED_EDGES` in the script. The
+script is wired into `task check` (and therefore `.github/workflows/check.yml`)
+so every PR exercises it.
+
+## Consequences
+
+Positive:
+
+- Reverse deps, service-to-service leaks, and accidental closure
+  expansions all fail the PR gate rather than landing silently. The
+  failure message names the offending edge(s) and the remediation.
+- The allowlist lives next to the script and is diff-visible — any
+  future intended edge is a three-line change (allowlist + ADR
+  entry + the pyproject.toml change) reviewed together.
+- The structural invariant is machine-checked, freeing code review
+  to focus on the content of a change rather than its packaging-layer
+  coupling.
+
+Negative:
+
+- Legitimate architectural changes now carry an ADR-and-allowlist
+  update in addition to the pyproject.toml edit. Acceptable: the cost
+  is proportional to the decision, and "introduce a new cross-service
+  runtime dependency" is genuinely worth writing an ADR for.
+- The script enforces `[project].dependencies` only; `[project.optional-dependencies]`
+  (extras) is out of scope. Extras are currently empty across the
+  workspace (only `agent-auth-common[testing]` uses them, and that
+  extra has no workspace deps); revisit if extras grow.
+
+## Follow-ups
+
+- Extend the script to include every `[project.optional-dependencies]`
+  group if and when extras start carrying workspace-internal edges —
+  currently not worth the code because no extra does.

--- a/design/decisions/README.md
+++ b/design/decisions/README.md
@@ -91,3 +91,5 @@ is linked from this index.
   — replaces `testcontainers-python` with a subprocess-native fluent builder under `tests/integration/harness/`; supersedes the testcontainers-specific parts of ADR 0004 / 0005 while keeping the per-test Compose-project shape. Closes #80.
 - [ADR 0035 — Keep a single workspace-wide release train for now](0035-workspace-release-model.md)
   — every workspace package keeps riding the repo-wide `v<X>.<Y>.<Z>` tag produced by semantic-release; revisit when an external consumer pins a package, when any package reaches independent 1.0 readiness, or when release cadences materially diverge. Per-package `setuptools_scm` blocks already in place so the flip is a config change, not a refactor.
+- [ADR 0036 — Workspace dep graph is an explicit allowlist verified in CI](0036-workspace-dep-graph-allowlist.md)
+  — `scripts/verify_workspace_deps.py` asserts the edge set in `packages/*/pyproject.toml` matches the seven "service → `agent-auth-common`" edges baked into `ALLOWED_EDGES`; reverse deps, service-to-service leaks, and missing allowlisted edges all fail `task check`. Any new cross-package edge requires an ADR update.

--- a/scripts/verify_workspace_deps.py
+++ b/scripts/verify_workspace_deps.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Verify the workspace dep graph matches the allowlist in ADR 0036.
+
+With eight workspace packages under ``packages/*/`` it is trivial to
+introduce an unintended edge — e.g. ``agent-auth-common`` starting to
+import from ``agent-auth`` (a reverse dep that would re-couple the
+common library to the service it was extracted from), or a bridge
+picking up a CLI as a runtime dependency. pyproject.toml review
+alone does not catch these.
+
+This script parses every ``packages/*/pyproject.toml``, extracts the
+``[project].dependencies`` list, narrows to workspace-member names
+(the ones that also appear as ``[project].name`` elsewhere in the
+workspace), and asserts the resulting edge set is a subset of
+``ALLOWED_EDGES``. Any unexpected edge — including reverse deps —
+fails the check. Missing allowlisted edges also fail so the
+allowlist can't drift out of sync with reality.
+
+Allowed edges are maintained in
+``design/decisions/0036-workspace-dep-graph-allowlist.md`` — any
+addition requires an ADR update.
+
+Usage::
+
+    scripts/verify_workspace_deps.py [--packages-dir DIR]
+
+``--packages-dir`` defaults to ``packages/`` under the repo root; it
+is plumbed through so the self-test in
+``tests/test_verify_workspace_deps.py`` can point the script at a
+fixture tree containing an injected reverse-dep.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Every edge in the current workspace. Ordering is (dependent,
+# dependency) — so ``("agent-auth", "agent-auth-common")`` reads
+# "agent-auth depends on agent-auth-common".
+#
+# Keep this sorted. Adding an edge requires updating ADR 0036 with
+# the justification.
+ALLOWED_EDGES: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("agent-auth", "agent-auth-common"),
+        ("gpg-backend-cli-host", "agent-auth-common"),
+        ("gpg-bridge", "agent-auth-common"),
+        ("gpg-cli", "agent-auth-common"),
+        ("things-bridge", "agent-auth-common"),
+        ("things-cli", "agent-auth-common"),
+        ("things-client-cli-applescript", "agent-auth-common"),
+    }
+)
+
+# PEP 508 package name: first segment before any version specifier,
+# extra bracket, environment marker, or whitespace. ``re`` is used
+# rather than ``packaging.requirements.Requirement`` so the script
+# stays stdlib-only (Python 3.11 gives us ``tomllib``).
+_NAME_RE = re.compile(r"([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+
+def _dependency_name(requirement: str) -> str:
+    match = _NAME_RE.match(requirement.strip())
+    if match is None:
+        raise ValueError(f"could not parse dependency name from {requirement!r}")
+    return match.group(1)
+
+
+def load_workspace(packages_dir: Path) -> dict[str, set[str]]:
+    """Return a mapping of workspace-member name → declared dep names.
+
+    Only ``[project].dependencies`` is consulted; optional extras are
+    out of scope for the allowlist (they do not affect the
+    production install closure).
+    """
+    members: dict[str, set[str]] = {}
+    for pyproject in sorted(packages_dir.glob("*/pyproject.toml")):
+        with pyproject.open("rb") as fh:
+            data = tomllib.load(fh)
+        project = data.get("project", {})
+        name = project.get("name")
+        if not name:
+            raise ValueError(f"{pyproject} has no [project].name")
+        deps = {_dependency_name(dep) for dep in project.get("dependencies", [])}
+        members[name] = deps
+    return members
+
+
+def observed_edges(members: dict[str, set[str]]) -> set[tuple[str, str]]:
+    """Narrow every package's dep list to workspace-internal edges."""
+    workspace_names = set(members)
+    return {(name, dep) for name, deps in members.items() for dep in deps if dep in workspace_names}
+
+
+def check(
+    members: dict[str, set[str]],
+    allowed: frozenset[tuple[str, str]] = ALLOWED_EDGES,
+) -> tuple[set[tuple[str, str]], set[tuple[str, str]]]:
+    """Return ``(unexpected, missing)`` sets of edges versus the allowlist."""
+    observed = observed_edges(members)
+    return observed - allowed, allowed - observed
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--packages-dir",
+        type=Path,
+        default=REPO_ROOT / "packages",
+        help="Path to the workspace packages directory (default: packages/ under the repo root).",
+    )
+    args = parser.parse_args(argv)
+
+    packages_dir: Path = args.packages_dir
+    if not packages_dir.is_dir():
+        print(f"verify-workspace-deps: {packages_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    members = load_workspace(packages_dir)
+    if not members:
+        print(
+            f"verify-workspace-deps: no pyproject.toml files under {packages_dir}/*/",
+            file=sys.stderr,
+        )
+        return 2
+
+    unexpected, missing = check(members)
+
+    ok = True
+    if unexpected:
+        print(
+            "verify-workspace-deps: unexpected workspace-internal edges (not in ALLOWED_EDGES):",
+            file=sys.stderr,
+        )
+        for src, dst in sorted(unexpected):
+            print(f"  - {src} -> {dst}", file=sys.stderr)
+        print(
+            "\n"
+            "Fix: drop the dependency, OR add an ADR justifying the new edge "
+            "and extend ALLOWED_EDGES in scripts/verify_workspace_deps.py.",
+            file=sys.stderr,
+        )
+        ok = False
+
+    if missing:
+        print(
+            "verify-workspace-deps: allowlisted edges not observed in pyproject.toml:",
+            file=sys.stderr,
+        )
+        for src, dst in sorted(missing):
+            print(f"  - {src} -> {dst}", file=sys.stderr)
+        print(
+            "\n"
+            "Fix: restore the dependency, OR remove the edge from "
+            "ALLOWED_EDGES (and update ADR 0036).",
+            file=sys.stderr,
+        )
+        ok = False
+
+    if not ok:
+        return 1
+
+    observed = observed_edges(members)
+    print(
+        f"verify-workspace-deps: workspace dep graph matches the ADR 0036 allowlist "
+        f"({len(observed)} edges across {len(members)} members)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/tests/test_verify_workspace_deps.py
+++ b/tests/test_verify_workspace_deps.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for scripts/verify_workspace_deps.py.
+
+The script is the load-bearing piece of ADR 0036's allowlist: if it
+fails to notice an unexpected workspace edge, a reverse dep (or a
+service-to-service leak) lands on main without an ADR update. These
+tests drive the script against fixture pyproject.toml trees — both
+the happy path and an injected reverse-dep — so the allowlist stays
+honestly enforced.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "verify_workspace_deps.py"
+
+
+def _write_pyproject(root: Path, name: str, deps: list[str]) -> None:
+    """Create a minimal pyproject.toml for ``name`` under ``root/<name>/``."""
+    pkg_dir = root / name
+    pkg_dir.mkdir(parents=True)
+    deps_block = ", ".join(f'"{dep}"' for dep in deps)
+    pkg_dir.joinpath("pyproject.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [project]
+            name = "{name}"
+            version = "0"
+            requires-python = ">=3.11"
+            dependencies = [{deps_block}]
+            """
+        )
+    )
+
+
+def _run(packages_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--packages-dir", str(packages_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_current_workspace_graph_matches_allowlist() -> None:
+    # The authoritative invariant: the real packages/ tree must be
+    # clean. Running without --packages-dir exercises the default
+    # path so the script's own bootstrapping stays covered.
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "matches the ADR 0036 allowlist" in result.stdout
+
+
+def test_injected_reverse_dep_fails(tmp_path: Path) -> None:
+    # Reverse dep: agent-auth-common picks up agent-auth as a
+    # runtime dependency. This inverts the intended layering (the
+    # common library should not know about the services that
+    # consume it) and must fail loudly.
+    packages = tmp_path / "packages"
+    _write_pyproject(packages, "agent-auth", ["agent-auth-common"])
+    _write_pyproject(packages, "agent-auth-common", ["agent-auth"])
+
+    result = _run(packages)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "unexpected workspace-internal edges" in result.stderr
+    assert "agent-auth-common -> agent-auth" in result.stderr
+
+
+def test_service_to_service_leak_fails(tmp_path: Path) -> None:
+    # A CLI picking up a service runtime dep (e.g. things-cli
+    # reaching into things-bridge) is the other shape of unintended
+    # coupling — each CLI should only lean on agent-auth-common's
+    # HTTP client layer.
+    packages = tmp_path / "packages"
+    _write_pyproject(packages, "agent-auth-common", [])
+    _write_pyproject(packages, "things-bridge", ["agent-auth-common"])
+    _write_pyproject(packages, "things-cli", ["agent-auth-common", "things-bridge"])
+
+    result = _run(packages)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "things-cli -> things-bridge" in result.stderr
+
+
+def test_missing_allowlisted_edge_fails(tmp_path: Path) -> None:
+    # If ALLOWED_EDGES names an edge that no package actually
+    # declares (e.g. a package was deleted but the allowlist was
+    # not cleaned up), the allowlist has drifted — flag it so the
+    # two stay in sync.
+    packages = tmp_path / "packages"
+    _write_pyproject(packages, "agent-auth-common", [])
+    _write_pyproject(packages, "agent-auth", ["agent-auth-common"])
+    # Deliberately omit the other six service packages that the
+    # allowlist names; the script should report them as missing.
+
+    result = _run(packages)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "allowlisted edges not observed" in result.stderr
+    assert "things-bridge -> agent-auth-common" in result.stderr
+
+
+def test_third_party_deps_are_ignored(tmp_path: Path) -> None:
+    # PyPI dependencies like ``cryptography`` or ``pyyaml`` must
+    # never show up in the edge graph — the script only considers
+    # names that also appear as a workspace member.
+    packages = tmp_path / "packages"
+    _write_pyproject(packages, "agent-auth-common", [])
+    _write_pyproject(
+        packages,
+        "agent-auth",
+        ["agent-auth-common", "cryptography>=42.0", "keyring>=25.0", "pyyaml>=6.0"],
+    )
+    _write_pyproject(packages, "gpg-backend-cli-host", ["agent-auth-common"])
+    _write_pyproject(packages, "gpg-bridge", ["agent-auth-common"])
+    _write_pyproject(packages, "gpg-cli", ["agent-auth-common"])
+    _write_pyproject(packages, "things-bridge", ["agent-auth-common"])
+    _write_pyproject(packages, "things-cli", ["agent-auth-common"])
+    _write_pyproject(packages, "things-client-cli-applescript", ["agent-auth-common"])
+
+    result = _run(packages)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "matches the ADR 0036 allowlist" in result.stdout


### PR DESCRIPTION
## Summary

- New `scripts/verify_workspace_deps.py` parses every `packages/*/pyproject.toml`, narrows each dep list to workspace-member names, and asserts the edge set matches the `ALLOWED_EDGES` allowlist baked into the script.
- New ADR 0035 documents the seven `service → agent-auth-common` edges and the requirement that any new cross-package edge ships with an ADR amendment and an `ALLOWED_EDGES` update.
- Wired into `task check` (and therefore `.github/workflows/check.yml`) plus the standalone `task verify-workspace-deps` for local iteration.
- `tests/test_verify_workspace_deps.py` covers happy path, injected reverse dep, service-to-service leak, missing allowlisted edge, and third-party-only case.

## Test plan

- [x] `scripts/verify_workspace_deps.py` reports `7 edges across 8 members`.
- [x] `pytest tests/test_verify_workspace_deps.py` passes (5 tests).
- [x] Full `scripts/test.sh` suite passes (630 passed, coverage 75.19%).
- [x] `task check` runs the new gate as the last step.
- [x] `scripts/verify-standards.sh`, `scripts/lint.sh`, `scripts/format.sh --check`, `scripts/typecheck.sh`, `scripts/reuse-lint.sh` all pass.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)