### PR TITLE
docs: add a README to every workspace package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@ agent-auth provides a local authorization layer between AI agents (e.g. Claude C
 - **CLI interface** for token lifecycle management (create, list, modify, revoke, rotate)
 - **HTTP validation server** for runtime token and scope checks
 
+## Packages
+
+Each service in the monorepo ships as its own installable package
+under [`packages/`](packages/). Click through for the package's own
+README — public surface, configuration, and the ADRs that motivate
+its design.
+
+| Package                                                                             | Purpose                                                                                                 |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| [`agent-auth`](packages/agent-auth/README.md)                                       | Token authorization service — HMAC-signed access/refresh pairs, three-tier scope model, SQLite store.   |
+| [`things-bridge`](packages/things-bridge/README.md)                                 | HTTP bridge from agent-auth-protected clients to the Things 3 to-do app.                                |
+| [`things-cli`](packages/things-cli/README.md)                                       | Read-only command-line client for `things-bridge`.                                                      |
+| [`things-client-cli-applescript`](packages/things-client-cli-applescript/README.md) | macOS-only AppleScript-backed implementation of the Things-client contract; invoked by `things-bridge`. |
+| [`gpg-bridge`](packages/gpg-bridge/README.md)                                       | Host-side HTTP bridge that brokers GPG sign/verify on behalf of devcontainer-resident callers.          |
+| [`gpg-cli`](packages/gpg-cli/README.md)                                             | Devcontainer `gpg.program` replacement that forwards git's sign/verify argv to `gpg-bridge`.            |
+| [`gpg-backend-cli-host`](packages/gpg-backend-cli-host/README.md)                   | Host-side GPG backend invoked as a subprocess by `gpg-bridge`.                                          |
+| [`agent-auth-common`](packages/agent-auth-common/README.md)                         | Library-only workspace package: shared types, HTTP clients, Prometheus metrics helper.                  |
+
 ## Installation
 
 Each service in this repository ships as its own installable Python

--- a/packages/agent-auth-common/README.md
+++ b/packages/agent-auth-common/README.md
@@ -1,0 +1,34 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# agent-auth-common
+
+Library-only workspace package shared by every service in this repo.
+Stdlib-only at runtime so it stays cheap to consume from CLIs that
+only need typed clients or domain models.
+
+## Public surface
+
+| Module                              | Purpose                                                                                                                                         |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent_auth_client`                 | Typed HTTP client for the `agent-auth` server (token validate / refresh / management endpoints).                                                |
+| `things_bridge_client`              | Typed HTTP client for the `things-bridge` HTTP API.                                                                                             |
+| `things_models`                     | Dataclasses + typed `NewType` ids (`TodoId`, `ProjectId`, `AreaId`) shared by every Things-side consumer.                                       |
+| `things_client_common`              | Shared argparse / dispatch surface implemented by every Things-client CLI (production AppleScript and the test fake).                           |
+| `gpg_models` / `gpg_backend_common` | Dataclasses, errors, JSON-line protocol, and dispatcher shared by `gpg-bridge`, `gpg-cli`, and `gpg-backend-cli-host`.                          |
+| `server_metrics`                    | Prometheus exposition-format helper used by the HTTP servers (`agent-auth`, `things-bridge`, `gpg-bridge`).                                     |
+| `tests_support` (extra, test-only)  | Out-of-process notifier sidecar consumed by Docker integration tests; gated behind the `tests` extra so it never ships in a production install. |
+
+## Install
+
+This package is a workspace dependency — installing any of the
+service packages (`agent-auth`, `things-bridge`, `gpg-bridge`, ...) pulls
+it in transitively. There is no standalone install path or CLI.
+
+## Related design
+
+- ADR [0030 — Per-service HTTP client libraries](../../design/decisions/0030-per-service-http-client-libraries.md)
+- ADR [0003 — Things-client CLI split](../../design/decisions/0003-things-client-cli-split.md)

--- a/packages/agent-auth/README.md
+++ b/packages/agent-auth/README.md
@@ -1,0 +1,61 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# agent-auth
+
+Token-based authorization service for gating AI-agent access to local
+applications. Issues HMAC-signed access / refresh token pairs scoped
+under a three-tier model (`allow` / `prompt` / `deny`), persists them
+in an encrypted SQLite store, and exposes the trust-root HTTP API that
+every other service in this repo validates against.
+
+## Public surface
+
+### CLI — `agent-auth`
+
+| Subcommand                         | Purpose                                                                    |
+| ---------------------------------- | -------------------------------------------------------------------------- |
+| `agent-auth serve`                 | Start the HTTP server (default `127.0.0.1:9100`).                          |
+| `agent-auth token create`          | Mint a new token family with a scope set.                                  |
+| `agent-auth token list`            | List token families.                                                       |
+| `agent-auth token modify`          | Update scopes / expiry on an existing family.                              |
+| `agent-auth token rotate`          | Rotate the access / refresh pair for a family.                             |
+| `agent-auth token revoke`          | Revoke an entire family (refresh-token reuse triggers this automatically). |
+| `agent-auth management-token show` | Print the bootstrap management token used to authenticate other CLI calls. |
+
+The `agent-auth-notifier` sidecar lives in this package too — an
+out-of-process JIT approval prompt for `prompt`-tier scopes.
+
+### HTTP — `/agent-auth/v1/*`
+
+Validate, refresh, and management endpoints documented in
+[`openapi/agent-auth.v1.yaml`](./openapi/agent-auth.v1.yaml). The
+unversioned `/agent-auth/health` and `/agent-auth/metrics` endpoints
+are also served.
+
+## Configuration
+
+`~/.config/agent-auth/config.yaml` controls host/port, token TTLs,
+notification plugin URL, and TLS material. The XDG layout for the
+SQLite store and audit log is documented in
+[ADR 0012](../../design/decisions/0012-xdg-path-layout.md).
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/aidanns/agent-auth/main/packages/agent-auth/install.sh | bash
+```
+
+Or run from a development checkout via `task agent-auth -- <args...>`.
+
+## Related design
+
+- ADR [0006 — Token format](../../design/decisions/0006-token-format.md)
+- ADR [0007 — SQLite field-level encryption](../../design/decisions/0007-sqlite-field-level-encryption.md)
+- ADR [0008 — System keyring for key material](../../design/decisions/0008-system-keyring-for-key-material.md)
+- ADR [0009 — CLI / server split](../../design/decisions/0009-cli-server-split.md)
+- ADR [0010 — Three-tier scope model](../../design/decisions/0010-three-tier-scope-model.md)
+- ADR [0011 — Refresh-token reuse, family revocation](../../design/decisions/0011-refresh-token-reuse-family-revocation.md)

--- a/packages/gpg-backend-cli-host/README.md
+++ b/packages/gpg-backend-cli-host/README.md
@@ -1,0 +1,41 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# gpg-backend-cli-host
+
+Host-side GPG backend invoked as a subprocess by
+[`gpg-bridge`](../gpg-bridge/). Wraps the real host `gpg` binary and
+emits a JSON envelope on stdout that the bridge parses; conceptually
+the GPG-side analogue of `things-client-cli-applescript`.
+
+## Public surface
+
+### CLI — `gpg-backend-cli-host`
+
+Invoked by `gpg-bridge` per request; not intended to be run
+interactively. Each invocation accepts a single sign or verify
+operation parsed out of argv, shells to the host `gpg`, and prints a
+JSON envelope describing the result (or a structured error).
+
+## Platform requirements
+
+- A working host `gpg` install with the signing key loaded into the
+  keyring being used.
+- The user's GPG agent is reused; no key material is stored in this
+  package.
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/aidanns/agent-auth/main/packages/gpg-backend-cli-host/install.sh | bash
+```
+
+Or run from a development checkout via
+`task gpg-backend-host -- <args...>`.
+
+## Related design
+
+- ADR [0033 — gpg-bridge / gpg-cli split](../../design/decisions/0033-gpg-bridge-cli-split.md)

--- a/packages/gpg-bridge/README.md
+++ b/packages/gpg-bridge/README.md
@@ -1,0 +1,50 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# gpg-bridge
+
+Host-side HTTP bridge that performs git's commit / tag signing on
+behalf of devcontainer-resident callers. Mirrors the things-bridge
+split: the bridge holds no GPG logic itself — it shells out to a
+configured backend (default
+[`gpg-backend-cli-host`](../gpg-backend-cli-host/), which calls the
+real host `gpg`). Authorization is delegated to
+[`agent-auth`](../agent-auth/) under the `gpg:sign` scope, and key
+allowlisting sits in bridge config.
+
+## Public surface
+
+### CLI — `gpg-bridge`
+
+| Subcommand         | Purpose                                           |
+| ------------------ | ------------------------------------------------- |
+| `gpg-bridge serve` | Start the HTTP server (default `127.0.0.1:9300`). |
+
+### HTTP
+
+POST `/gpg-bridge/v1/sign` and `/gpg-bridge/v1/verify`, each
+forwarding to the configured backend after `agent-auth` authorization
+and per-key allowlist enforcement. Health and metrics on
+`/gpg-bridge/health` / `/gpg-bridge/metrics`.
+
+## Configuration
+
+`~/.config/gpg-bridge/config.yaml` controls host/port, the
+`agent-auth` URL, the `gpg_backend_command` argv, and the
+`allowed_signing_keys` list. TLS material can be supplied so a
+devcontainer reaching the host bridge gets transport protection.
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/aidanns/agent-auth/main/packages/gpg-bridge/install.sh | bash
+```
+
+Or run from a development checkout via `task gpg-bridge -- <args...>`.
+
+## Related design
+
+- ADR [0033 — gpg-bridge / gpg-cli split](../../design/decisions/0033-gpg-bridge-cli-split.md)

--- a/packages/gpg-cli/README.md
+++ b/packages/gpg-cli/README.md
@@ -1,0 +1,50 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# gpg-cli
+
+Devcontainer-side `gpg` replacement. Wired into git via
+`git config gpg.program gpg-cli`, it accepts git's standard sign /
+verify argv and forwards each request to a host-side
+[`gpg-bridge`](../gpg-bridge/) over HTTPS using a bearer token issued
+by [`agent-auth`](../agent-auth/) for the `gpg:sign` scope.
+
+The devcontainer never sees the signing key or the host gpg keyring —
+the bridge brokers the call to the host `gpg` and returns the
+detached signature.
+
+## Public surface
+
+### CLI — `gpg-cli`
+
+The CLI is a drop-in replacement for `gpg.program`; it implements
+exactly the subset of git's gpg invocation surface needed for commit
+and tag signing/verification (`--sign`, `--verify`,
+`--list-keys`, ...).
+
+## Configuration
+
+`~/.config/gpg-cli/config.yaml` configures the bridge URL and TLS
+trust material. Token credentials are stored in the system keyring
+(or, when no backend is available, a `0600` YAML fallback under
+`~/.config/gpg-cli/`).
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/aidanns/agent-auth/main/packages/gpg-cli/install.sh | bash
+```
+
+Or run from a development checkout via `task gpg-cli -- <args...>`.
+After install, point git at it once:
+
+```bash
+git config --global gpg.program gpg-cli
+```
+
+## Related design
+
+- ADR [0033 — gpg-bridge / gpg-cli split](../../design/decisions/0033-gpg-bridge-cli-split.md)

--- a/packages/things-bridge/README.md
+++ b/packages/things-bridge/README.md
@@ -1,0 +1,62 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# things-bridge
+
+HTTP bridge that exposes a read-only, agent-auth-protected view of
+the Things 3 to-do app. Holds no Things logic itself: each request is
+translated into a subprocess invocation of a configured Things-client
+CLI (default [`things-client-cli-applescript`](../things-client-cli-applescript/),
+which shells out to `osascript` on macOS) and the JSON envelope on
+stdout is parsed and returned to the caller.
+
+## Public surface
+
+### CLI — `things-bridge`
+
+| Subcommand            | Purpose                                           |
+| --------------------- | ------------------------------------------------- |
+| `things-bridge serve` | Start the HTTP server (default `127.0.0.1:9200`). |
+
+### HTTP — `/things-bridge/v1/*`
+
+Read-only endpoints over Things `todos`, `projects`, `areas`. The full
+contract lives in [`openapi/things-bridge.v1.yaml`](./openapi/things-bridge.v1.yaml).
+`/things-bridge/health` and `/things-bridge/metrics` are unversioned.
+
+## Configuration
+
+`~/.config/things-bridge/config.yaml` configures host/port, the
+`agent-auth` URL, and the `things_client_command` argv used to launch
+the Things-client subprocess. For Linux devcontainer e2e, point the
+command at the test-only fake:
+
+```yaml
+things_client_command:
+  - python
+  - -m
+  - tests.things_client_fake
+  - --fixtures
+  - tests/things_client_fake/fake-things.yaml
+```
+
+The bridge re-validates every request with `agent-auth` before
+acting; it never caches authorisation decisions and never trusts the
+bearer token it receives directly.
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/aidanns/agent-auth/main/packages/things-bridge/install.sh | bash
+```
+
+Or run from a development checkout via `task things-bridge -- <args...>`.
+
+## Related design
+
+- ADR [0001 — Things-client fake](../../design/decisions/0001-things-client-fake.md) (superseded by 0003)
+- ADR [0003 — Things-client CLI split](../../design/decisions/0003-things-client-cli-split.md)
+- ADR [0013 — AppleScript Things bridge](../../design/decisions/0013-applescript-things-bridge.md)

--- a/packages/things-cli/README.md
+++ b/packages/things-cli/README.md
@@ -1,0 +1,43 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# things-cli
+
+Read-only command-line client for [`things-bridge`](../things-bridge/).
+Auto-refreshes / reissues tokens via [`agent-auth`](../agent-auth/) and
+emits human-readable text by default (or JSON with `--json`).
+
+## Public surface
+
+### CLI — `things-cli`
+
+| Subcommand                        | Purpose                                                                              |
+| --------------------------------- | ------------------------------------------------------------------------------------ |
+| `things-cli login`                | Interactively store credentials (bridge URL, auth URL, family id, refresh token).    |
+| `things-cli status`               | Show redacted credential status.                                                     |
+| `things-cli logout`               | Discard stored credentials.                                                          |
+| `things-cli todos list / show`    | List/show todos (filter by status, list, project, area; `--list TMTodayListSource`). |
+| `things-cli projects list / show` | List/show projects.                                                                  |
+| `things-cli areas list / show`    | List/show areas.                                                                     |
+
+## Credentials
+
+Stored in the system keyring by default. When no keyring backend is
+available (e.g. inside a devcontainer), the CLI falls back to a
+`0600` YAML file at `~/.config/things-cli/credentials.yaml`.
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/aidanns/agent-auth/main/packages/things-cli/install.sh | bash
+```
+
+Or run from a development checkout via `task things-cli -- <args...>`.
+
+## Related design
+
+- ADR [0003 — Things-client CLI split](../../design/decisions/0003-things-client-cli-split.md)
+- ADR [0030 — Per-service HTTP client libraries](../../design/decisions/0030-per-service-http-client-libraries.md)

--- a/packages/things-client-cli-applescript/README.md
+++ b/packages/things-client-cli-applescript/README.md
@@ -1,0 +1,52 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# things-client-cli-applescript
+
+macOS-only AppleScript-backed implementation of the Things-client
+contract (defined under
+[`agent_auth_common.things_client_common`](../agent-auth-common/)).
+Invoked as a subprocess by [`things-bridge`](../things-bridge/), but
+also useful standalone for local Things 3 debugging without the
+bridge or `agent-auth`.
+
+## Public surface
+
+### CLI — `things-client-cli-applescript`
+
+Read-only commands over the Things 3 model; all emit a JSON envelope
+on stdout suitable for the `things-bridge` subprocess parser.
+
+| Subcommand      | Purpose                                               |
+| --------------- | ----------------------------------------------------- |
+| `todos list`    | List todos (optional status / list / project / area). |
+| `todos show`    | Show a single todo by id.                             |
+| `projects list` | List projects.                                        |
+| `projects show` | Show a single project by id.                          |
+| `areas list`    | List areas.                                           |
+| `areas show`    | Show a single area by id.                             |
+
+## Platform requirements
+
+- macOS with Things 3 installed.
+- Automation permission for the invoking process to control Things 3.
+
+The package installs on Linux (some contract-test scenarios need
+that), but every command will fail at runtime without `osascript`.
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/aidanns/agent-auth/main/packages/things-client-cli-applescript/install.sh | bash
+```
+
+Or run from a development checkout via
+`task things-client-applescript -- <args...>`.
+
+## Related design
+
+- ADR [0013 — AppleScript Things bridge](../../design/decisions/0013-applescript-things-bridge.md)
+- ADR [0003 — Things-client CLI split](../../design/decisions/0003-things-client-cli-split.md)

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -1639,6 +1639,31 @@ fi
 
 echo "verify-standards: every packages/<service>/ with [project.scripts] ships an executable install.sh; library-only packages have none."
 
+# Every workspace package must ship its own README.md describing
+# purpose, public surface, and pointers to relevant ADRs (#269). The
+# root README only links the package list — the package's README is
+# the canonical entry point for someone who lands on a single service
+# directory via a deep link.
+readme_drift=0
+shopt -s nullglob
+for pkg_dir in packages/*/; do
+  [[ -d "${pkg_dir}" ]] || continue
+  readme="${pkg_dir}README.md"
+  if [[ ! -f "${readme}" ]]; then
+    echo "verify-standards: ${readme} is missing." >&2
+    readme_drift=1
+  fi
+done
+shopt -u nullglob
+
+if [[ "${readme_drift}" -ne 0 ]]; then
+  echo "  Every packages/<service>/ must carry a README.md covering purpose," >&2
+  echo "  public surface, configuration, and links to relevant ADRs." >&2
+  exit 1
+fi
+
+echo "verify-standards: every packages/<service>/ ships a README.md."
+
 # lefthook hooks must be installed locally so the pre-commit commands
 # configured in lefthook.yml actually fire. Skipped when CI=true — CI
 # gates the same checks explicitly via workflow steps, so a fresh


### PR DESCRIPTION
## Summary

- Add a per-package ``README.md`` to all eight packages under ``packages/`` covering purpose, public surface (CLI subcommands and HTTP routes), configuration, install / dev path, and links to the ADRs that motivate the design.
- Insert a new "Packages" section near the top of the root ``README.md`` — a one-line index linking to each package's own README so a fresh visitor lands on the right package quickly.
- Extend ``scripts/verify-standards.sh`` to fail when any ``packages/<svc>/README.md`` is missing.

Closes #269

## Test plan

- [x] ``task verify-standards`` (new check passes)
- [x] Negative path: removed ``packages/agent-auth-common/README.md`` and confirmed verify-standards reports ``packages/agent-auth-common/README.md is missing.`` then restored.
- [x] ``task typecheck``
- [x] ``task test`` (unit, 625 passed, coverage 75.19%)
- [x] Spot-checked claims in each README — default ports (`9100/9200/9300`), CLI subcommand surfaces, the ``--list TMTodayListSource`` flag, and the ``agent-auth-notifier`` console-script all line up with the source.