### PR TITLE
feat(coverage): split --cov-fail-under into per-package floors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,24 +71,24 @@ that setup.
 Every repeatable operation is exposed through the task runner. Run
 `task --list` for the current catalogue. Current tasks:
 
-| Task                                       | Description                                                                                                                                               |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `task test`                                | Run the pytest suite with coverage (unit by default; pass `-- --fast`, `-- --integration`, or `-- --all`). Fails below the `--cov-fail-under` floor.      |
-| `task benchmark`                           | Run the pytest-benchmark suite under `packages/agent-auth/benchmarks/` (scheduled weekly in CI; see `packages/agent-auth/benchmarks/README.md`).          |
-| `task lint`                                | Run all configured linters (shellcheck, ruff check, keep-sorted).                                                                                         |
-| `task format`                              | Run all configured formatters (shfmt, ruff format, mdformat, taplo). Pass `-- --check` for diff-only mode (CI uses this).                                 |
-| `task typecheck`                           | Run mypy + pyright (strict) on every `packages/<svc>/src/` tree and `tests/`.                                                                             |
-| `task build`                               | Build sdist and wheel distributions into `dist/`.                                                                                                         |
-| `task install-hooks`                       | Install project git hooks (lefthook).                                                                                                                     |
-| `task verify-design`                       | Verify every leaf function in the functional decomposition is allocated in the product breakdown.                                                         |
-| `task verify-function-tests`               | Verify every leaf function in the functional decomposition has test coverage.                                                                             |
-| `task verify-dependencies`                 | Verify required CLI tools (python3, task, yq, ...) are installed on PATH.                                                                                 |
-| `task verify-standards`                    | Verify generic, portable standards (Taskfile task coverage, Dependabot ecosystem coverage, bash CI gating). Does not enforce project-specific task names. |
-| `task release`                             | Cut a release (version bump, tag, GitHub release, publish).                                                                                               |
-| `task agent-auth -- <args>`                | Run the `agent-auth` CLI (any subcommand).                                                                                                                |
-| `task things-bridge -- <args>`             | Run the `things-bridge` CLI.                                                                                                                              |
-| `task things-cli -- <args>`                | Run the `things-cli` client.                                                                                                                              |
-| `task things-client-applescript -- <args>` | Run the `things-client-cli-applescript` CLI (macOS-only).                                                                                                 |
+| Task                                       | Description                                                                                                                                                                         |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `task test`                                | Run the pytest suite with coverage (unit by default; pass `-- --fast`, `-- --integration`, or `-- --all`). Fails if any package's per-package `--cov-fail-under` floor is breached. |
+| `task benchmark`                           | Run the pytest-benchmark suite under `packages/agent-auth/benchmarks/` (scheduled weekly in CI; see `packages/agent-auth/benchmarks/README.md`).                                    |
+| `task lint`                                | Run all configured linters (shellcheck, ruff check, keep-sorted).                                                                                                                   |
+| `task format`                              | Run all configured formatters (shfmt, ruff format, mdformat, taplo). Pass `-- --check` for diff-only mode (CI uses this).                                                           |
+| `task typecheck`                           | Run mypy + pyright (strict) on every `packages/<svc>/src/` tree and `tests/`.                                                                                                       |
+| `task build`                               | Build sdist and wheel distributions into `dist/`.                                                                                                                                   |
+| `task install-hooks`                       | Install project git hooks (lefthook).                                                                                                                                               |
+| `task verify-design`                       | Verify every leaf function in the functional decomposition is allocated in the product breakdown.                                                                                   |
+| `task verify-function-tests`               | Verify every leaf function in the functional decomposition has test coverage.                                                                                                       |
+| `task verify-dependencies`                 | Verify required CLI tools (python3, task, yq, ...) are installed on PATH.                                                                                                           |
+| `task verify-standards`                    | Verify generic, portable standards (Taskfile task coverage, Dependabot ecosystem coverage, bash CI gating). Does not enforce project-specific task names.                           |
+| `task release`                             | Cut a release (version bump, tag, GitHub release, publish).                                                                                                                         |
+| `task agent-auth -- <args>`                | Run the `agent-auth` CLI (any subcommand).                                                                                                                                          |
+| `task things-bridge -- <args>`             | Run the `things-bridge` CLI.                                                                                                                                                        |
+| `task things-cli -- <args>`                | Run the `things-cli` client.                                                                                                                                                        |
+| `task things-client-applescript -- <args>` | Run the `things-client-cli-applescript` CLI (macOS-only).                                                                                                                           |
 
 Each task dispatches to a script under `scripts/*.sh`; the scripts are
 the single source of truth and can also be invoked directly if
@@ -107,22 +107,34 @@ stay authoritative until #270 relocates the monolithic `tests/` and
 ### Coverage
 
 `task test` (unit mode, the default) collects line and branch coverage
-via `pytest-cov` and fails when total coverage drops below the floor
-configured in `pyproject.toml` under
-`[tool.pytest.ini_options].addopts` as `--cov-fail-under=<N>`. The
-floor ratchets upward per
+via `pytest-cov` into a unified `.coverage` database. After the pytest
+run, `scripts/check-package-coverage.sh` walks every
+`packages/<svc>/pyproject.toml`, extracts the per-package
+`--cov-fail-under=<N>` from `[tool.pytest.ini_options].addopts`, and
+fails if any package's slice of the report falls below its floor.
+The per-package floor model (#273) keeps a well-tested package from
+masking a regression in another and is the authoritative gate per
 `.claude/instructions/testing-standards.md` "Coverage".
 
-- **Bumping the floor** (coverage-improving PRs): run
-  `task test -- --unit` locally, read the reported `TOTAL` percentage,
-  update `--cov-fail-under=<N>` in `pyproject.toml` to one below the
-  new TOTAL (so fluctuation across environments doesn't flake CI), and
-  commit alongside the coverage-improving changes.
-- **Lowering the floor** (rare): only when a deliberate change removes
-  redundant coverage (e.g. a fixture refactor). Explain the reason in
-  the commit message body; never lower silently.
+Each package's tests can also be exercised in isolation via
+`task <svc>:test` (driven by `scripts/pkg-test.sh <svc>`). Pytest's
+rootdir discovery picks up `packages/<svc>/pyproject.toml` and
+enforces the same `--cov-fail-under` floor for the package alone, so
+focused dev loops fail on a per-package regression without waiting
+for the workspace gate.
+
+- **Bumping a floor** (coverage-improving PRs): run
+  `task <svc>:test` locally, read the reported `TOTAL` percentage,
+  update `--cov-fail-under=<N>` in `packages/<svc>/pyproject.toml`'s
+  pytest addopts to one below the new TOTAL (so fluctuation across
+  environments doesn't flake CI), and commit alongside the
+  coverage-improving changes.
+- **Lowering a floor** (rare): only when a deliberate change removes
+  redundant coverage (e.g. a fixture refactor or a code path moved
+  out to a different package). Explain the reason in the commit
+  message body; never lower silently.
 - **`--fast` and `--integration` modes** run without coverage collection
-  (`--no-cov`). The floor is measured against `--unit` only —
+  (`--no-cov`). The floors are measured against `--unit` only —
   integration tests exercise Docker-backed service interactions that
   don't map cleanly onto `packages/*/src/` line coverage.
 

--- a/packages/agent-auth-common/pyproject.toml
+++ b/packages/agent-auth-common/pyproject.toml
@@ -44,3 +44,27 @@ exclude = ["tests_support*"]
 # fine because everything is developed in lockstep and nothing is yet
 # published independently.
 fallback_version = "0.0.0+unknown"
+
+[tool.pytest.ini_options]
+# Per-package pytest config. See packages/agent-auth/pyproject.toml
+# for the full rationale. This package's coverage floor is
+# deliberately lower than the service packages' because much of
+# ``agent-auth-common`` is exception classes and protocol shapes
+# whose error paths only fire under cross-service-failure tests
+# (run from agent-auth or things-bridge integration suites, not
+# from this package's own tests).
+addopts = [
+    "--import-mode=importlib",
+    "--cov=agent_auth_client",
+    "--cov=gpg_backend_common",
+    "--cov=gpg_models",
+    "--cov=server_metrics",
+    "--cov=things_bridge_client",
+    "--cov=things_client_common",
+    "--cov=things_models",
+    "--cov-branch",
+    "--cov-report=term-missing",
+    "--cov-fail-under=49",
+]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/packages/agent-auth/pyproject.toml
+++ b/packages/agent-auth/pyproject.toml
@@ -37,3 +37,31 @@ fallback_version = "0.0.0+unknown"
 # a published version can override this in a release build via
 # ``pip install`` against PyPI.
 agent-auth-common = { workspace = true }
+
+[tool.pytest.ini_options]
+# Standalone pytest config for ``task agent-auth:test`` (driven by
+# ``scripts/pkg-test.sh agent-auth``). When pytest is invoked with a
+# path under ``packages/agent-auth/tests/``, rootdir discovery walks
+# up to this file and uses these options instead of the workspace
+# root's. Only the per-package floor and ``--cov`` selector live
+# here; cross-cutting settings (pythonpath for shared
+# ``agent-auth-common`` imports, the integration plugin) are mirrored
+# minimally because the workspace ``task test`` always runs through
+# the root ``pyproject.toml`` instead.
+addopts = [
+    "-p",
+    "tests_support.integration.plugin",
+    "--import-mode=importlib",
+    "--cov=agent_auth",
+    "--cov=agent_auth_notifier",
+    "--cov-branch",
+    "--cov-report=term-missing",
+    "--cov-fail-under=78",
+]
+pythonpath = [
+    # keep-sorted start
+    "../agent-auth-common/src",
+    "src",
+    # keep-sorted end
+]
+testpaths = ["tests"]

--- a/packages/gpg-backend-cli-host/pyproject.toml
+++ b/packages/gpg-backend-cli-host/pyproject.toml
@@ -28,3 +28,21 @@ fallback_version = "0.0.0+unknown"
 
 [tool.uv.sources]
 agent-auth-common = { workspace = true }
+
+[tool.pytest.ini_options]
+# Per-package pytest config. See packages/agent-auth/pyproject.toml
+# for the full rationale.
+addopts = [
+    "--import-mode=importlib",
+    "--cov=gpg_backend_cli_host",
+    "--cov-branch",
+    "--cov-report=term-missing",
+    "--cov-fail-under=58",
+]
+pythonpath = [
+    # keep-sorted start
+    "../agent-auth-common/src",
+    "src",
+    # keep-sorted end
+]
+testpaths = ["tests"]

--- a/packages/gpg-bridge/pyproject.toml
+++ b/packages/gpg-bridge/pyproject.toml
@@ -29,3 +29,25 @@ fallback_version = "0.0.0+unknown"
 
 [tool.uv.sources]
 agent-auth-common = { workspace = true }
+
+[tool.pytest.ini_options]
+# Per-package pytest config. See packages/agent-auth/pyproject.toml
+# for the full rationale. ``tests/`` is on the pythonpath so the
+# ``gpg_backend_fake`` test fake (run as ``python -m
+# gpg_backend_fake`` by the bridge subprocess in unit tests)
+# resolves as a top-level module from the workspace tree.
+addopts = [
+    "--import-mode=importlib",
+    "--cov=gpg_bridge",
+    "--cov-branch",
+    "--cov-report=term-missing",
+    "--cov-fail-under=62",
+]
+pythonpath = [
+    # keep-sorted start
+    "../agent-auth-common/src",
+    "src",
+    "tests",
+    # keep-sorted end
+]
+testpaths = ["tests"]

--- a/packages/gpg-cli/pyproject.toml
+++ b/packages/gpg-cli/pyproject.toml
@@ -29,3 +29,21 @@ fallback_version = "0.0.0+unknown"
 
 [tool.uv.sources]
 agent-auth-common = { workspace = true }
+
+[tool.pytest.ini_options]
+# Per-package pytest config. See packages/agent-auth/pyproject.toml
+# for the full rationale.
+addopts = [
+    "--import-mode=importlib",
+    "--cov=gpg_cli",
+    "--cov-branch",
+    "--cov-report=term-missing",
+    "--cov-fail-under=53",
+]
+pythonpath = [
+    # keep-sorted start
+    "../agent-auth-common/src",
+    "src",
+    # keep-sorted end
+]
+testpaths = ["tests"]

--- a/packages/things-bridge/pyproject.toml
+++ b/packages/things-bridge/pyproject.toml
@@ -29,3 +29,27 @@ fallback_version = "0.0.0+unknown"
 
 [tool.uv.sources]
 agent-auth-common = { workspace = true }
+
+[tool.pytest.ini_options]
+# Per-package pytest config. See packages/agent-auth/pyproject.toml
+# for the full rationale. ``tests/`` is on the pythonpath so the
+# ``things_client_fake`` test fake (run as ``python -m
+# things_client_fake`` by the bridge subprocess in unit + integration
+# tests) resolves as a top-level module from the workspace tree.
+addopts = [
+    "-p",
+    "tests_support.integration.plugin",
+    "--import-mode=importlib",
+    "--cov=things_bridge",
+    "--cov-branch",
+    "--cov-report=term-missing",
+    "--cov-fail-under=83",
+]
+pythonpath = [
+    # keep-sorted start
+    "../agent-auth-common/src",
+    "src",
+    "tests",
+    # keep-sorted end
+]
+testpaths = ["tests"]

--- a/packages/things-cli/pyproject.toml
+++ b/packages/things-cli/pyproject.toml
@@ -30,3 +30,23 @@ fallback_version = "0.0.0+unknown"
 
 [tool.uv.sources]
 agent-auth-common = { workspace = true }
+
+[tool.pytest.ini_options]
+# Per-package pytest config. See packages/agent-auth/pyproject.toml
+# for the full rationale.
+addopts = [
+    "-p",
+    "tests_support.integration.plugin",
+    "--import-mode=importlib",
+    "--cov=things_cli",
+    "--cov-branch",
+    "--cov-report=term-missing",
+    "--cov-fail-under=67",
+]
+pythonpath = [
+    # keep-sorted start
+    "../agent-auth-common/src",
+    "src",
+    # keep-sorted end
+]
+testpaths = ["tests"]

--- a/packages/things-client-cli-applescript/pyproject.toml
+++ b/packages/things-client-cli-applescript/pyproject.toml
@@ -28,3 +28,23 @@ fallback_version = "0.0.0+unknown"
 
 [tool.uv.sources]
 agent-auth-common = { workspace = true }
+
+[tool.pytest.ini_options]
+# Per-package pytest config. See packages/agent-auth/pyproject.toml
+# for the full rationale.
+addopts = [
+    "-p",
+    "tests_support.integration.plugin",
+    "--import-mode=importlib",
+    "--cov=things_client_applescript",
+    "--cov-branch",
+    "--cov-report=term-missing",
+    "--cov-fail-under=73",
+]
+pythonpath = [
+    # keep-sorted start
+    "../agent-auth-common/src",
+    "src",
+    # keep-sorted end
+]
+testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,12 +113,19 @@ markers = [
     "covers_function(*names): declare which functional-decomposition leaf functions a test exercises (read by `systems-engineering function verify`)",
     "perf_budget: asserts a latency budget documented in design/DESIGN.md § Performance budget. Discoverable as a group via `pytest -m perf_budget`.",
 ]
-# Coverage is gated at a ratcheting floor per
-# .claude/instructions/testing-standards.md. --cov-fail-under is the
-# single lever: never lowered without an explicit justification commit.
-# See CONTRIBUTING.md § "Coverage" for the bump procedure. Integration
-# tests run in a separate CI job and are excluded here — rolling them
-# into the floor would make it flaky on Docker availability.
+# Coverage is gated per-package: each ``packages/<svc>/pyproject.toml``
+# carries its own ``[tool.pytest.ini_options].addopts`` with
+# ``--cov=<package-modules>`` and ``--cov-fail-under=N`` (per
+# .claude/instructions/testing-standards.md and ADR 0036's
+# ratchet rationale). The workspace ``task test`` runs every
+# package's tests in a single pytest session here at the root and
+# emits a unified coverage report (``--cov=packages``), but the
+# floor is enforced afterwards by ``scripts/check-package-coverage.sh``,
+# which queries the same ``.coverage`` database for each package's
+# slice and asserts the per-package ``--cov-fail-under``. This makes
+# the workspace gate fail if **any** package regresses while keeping
+# the per-package ``task <svc>:test`` ratchets authoritative for
+# focused dev loops.
 #
 # ``-p tests_support.integration.plugin`` registers the workspace-wide
 # Docker-backed integration fixtures (image build, agent-auth /
@@ -141,7 +148,6 @@ addopts = [
     "--cov=packages",
     "--cov-branch",
     "--cov-report=term-missing",
-    "--cov-fail-under=74",
 ]
 
 [tool.coverage.run]

--- a/scripts/check-package-coverage.sh
+++ b/scripts/check-package-coverage.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# After a workspace pytest run that produced a unified ``.coverage``
+# database, enforce each package's ``--cov-fail-under`` floor against
+# its slice of the report. Fails the gate as soon as any package
+# regresses, listing every offending package (not just the first).
+#
+# Per-package floors live in each ``packages/<svc>/pyproject.toml``
+# under ``[tool.pytest.ini_options].addopts`` as
+# ``--cov-fail-under=N``. Per-package coverage selectors live in the
+# same addopts as ``--cov=<top-level-module>`` entries; this helper
+# uses those modules to scope ``coverage report --include`` to the
+# package's source tree.
+#
+# Tracked by issue #273 (per-package coverage floors).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_bootstrap_venv.sh
+source "${SCRIPT_DIR}/_bootstrap_venv.sh"
+
+if [[ ! -f .coverage ]]; then
+  echo "check-package-coverage: no .coverage database found in $(pwd)." >&2
+  echo "  Run 'task test' (or 'scripts/test.sh --unit') first." >&2
+  exit 2
+fi
+
+fail=0
+for pkg_dir in packages/*/; do
+  pkg_name="$(basename "${pkg_dir}")"
+  pyproject="${pkg_dir}pyproject.toml"
+  [[ -f "${pyproject}" ]] || continue
+
+  meta="$(
+    uv run --no-sync python3 - "${pyproject}" "${pkg_dir}" <<'PY'
+import sys
+import tomllib
+from pathlib import Path
+
+pyproject_path, pkg_dir = sys.argv[1:3]
+with open(pyproject_path, "rb") as f:
+    cfg = tomllib.load(f)
+addopts = cfg.get("tool", {}).get("pytest", {}).get("ini_options", {}).get("addopts", [])
+if isinstance(addopts, str):
+    addopts = addopts.split()
+floor = ""
+modules: list[str] = []
+i = 0
+while i < len(addopts):
+    arg = addopts[i]
+    if arg.startswith("--cov-fail-under="):
+        floor = arg.split("=", 1)[1]
+    elif arg == "--cov-fail-under" and i + 1 < len(addopts):
+        floor = addopts[i + 1]
+        i += 1
+    elif arg.startswith("--cov="):
+        modules.append(arg.split("=", 1)[1])
+    elif arg == "--cov" and i + 1 < len(addopts):
+        modules.append(addopts[i + 1])
+        i += 1
+    i += 1
+
+# Translate ``--cov=<module>`` entries to file globs under the
+# package's src/ tree so ``coverage report --include`` matches the
+# right files. Skip a package that defines no coverage selectors —
+# it's a library member with no own tests (very rare).
+include_globs: list[str] = []
+src_dir = Path(pkg_dir) / "src"
+for module in modules:
+    module_path = src_dir / module
+    if module_path.is_dir():
+        include_globs.append(f"{module_path}/*")
+print(floor or "")
+print(",".join(include_globs))
+PY
+  )"
+  floor="$(awk 'NR==1' <<<"${meta}")"
+  cov_paths="$(awk 'NR==2' <<<"${meta}")"
+
+  if [[ -z "${floor}" ]]; then
+    echo "check-package-coverage: ${pkg_name} has no --cov-fail-under in pyproject.toml." >&2
+    fail=1
+    continue
+  fi
+  if [[ -z "${cov_paths}" ]]; then
+    echo "check-package-coverage: ${pkg_name} has no resolvable --cov modules in pyproject.toml." >&2
+    fail=1
+    continue
+  fi
+
+  # ``coverage report --fail-under=N --include=<glob1,glob2>`` exits
+  # 2 when the slice falls below the floor. Pass all include globs
+  # as a single comma-separated list (coverage.py treats multiple
+  # ``--include=`` flags as an AND not OR; the comma form is the
+  # documented union).
+  if ! report_output=$(
+    uv run --no-sync coverage report \
+      --fail-under="${floor}" \
+      --include="${cov_paths}" 2>&1
+  ); then
+    echo "check-package-coverage: ${pkg_name} below floor ${floor}%:" >&2
+    printf '  %s\n' "${report_output//$'\n'/$'\n'  }" >&2
+    fail=1
+  else
+    pct=$(grep -E "^TOTAL " <<<"${report_output}" | awk '{print $NF}')
+    echo "check-package-coverage: ${pkg_name} ${pct} (floor ${floor}%)"
+  fi
+done
+
+if [[ "${fail}" -ne 0 ]]; then
+  exit 1
+fi

--- a/scripts/pkg-test.sh
+++ b/scripts/pkg-test.sh
@@ -10,16 +10,14 @@
 # stays package-scoped so each service can be iterated on in
 # isolation. Extra arguments are forwarded to pytest.
 #
-# Coverage is disabled here: the workspace-level --cov-fail-under
-# floor only makes sense over the full suite (see
-# pyproject.toml [tool.pytest.ini_options]). Per-package floors are
-# tracked separately in #273.
-#
-# Until #270 relocates the monolithic tests/ tree into per-package
-# trees, packages/<svc>/tests/ does not yet exist. Rather than making
-# `task <svc>:test` fail on every package, we report the missing
-# directory and exit 0; once #270 lands each package will grow its
-# own tree and the helper becomes authoritative.
+# Each ``packages/<svc>/pyproject.toml`` carries its own
+# ``[tool.pytest.ini_options]`` with ``--cov=src`` and
+# ``--cov-fail-under=N`` (the per-package floor set in #273). Pytest's
+# rootdir discovery resolves to ``packages/<svc>/`` when the test
+# path is under that tree, so those settings load automatically.
+# Integration trees under ``packages/<svc>/tests/integration/`` are
+# excluded — they belong to the Docker-backed run driven by
+# scripts/test.sh.
 
 set -euo pipefail
 
@@ -43,9 +41,17 @@ fi
 
 tests_dir="${pkg_dir}/tests"
 if [[ ! -d "${tests_dir}" ]]; then
-  echo "pkg-test: ${tests_dir}/ does not exist; tests have not been relocated yet (tracked in #270)." >&2
-  echo "pkg-test: skipping. Run scripts/test.sh to exercise the monolithic suite." >&2
+  echo "pkg-test: ${tests_dir}/ does not exist." >&2
+  echo "pkg-test: skipping. Run scripts/test.sh to exercise the workspace suite." >&2
   exit 0
 fi
 
-exec uv run --no-sync pytest "${tests_dir}" --no-cov "$@"
+# Ignore the per-package integration/ subdir if present — those tests
+# need Docker and the workspace-level scripts/test.sh --integration
+# fixtures, not the in-process unit-test ratchet driven by this script.
+ignore_args=()
+if [[ -d "${tests_dir}/integration" ]]; then
+  ignore_args+=("--ignore=${tests_dir}/integration")
+fi
+
+exec uv run --no-sync pytest "${tests_dir}" "${ignore_args[@]}" "$@"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -120,14 +120,22 @@ INTEGRATION_TIMING_OPTS=(
 
 case "${mode}" in
   unit)
-    exec uv run --no-sync pytest "${UNIT_IGNORE_OPTS[@]}" "${UNIT_TEST_PATHS[@]}" "$@"
+    uv run --no-sync pytest "${UNIT_IGNORE_OPTS[@]}" "${UNIT_TEST_PATHS[@]}" "$@"
+    # The workspace pytest run leaves behind a unified ``.coverage``
+    # database; per-package floors are enforced by querying it
+    # afterwards (#273). Skip the gate when extra args are present —
+    # an iterative ``-k <test>`` invocation would deliberately under-
+    # exercise its package's surface.
+    if [[ $# -eq 0 ]]; then
+      exec scripts/check-package-coverage.sh
+    fi
     ;;
   fast)
     # Disable coverage collection: --fast runs a curated smoke subset
-    # that only exercises ~6% of packages/*/src/, so the
-    # --cov-fail-under=74 floor configured in pyproject.toml would
-    # always fail. The floor is measured against --unit (the
-    # authoritative gate).
+    # that only exercises ~6% of packages/*/src/, so the per-package
+    # floors enforced by ``check-package-coverage.sh`` would always
+    # fail. The floor is measured against --unit (the authoritative
+    # gate).
     exec uv run --no-sync pytest --no-cov "${FAST_TESTS[@]}" "$@"
     ;;
   integration)
@@ -145,6 +153,10 @@ case "${mode}" in
     ;;
   all)
     uv run --no-sync pytest "${UNIT_IGNORE_OPTS[@]}" "${UNIT_TEST_PATHS[@]}" "$@"
+    # Same skip-on-extra-args carve-out as the ``unit`` mode.
+    if [[ $# -eq 0 ]]; then
+      scripts/check-package-coverage.sh
+    fi
     exec uv run --no-sync pytest --no-cov "${INTEGRATION_TIMING_OPTS[@]}" "${SERVICE_PATHS[@]}" "$@"
     ;;
 esac

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -1321,16 +1321,19 @@ PY
   echo "verify-standards: mypy and pyright ratchet lists are in sync."
 fi
 
-# pytest-cov coverage floor per
+# Per-package pytest-cov coverage floors per
 # .claude/instructions/testing-standards.md (Coverage) and
-# .claude/instructions/python.md (Tooling: pytest-cov). The
-# deterministic regression check from issue #37:
+# .claude/instructions/python.md (Tooling: pytest-cov), tightened in
+# #273 to per-package floors so a well-tested package can't mask a
+# regression in another:
 #
-#   - pyproject.toml (or pytest.ini) sets --cov-fail-under=<N> in
-#     pytest's addopts (N > 0).
-#   - At least one CI workflow invokes `pytest --cov` (directly or
+#   - Each ``packages/<svc>/pyproject.toml`` sets
+#     ``--cov-fail-under=<N>`` (N > 0) in pytest's addopts.
+#   - At least one CI workflow invokes ``pytest --cov`` (directly or
 #     via a task dispatcher that reaches pytest through pytest.ini
-#     addopts).
+#     addopts) AND runs scripts/check-package-coverage.sh, which
+#     enforces every package's floor against the unified .coverage
+#     database.
 
 coverage_missing=0
 
@@ -1340,11 +1343,16 @@ fail_coverage_check() {
   coverage_missing=1
 }
 
-if ! grep -qE -- "--cov-fail-under=[1-9][0-9]*" <<<"${pyproject_stripped}"; then
-  fail_coverage_check \
-    "pyproject.toml pytest addopts does not set --cov-fail-under=<N>." \
-    "Add '--cov-fail-under=<N>' to [tool.pytest.ini_options].addopts (see .claude/instructions/testing-standards.md Coverage)."
-fi
+shopt -s nullglob
+for pkg_pyproject in packages/*/pyproject.toml; do
+  pkg_stripped="$(strip_comments "${pkg_pyproject}")"
+  if ! grep -qE -- "--cov-fail-under[ =]\"?[1-9][0-9]*" <<<"${pkg_stripped}"; then
+    fail_coverage_check \
+      "${pkg_pyproject} does not set --cov-fail-under=<N> in [tool.pytest.ini_options].addopts." \
+      "Add a per-package floor to addopts (see #273 / .claude/instructions/testing-standards.md Coverage)."
+  fi
+done
+shopt -u nullglob
 
 # The CI gate is satisfied whether pytest is invoked directly (with
 # --cov on the command line) or transitively through `task test`
@@ -1362,7 +1370,7 @@ if [[ ${coverage_missing} -ne 0 ]]; then
   exit 1
 fi
 
-echo "verify-standards: pytest-cov fail-under threshold set in pyproject.toml and gated in CI."
+echo "verify-standards: every packages/<svc>/pyproject.toml carries a --cov-fail-under floor, and CI runs 'task test'."
 
 # CONTRIBUTING.md must exist and contain the four required sections per
 # .claude/instructions/release-and-hygiene.md.


### PR DESCRIPTION
## Summary

- Replaces the single workspace-level `--cov-fail-under=74` with a per-package floor in each `packages/<svc>/pyproject.toml`. Floors set 1 point below each package's currently-measured coverage (per the existing CONTRIBUTING.md ratchet rule): agent-auth 78, agent-auth-common 49, things-bridge 83, things-cli 67, things-client-cli-applescript 73, gpg-bridge 62, gpg-backend-cli-host 58, gpg-cli 53.
- Workspace `task test` keeps a single pytest run for speed but post-checks each package's slice via the new `scripts/check-package-coverage.sh`. A well-tested package can no longer mask a regression in another.
- `task <svc>:test` (driven by `scripts/pkg-test.sh`) inherits each package's `[tool.pytest.ini_options]` so focused dev loops fail on a per-package regression.
- `scripts/verify-standards.sh` rewritten to assert every `packages/<svc>/pyproject.toml` carries a `--cov-fail-under`. CONTRIBUTING.md § Coverage updated for the per-package ratchet procedure.
- `--cov` selectors switched from path-based (`--cov=src`) to module-name based (`--cov=agent_auth`, `--cov=things_bridge`, …) so they resolve regardless of pytest cwd / rootdir. `agent-auth-common` lists every shipped top-level module explicitly so `tests_support` (in `src/` for editable-dev ergonomics, excluded from the wheel) does not get measured.

Closes #273

## Test plan

- [x] Each `task <svc>:test` reports its floor, passes against current coverage.
- [x] Workspace `task test` runs pytest once, emits unified report, then `check-package-coverage.sh` reports every package above its floor.
- [x] `task verify-standards` passes (per-package floor check + workspace coverage gate).
- [x] `task lint`, `task typecheck`, `task format -- --check`, `task reuse-lint` pass.
- [ ] CI green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)