### PR TITLE
fix(test-harness): drop docker compose -t override; gate compose_stop budget

### DIFF
--- a/packages/agent-auth-common/src/tests_support/integration/harness/_cluster.py
+++ b/packages/agent-auth-common/src/tests_support/integration/harness/_cluster.py
@@ -51,6 +51,9 @@ _log = logging.getLogger("integration.harness")
 
 DEFAULT_START_TIMEOUT_SECONDS = 30.0
 DEFAULT_POLL_INTERVAL_SECONDS = 0.2
+# Subprocess-side hard budget for ``docker compose down``. NOT propagated
+# to docker via ``-t``; the per-service ``stop_grace_period`` in the
+# compose file owns the SIGTERM→SIGKILL window. See #288 / ``_compose_down``.
 DEFAULT_STOP_TIMEOUT_SECONDS = 30.0
 DEFAULT_CONFIG_TIMEOUT_SECONDS = 30.0
 DEFAULT_UP_TIMEOUT_SECONDS = 300.0
@@ -460,8 +463,14 @@ class StartedCluster:
             )
 
     def _compose_down(self) -> None:
-        # Defensive: docker compose down -t takes an int (seconds).
-        down_timeout = int(self.stop_timeout_seconds)
+        # No ``-t`` here on purpose: the per-service ``stop_grace_period``
+        # in ``docker/docker-compose.yaml`` is the source of truth for the
+        # SIGTERM→SIGKILL window, and a CLI ``-t`` would silently override
+        # it. Passing ``-t 30`` here previously masked #154's graceful
+        # shutdown handlers and pushed every teardown to ~30 s — see #288.
+        # ``stop_timeout_seconds`` survives only as the subprocess-level
+        # safety budget below, so a wedged ``docker compose`` can't hang
+        # the harness forever.
         result = subprocess.run(
             [
                 "docker",
@@ -472,8 +481,6 @@ class StartedCluster:
                 "down",
                 "-v",
                 "--remove-orphans",
-                "-t",
-                str(down_timeout),
             ],
             env=self._subprocess_env(),
             capture_output=True,

--- a/packages/agent-auth-common/src/tests_support/integration/plugin.py
+++ b/packages/agent-auth-common/src/tests_support/integration/plugin.py
@@ -63,6 +63,7 @@ from tests_support.integration.support import (
     PER_SERVICE_DOCKERFILES,
     build_test_image,
     docker_compose_available,
+    phase_budget_breaches,
     phase_timer,
     seed_empty_fixtures_dir,
 )
@@ -94,6 +95,15 @@ APPROVAL_PLUGINS = {
 NOTIFIER_SIDECAR_URL = "http://notifier:9150/"
 
 AGENT_AUTH_INTERNAL_PORT = 9100
+
+# Per-test ``compose_stop`` budget (seconds). The compose file pins
+# ``stop_grace_period: 5s`` per service and the agent-auth /
+# things-bridge SIGTERM handlers (#154) drain in ~5 s, so a healthy
+# teardown + docker overhead lands well under this. Set high enough to
+# tolerate a slow CI runner but low enough to catch a regression to
+# 30 s like the one #288 fixed. Wired into the integration plugin's
+# fixture teardowns and asserted in ``pytest_sessionfinish`` below.
+COMPOSE_STOP_BUDGET_SECONDS = 10.0
 
 
 @dataclass
@@ -347,6 +357,39 @@ def pytest_runtest_makereport(item, call):
     setattr(item, f"rep_{report.when}", report)
 
 
+def pytest_sessionfinish(session, exitstatus):
+    """Fail the integration session if any phase exceeded its budget.
+
+    The fixture teardowns wrap ``running.stop()`` in a defensive
+    ``except Exception`` so a failing teardown can't mask the
+    originating test failure. That swallow would also hide a
+    ``compose_stop`` budget breach if it raised inline, which would
+    re-introduce exactly the silent-regression class #288 is about. So
+    instead, ``phase_timer`` records breaches into a module-level list
+    and this hook converts them into a non-zero session exit at the end
+    of the run, where there's nothing left to mask.
+    """
+    breaches = phase_budget_breaches()
+    if not breaches:
+        return
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    lines = ["integration phase budget exceeded:"]
+    for b in breaches:
+        suffix = " ".join(f"{k}={v}" for k, v in b.fields.items())
+        lines.append(
+            f"  phase={b.phase} elapsed_seconds={b.elapsed_seconds:.3f} "
+            f"budget_seconds={b.budget_seconds:.3f} {suffix}".rstrip()
+        )
+    message = "\n".join(lines)
+    if reporter is not None:
+        reporter.write_sep("=", "INTEGRATION BUDGET FAILURE", red=True)
+        reporter.write_line(message)
+    else:
+        print(message)
+    if exitstatus == pytest.ExitCode.OK:
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
+
+
 @pytest.fixture
 def agent_auth_container_factory(
     _test_image_tags: dict[str, str],
@@ -411,7 +454,12 @@ def agent_auth_container_factory(
     failed = _test_failed(request)
     for running in started:
         try:
-            with phase_timer("compose_stop", project=running.project_name, service="agent-auth"):
+            with phase_timer(
+                "compose_stop",
+                project=running.project_name,
+                service="agent-auth",
+                budget_seconds=COMPOSE_STOP_BUDGET_SECONDS,
+            ):
                 running.stop(test_failed=failed)
         except Exception as e:
             print(f"warning: compose teardown failed: {e!r}")
@@ -613,7 +661,12 @@ def things_bridge_stack_factory(
     failed = _test_failed(request)
     for running in started:
         try:
-            with phase_timer("compose_stop", project=running.project_name, service="things-bridge"):
+            with phase_timer(
+                "compose_stop",
+                project=running.project_name,
+                service="things-bridge",
+                budget_seconds=COMPOSE_STOP_BUDGET_SECONDS,
+            ):
                 running.stop(test_failed=failed)
         except Exception as e:
             print(f"warning: compose teardown failed: {e!r}")

--- a/packages/agent-auth-common/src/tests_support/integration/support.py
+++ b/packages/agent-auth-common/src/tests_support/integration/support.py
@@ -21,6 +21,7 @@ import subprocess
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[5]
@@ -48,13 +49,60 @@ PER_SERVICE_DOCKERFILES: dict[str, Path] = {
 _timing_log = logging.getLogger("integration.timing")
 
 
+@dataclass(frozen=True)
+class PhaseBudgetBreach:
+    """Record of a :func:`phase_timer` block that exceeded its budget.
+
+    Consumed by the ``pytest_sessionfinish`` hook in
+    ``tests_support.integration.plugin`` to fail the session — that is
+    how #288's CI gate prevents a future harness change from silently
+    re-introducing slow teardowns. ``fields`` carries the structured
+    context the caller passed (project, service, …) so the failure
+    output can pinpoint which compose project blew the budget.
+    """
+
+    phase: str
+    elapsed_seconds: float
+    budget_seconds: float
+    fields: dict[str, str] = field(default_factory=dict)
+
+
+_phase_budget_breaches: list[PhaseBudgetBreach] = []
+
+
+def phase_budget_breaches() -> tuple[PhaseBudgetBreach, ...]:
+    """Return all breaches recorded since the last :func:`clear_phase_budget_breaches`."""
+    return tuple(_phase_budget_breaches)
+
+
+def clear_phase_budget_breaches() -> None:
+    """Drop all recorded breaches. Used by tests to isolate the global list."""
+    _phase_budget_breaches.clear()
+
+
 @contextmanager
-def phase_timer(phase: str, **fields: object) -> Iterator[None]:
+def phase_timer(
+    phase: str,
+    *,
+    budget_seconds: float | None = None,
+    **fields: object,
+) -> Iterator[None]:
     """Log wall-clock time spent inside the ``with`` block.
 
     Extra ``fields`` are appended as ``key=value`` pairs so callers can
     correlate phases (e.g. compose project name, image tag) without
     parsing test ids.
+
+    When ``budget_seconds`` is set and elapsed exceeds it, a
+    :class:`PhaseBudgetBreach` is appended to the module-level breach
+    list (see :func:`phase_budget_breaches`) and a WARNING is emitted on
+    the same logger. The breach record is also raised at the end of the
+    pytest session by the integration plugin's ``pytest_sessionfinish``
+    hook, failing the run. Suppressing the breach with a ``try/except``
+    around the ``with`` block does not erase it — by design, so the
+    fixture teardowns that wrap ``running.stop()`` in a defensive
+    ``except Exception`` (to avoid masking earlier test failures) cannot
+    accidentally swallow a budget regression.
     """
     start = time.monotonic()
     try:
@@ -63,6 +111,22 @@ def phase_timer(phase: str, **fields: object) -> Iterator[None]:
         elapsed = time.monotonic() - start
         suffix = "".join(f" {k}={v}" for k, v in fields.items())
         _timing_log.info("phase=%s elapsed_seconds=%.3f%s", phase, elapsed, suffix)
+        if budget_seconds is not None and elapsed > budget_seconds:
+            _phase_budget_breaches.append(
+                PhaseBudgetBreach(
+                    phase=phase,
+                    elapsed_seconds=elapsed,
+                    budget_seconds=budget_seconds,
+                    fields={k: str(v) for k, v in fields.items()},
+                )
+            )
+            _timing_log.warning(
+                "phase=%s exceeded budget %.3fs: elapsed_seconds=%.3f%s",
+                phase,
+                budget_seconds,
+                elapsed,
+                suffix,
+            )
 
 
 def docker_compose_available() -> bool:

--- a/packages/agent-auth-common/tests/test_integration_harness.py
+++ b/packages/agent-auth-common/tests/test_integration_harness.py
@@ -540,6 +540,31 @@ def test_stop_is_idempotent(tmp_path, monkeypatch):
     assert len(recorder.calls) == first_count
 
 
+def test_compose_down_does_not_pass_explicit_timeout_flag(tmp_path, monkeypatch):
+    """Pin #288: ``-t`` would override the compose-file ``stop_grace_period``.
+
+    Hard-coding ``-t 30`` pushed every per-test teardown to ~30 s by
+    silently overriding the per-service grace period in
+    ``docker/docker-compose.yaml`` (and defeating the SIGTERM handlers
+    from #154). Anchoring the down argv shape here prevents a future
+    refactor from re-introducing the regression unnoticed.
+    """
+    cluster = _make_started_cluster(tmp_path)
+    recorder = _SubprocessRecorder(lambda argv, env: _FakeCompletedProcess(args=argv, returncode=0))
+    monkeypatch.setattr("tests_support.integration.harness._cluster.subprocess.run", recorder)
+
+    cluster.stop(test_failed=False)
+
+    down_call = next(call for call in recorder.calls if "down" in call.args)
+    assert "-t" not in down_call.args, (
+        f"docker compose down argv contains -t, which overrides the "
+        f"compose-file stop_grace_period. argv={down_call.args!r}"
+    )
+    # Sanity: the rest of the down shape is still what the harness needs.
+    assert "-v" in down_call.args
+    assert "--remove-orphans" in down_call.args
+
+
 # ---------------------------------------------------------------------------
 # Builder is re-usable as a factory (no accidental freezing)
 # ---------------------------------------------------------------------------

--- a/packages/agent-auth-common/tests/test_integration_support.py
+++ b/packages/agent-auth-common/tests/test_integration_support.py
@@ -19,12 +19,31 @@ import logging
 import time
 from pathlib import Path
 
+import pytest
+
 from tests_support.integration import plugin as integration_plugin
 from tests_support.integration.support import (
     _cache_scope_for_dockerfile,
     _gha_cache_args,
+    clear_phase_budget_breaches,
+    phase_budget_breaches,
     phase_timer,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_phase_budget_breaches():
+    """Reset the module-level breach list around every test in this file.
+
+    ``phase_timer`` writes into a shared list so the integration plugin's
+    ``pytest_sessionfinish`` hook can fail the run on a teardown-budget
+    regression. Tests in this file deliberately drive the same list, so
+    we clear it before *and* after each test to keep one test from
+    leaking state into the next.
+    """
+    clear_phase_budget_breaches()
+    yield
+    clear_phase_budget_breaches()
 
 
 def test_phase_timer_logs_phase_name_and_elapsed_seconds(caplog):
@@ -79,6 +98,73 @@ def test_phase_timer_elapsed_is_monotonic(caplog):
     elapsed_token = next(t for t in record.message.split() if t.startswith("elapsed_seconds="))
     elapsed = float(elapsed_token.split("=", 1)[1])
     assert elapsed > 0.0
+
+
+# ``phase_timer(budget_seconds=...)`` underpins the #288 CI gate: a
+# breach is appended to a module-level list that the integration
+# plugin's ``pytest_sessionfinish`` hook converts into a non-zero
+# session exit. Tests below pin the contract: no breach when within
+# budget, exactly one breach (with the right metadata) when over,
+# and no surprise raise from the context manager itself.
+
+
+def test_phase_timer_records_no_breach_when_within_budget():
+    with phase_timer("ok_phase", budget_seconds=10.0):
+        pass
+
+    assert phase_budget_breaches() == ()
+
+
+def test_phase_timer_records_breach_when_budget_exceeded(monkeypatch, caplog):
+    # Drive elapsed time deterministically so the test doesn't depend on
+    # ``time.sleep`` precision. Patching ``time.monotonic`` inside the
+    # support module is enough — phase_timer reads it via the bare
+    # ``time`` import, so the patch lands on the same function object.
+    clock = iter([100.0, 100.5])
+    monkeypatch.setattr("tests_support.integration.support.time.monotonic", lambda: next(clock))
+
+    with (
+        caplog.at_level(logging.WARNING, logger="integration.timing"),
+        phase_timer("compose_stop", budget_seconds=0.1, project="proj-x", service="svc-y"),
+    ):
+        pass
+
+    (breach,) = phase_budget_breaches()
+    assert breach.phase == "compose_stop"
+    assert breach.budget_seconds == 0.1
+    # The deterministic clock above means elapsed is exactly 0.5 s.
+    assert breach.elapsed_seconds == pytest.approx(0.5)
+    assert breach.fields == {"project": "proj-x", "service": "svc-y"}
+    # And the WARNING fires alongside the INFO line so a developer
+    # tailing logs sees the regression even before sessionfinish runs.
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warning_records) == 1
+    assert "exceeded budget" in warning_records[0].message
+
+
+def test_phase_timer_does_not_raise_on_breach():
+    """The breach is recorded; the ``with`` block itself completes cleanly.
+
+    The fixture teardowns that wrap ``running.stop()`` catch ``Exception``
+    to avoid masking earlier test failures. If ``phase_timer`` raised
+    inline on a breach, that ``except`` would swallow the regression
+    signal — which is exactly the ``compose_stop`` budget gap #288 fixes.
+    """
+    sentinel = object()
+
+    with phase_timer("compose_stop", budget_seconds=0.0):
+        result = sentinel
+
+    assert result is sentinel
+    assert len(phase_budget_breaches()) == 1
+
+
+def test_phase_timer_without_budget_records_no_breach_even_when_slow(monkeypatch):
+    clock = iter([0.0, 999.0])
+    monkeypatch.setattr("tests_support.integration.support.time.monotonic", lambda: next(clock))
+    with phase_timer("untimed_phase"):
+        pass
+    assert phase_budget_breaches() == ()
 
 
 # ``_resolve_test_image_tags`` decides whether the session owns the


### PR DESCRIPTION
## Summary

- Drop `-t 30` from `docker compose down` in the integration harness so the per-service `stop_grace_period: 5s` in `docker/docker-compose.yaml` is honored. The CLI flag was silently overriding the compose-file value, pushing every `compose_stop` to ~31 s and undoing the graceful-shutdown plumbing from #154.
- `phase_timer` now accepts `budget_seconds=`; on breach it records a `PhaseBudgetBreach` and emits a WARNING. The integration plugin's new `pytest_sessionfinish` hook converts any breaches into a non-zero session exit so a future regression of the same shape can't silently land.
- Wire the gate into the two `compose_stop` fixture-teardown call sites with a 10 s budget.

## Why a 30 s teardown happened

The `things-cli` integration job runs five trivial tests in 172.9 s, ~155 s of which is teardown:

```
phase=compose_stop elapsed_seconds=31.196
phase=compose_stop elapsed_seconds=30.960
phase=compose_stop elapsed_seconds=30.953
phase=compose_stop elapsed_seconds=31.207
phase=compose_stop elapsed_seconds=30.929
```

The 30 s figure is exactly the `-t 30` window the harness was passing. `docker compose down -t <N>` overrides any compose-file `stop_grace_period`, so SIGTERM handlers from #154 (which exit in ~5 s) never got a chance to short-circuit Docker's grace window. The override regressed in #252 — the testcontainers wrapper called `compose.stop()` with no `-t` and the compose-file 5 s applied.

## Why the gate uses a recorded list, not an inline raise

The fixture teardowns wrap `running.stop()` in a defensive `except Exception` so a failing teardown can't mask an earlier test failure. If `phase_timer` raised inline on a breach, that `except` would swallow the regression signal — exactly the class of silence this issue is about. Recording into a module-level list and failing in `pytest_sessionfinish` keeps the swallow semantics for real teardown errors and still surfaces budget breaches loudly at session end.

## Test plan

- [x] `./scripts/test.sh --unit` — 627 passed, 3 skipped, coverage 75.59 %.
- [x] `./scripts/typecheck.sh` — 161 source files, 0 errors.
- [x] `./scripts/lint.sh` / `./scripts/format.sh` — all checks pass.
- [x] `./scripts/verify-standards.sh` / `./scripts/verify-function-tests.sh` — clean.
- [x] New unit tests pin the `down` argv shape (no `-t`) and the `phase_timer` budget contract (no breach when within budget; one breach with the right metadata when over; no inline raise so `except Exception` can't swallow it).
- [ ] Integration suite needs a Docker host. CI will exercise the four per-service slices end-to-end and the timing log lines should drop to <10 s per `compose_stop`. If any teardown still lands at ~30 s after this change, scenario 2 in #288 is in play (SIGTERM handlers themselves regressed) and needs a follow-up against the server signal handlers — but the budget gate added here will surface that loudly instead of silently.

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)