### PR TITLE
fix(test-support): install SIGTERM handler in notifier so compose teardown exits cleanly

### DIFF
--- a/packages/agent-auth-common/src/tests_support/integration/harness/_cluster.py
+++ b/packages/agent-auth-common/src/tests_support/integration/harness/_cluster.py
@@ -30,6 +30,7 @@ Design properties preserved from ``palantir/docker-compose-rule``:
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import subprocess
@@ -463,15 +464,48 @@ class StartedCluster:
             )
 
     def _compose_down(self) -> None:
-        # No ``-t`` here on purpose: the per-service ``stop_grace_period``
+        # Split into ``stop`` → diagnostic capture → ``down`` so a slow
+        # teardown leaves an artefact in CI logs identifying which service
+        # hit the grace ceiling. This is the diagnostic step from #294
+        # (compose_stop sits at the 5 s grace ceiling) — once #294 has a
+        # fix in hand, this can go back to a single ``down`` call.
+        #
+        # No ``-t`` on stop or down: the per-service ``stop_grace_period``
         # in ``docker/docker-compose.yaml`` is the source of truth for the
         # SIGTERM→SIGKILL window, and a CLI ``-t`` would silently override
-        # it. Passing ``-t 30`` here previously masked #154's graceful
-        # shutdown handlers and pushed every teardown to ~30 s — see #288.
-        # ``stop_timeout_seconds`` survives only as the subprocess-level
-        # safety budget below, so a wedged ``docker compose`` can't hang
-        # the harness forever.
-        result = subprocess.run(
+        # it (the original #288 regression). ``stop_timeout_seconds``
+        # survives only as the subprocess-level safety budget on each
+        # subprocess call below, so a wedged ``docker compose`` can't
+        # hang the harness forever.
+        subprocess_timeout = max(60.0, self.stop_timeout_seconds + 30.0)
+
+        stop_result = subprocess.run(
+            [
+                "docker",
+                "compose",
+                *self.file_args(),
+                "--project-name",
+                self.project_name,
+                "stop",
+            ],
+            env=self._subprocess_env(),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=subprocess_timeout,
+        )
+        if stop_result.returncode != 0:
+            _log.warning(
+                "docker compose stop failed for project %r: exit=%d stdout=%r stderr=%r",
+                self.project_name,
+                stop_result.returncode,
+                stop_result.stdout,
+                stop_result.stderr,
+            )
+
+        self._dump_exit_diagnostic()
+
+        down_result = subprocess.run(
             [
                 "docker",
                 "compose",
@@ -486,18 +520,102 @@ class StartedCluster:
             capture_output=True,
             text=True,
             check=False,
-            timeout=max(60.0, self.stop_timeout_seconds + 30.0),
+            timeout=subprocess_timeout,
         )
-        if result.returncode != 0:
+        if down_result.returncode != 0:
             # Log rather than raise — teardown must be best-effort so a
             # failing-down doesn't mask the test's original failure.
             _log.warning(
                 "docker compose down failed for project %r: exit=%d stdout=%r stderr=%r",
                 self.project_name,
-                result.returncode,
-                result.stdout,
-                result.stderr,
+                down_result.returncode,
+                down_result.stdout,
+                down_result.stderr,
             )
+
+    def _dump_exit_diagnostic(self) -> None:
+        """Log per-container exit code and a tail of stderr after ``stop``.
+
+        Diagnostic for #294 — surface which container hit the
+        ``stop_grace_period: 5s`` ceiling on every teardown. Best-effort:
+        any failure here is logged and swallowed so it can't block
+        ``down`` (and mask the test's original failure).
+        """
+        ps_result = subprocess.run(
+            [
+                "docker",
+                "compose",
+                *self.file_args(),
+                "--project-name",
+                self.project_name,
+                "ps",
+                "-a",
+                "--format",
+                "json",
+            ],
+            env=self._subprocess_env(),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30.0,
+        )
+        if ps_result.returncode != 0:
+            _log.warning(
+                "docker compose ps for project %r failed: exit=%d stderr=%r",
+                self.project_name,
+                ps_result.returncode,
+                ps_result.stderr,
+            )
+            return
+
+        # ``docker compose ps --format json`` emits one JSON object per
+        # line (NDJSON) on most CLI versions, but some emit a single
+        # array. Tolerate either shape so the diagnostic survives a
+        # future compose CLI tweak.
+        rows: list[dict[str, object]] = []
+        body = ps_result.stdout.strip()
+        if not body:
+            return
+        if body.startswith("["):
+            try:
+                rows = json.loads(body)
+            except json.JSONDecodeError:
+                rows = []
+        else:
+            for raw in body.splitlines():
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+
+        for row in rows:
+            service = str(row.get("Service") or row.get("Name") or "<unknown>")
+            state = str(row.get("State") or "")
+            exit_code = row.get("ExitCode")
+            _log.info(
+                "compose_stop_diag project=%s service=%s state=%s exit_code=%s",
+                self.project_name,
+                service,
+                state,
+                exit_code,
+            )
+            # Dump a tail of the container's stderr if it didn't exit
+            # cleanly. ``docker compose logs`` returns combined stdout
+            # and stderr; that's good enough — the agent-auth /
+            # things-bridge watchdog ``force-exiting`` line goes to
+            # stderr and should show up here.
+            if exit_code not in (0, "0", None):
+                logs_text = self.logs(service)
+                tail = "\n".join(logs_text.splitlines()[-20:])
+                _log.info(
+                    "compose_stop_diag project=%s service=%s logs_tail=\n%s",
+                    self.project_name,
+                    service,
+                    tail,
+                )
 
     def _save_logs(self) -> None:
         assert self.logs_dir is not None

--- a/packages/agent-auth-common/src/tests_support/integration/plugin.py
+++ b/packages/agent-auth-common/src/tests_support/integration/plugin.py
@@ -97,13 +97,15 @@ NOTIFIER_SIDECAR_URL = "http://notifier:9150/"
 AGENT_AUTH_INTERNAL_PORT = 9100
 
 # Per-test ``compose_stop`` budget (seconds). The compose file pins
-# ``stop_grace_period: 5s`` per service and the agent-auth /
-# things-bridge SIGTERM handlers (#154) drain in ~5 s, so a healthy
-# teardown + docker overhead lands well under this. Set high enough to
-# tolerate a slow CI runner but low enough to catch a regression to
-# 30 s like the one #288 fixed. Wired into the integration plugin's
-# fixture teardowns and asserted in ``pytest_sessionfinish`` below.
-COMPOSE_STOP_BUDGET_SECONDS = 10.0
+# ``stop_grace_period: 5s`` per service; with SIGTERM handlers wired
+# across all three (agent-auth + things-bridge from #154, notifier
+# from #294) every container exits cleanly in well under a second, so
+# a healthy teardown + docker overhead lands at ~1-2 s. The 3 s budget
+# absorbs slow-CI noise without being so loose it would have hidden
+# the original #288 regression (~30 s) or the #294 ceiling (~6 s).
+# Wired into the integration plugin's fixture teardowns and asserted
+# in ``pytest_sessionfinish`` below.
+COMPOSE_STOP_BUDGET_SECONDS = 3.0
 
 
 @dataclass

--- a/packages/agent-auth-common/src/tests_support/notifier/__main__.py
+++ b/packages/agent-auth-common/src/tests_support/notifier/__main__.py
@@ -18,7 +18,17 @@ def main() -> None:
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=9150)
     args = parser.parse_args()
-    run_fixed_notifier(args.host, args.port, approved=(args.mode == "approve"))
+    # ``install_signal_handlers=True`` is critical here: the integration
+    # compose stack runs this entrypoint as PID 1 inside the notifier
+    # container, where the kernel ignores SIGTERM unless the process
+    # explicitly handles it. See the docstring in ``server.py`` and #294
+    # for the diagnostic chain.
+    run_fixed_notifier(
+        args.host,
+        args.port,
+        approved=(args.mode == "approve"),
+        install_signal_handlers=True,
+    )
 
 
 if __name__ == "__main__":

--- a/packages/agent-auth-common/src/tests_support/notifier/server.py
+++ b/packages/agent-auth-common/src/tests_support/notifier/server.py
@@ -7,7 +7,10 @@
 from __future__ import annotations
 
 import json
+import signal
+import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from socketserver import BaseServer
 from typing import Any
 
 
@@ -34,12 +37,59 @@ def _make_handler(decision: dict[str, Any]) -> type[BaseHTTPRequestHandler]:
     return _FixedHandler
 
 
-def run_fixed_notifier(host: str, port: int, approved: bool) -> None:
+def install_shutdown_handler(server: BaseServer) -> None:
+    """Install SIGTERM / SIGINT handlers that kick ``serve_forever`` out.
+
+    Only safe to call from the main thread of the main interpreter
+    (``signal.signal`` raises ``ValueError`` elsewhere). The
+    ``python -m tests_support.notifier`` entrypoint enables it via
+    ``run_fixed_notifier(..., install_signal_handlers=True)``; in-process
+    callers (the unit tests) leave it off so signal-handler installation
+    never grabs pytest's main thread.
+
+    The handler is required because ``python -m tests_support.notifier``
+    runs as PID 1 inside the integration-test compose container. The
+    Linux kernel treats PID 1 specially: signals with no installed
+    handler are silently *ignored* — not default-action, despite the
+    C-level ``SIG_DFL`` semantics for non-PID-1 processes. Without
+    this handler, ``docker compose stop`` waits the full
+    ``stop_grace_period`` and SIGKILLs the container at the boundary,
+    which produced the consistent ~6 s teardown ceiling diagnosed in
+    #294 (every notifier instance exited 137).
+
+    Calling ``server.shutdown()`` from the signal-handler frame would
+    deadlock against ``serve_forever`` (the same caveat that drives
+    ``packages/agent-auth/src/agent_auth/server.py``'s handler), so we
+    dispatch it onto a daemon thread and let the main thread keep
+    spinning until ``serve_forever`` returns.
+    """
+
+    def _handle(_signum: int, _frame: object) -> None:
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    signal.signal(signal.SIGTERM, _handle)
+    signal.signal(signal.SIGINT, _handle)
+
+
+def run_fixed_notifier(
+    host: str,
+    port: int,
+    approved: bool,
+    *,
+    install_signal_handlers: bool = False,
+) -> None:
     """Serve a notifier that returns the same decision on every POST.
 
     Blocks until interrupted. The decision body is deliberately the
     minimum the wire protocol requires so tests don't accidentally
     couple to optional fields the server may add later.
+
+    Pass ``install_signal_handlers=True`` only when running this on the
+    main thread of the main interpreter (e.g. the
+    ``python -m tests_support.notifier`` script entrypoint). The
+    in-process unit tests start the notifier from a daemon thread and
+    pass the default (``False``) — installing signal handlers there
+    would raise ``ValueError`` from ``signal.signal``.
     """
     decision = {"approved": approved, "grant_type": "once"}
     handler = _make_handler(decision)
@@ -50,6 +100,8 @@ def run_fixed_notifier(host: str, port: int, approved: bool) -> None:
         f"tests_support.notifier {mode} listening on http://{host}:{bound}",
         flush=True,
     )
+    if install_signal_handlers:
+        install_shutdown_handler(server)
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/packages/agent-auth-common/tests/test_integration_harness.py
+++ b/packages/agent-auth-common/tests/test_integration_harness.py
@@ -555,14 +555,76 @@ def test_compose_down_does_not_pass_explicit_timeout_flag(tmp_path, monkeypatch)
 
     cluster.stop(test_failed=False)
 
+    for call in recorder.calls:
+        argv = call.args
+        if "stop" in argv or "down" in argv:
+            assert "-t" not in argv, (
+                f"docker compose argv contains -t, which overrides the "
+                f"compose-file stop_grace_period. argv={argv!r}"
+            )
     down_call = next(call for call in recorder.calls if "down" in call.args)
-    assert "-t" not in down_call.args, (
-        f"docker compose down argv contains -t, which overrides the "
-        f"compose-file stop_grace_period. argv={down_call.args!r}"
-    )
     # Sanity: the rest of the down shape is still what the harness needs.
     assert "-v" in down_call.args
     assert "--remove-orphans" in down_call.args
+
+
+def test_stop_runs_compose_stop_then_diagnostic_then_down(tmp_path, monkeypatch):
+    """#294 diagnostic: split into ``stop`` → ``ps`` → ``down`` so a slow
+    teardown leaves an artefact identifying which container hit the
+    grace ceiling. The order matters — ``ps`` must come AFTER ``stop``
+    (so exit codes reflect the SIGTERM-handler outcome) and BEFORE
+    ``down`` (after which containers are removed and ``ps`` returns
+    nothing).
+    """
+    cluster = _make_started_cluster(tmp_path)
+    recorder = _SubprocessRecorder(lambda argv, env: _FakeCompletedProcess(args=argv, returncode=0))
+    monkeypatch.setattr("tests_support.integration.harness._cluster.subprocess.run", recorder)
+
+    cluster.stop(test_failed=False)
+
+    phases = [c.args[c.args.index("--project-name") + 2] for c in recorder.calls]
+    assert phases.index("stop") < phases.index("ps")
+    assert phases.index("ps") < phases.index("down")
+
+
+def test_stop_diagnostic_dumps_exit_codes_for_each_service(tmp_path, monkeypatch, caplog):
+    """Per-container exit code lands on the ``integration.harness`` logger.
+
+    The shape is ``compose_stop_diag service=<name> exit_code=<n>`` so
+    grepping CI logs for ``compose_stop_diag`` after a slow teardown
+    pinpoints the offending service without requiring a uploaded log
+    artefact.
+    """
+    cluster = _make_started_cluster(tmp_path)
+
+    def _handler(argv: list[str], env: dict[str, str] | None) -> _FakeCompletedProcess:
+        if "ps" in argv and "--format" in argv:
+            return _FakeCompletedProcess(
+                args=argv,
+                stdout=(
+                    '{"Service":"agent-auth","State":"exited","ExitCode":0}\n'
+                    '{"Service":"things-bridge","State":"exited","ExitCode":137}\n'
+                ),
+                returncode=0,
+            )
+        if "logs" in argv:
+            return _FakeCompletedProcess(args=argv, stdout="line1\nline2\n", returncode=0)
+        return _FakeCompletedProcess(args=argv, returncode=0)
+
+    monkeypatch.setattr(
+        "tests_support.integration.harness._cluster.subprocess.run",
+        _SubprocessRecorder(_handler),
+    )
+
+    with caplog.at_level("INFO", logger="integration.harness"):
+        cluster.stop(test_failed=False)
+
+    diag_messages = [r.message for r in caplog.records if "compose_stop_diag" in r.message]
+    assert any("service=agent-auth" in m and "exit_code=0" in m for m in diag_messages)
+    assert any("service=things-bridge" in m and "exit_code=137" in m for m in diag_messages)
+    # Logs tail only emitted for non-clean exits — keeps the success path quiet.
+    assert any("logs_tail=" in m and "service=things-bridge" in m for m in diag_messages)
+    assert not any("logs_tail=" in m and "service=agent-auth" in m for m in diag_messages)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agent-auth-common/tests/test_tests_support_notifier.py
+++ b/packages/agent-auth-common/tests/test_tests_support_notifier.py
@@ -12,7 +12,11 @@ OS-assigned port so a regression is caught without a container spin-up.
 from __future__ import annotations
 
 import json
+import os
+import signal
 import socket
+import subprocess
+import sys
 import threading
 import time
 import urllib.request
@@ -67,6 +71,79 @@ def test_approve_notifier_returns_approved_once(approve_notifier):
     result = client.request_approval("fam1", "things:read", "list todos")
     assert result.approved is True
     assert result.grant_type == "once"
+
+
+def test_notifier_subprocess_exits_cleanly_on_sigterm():
+    """#294: ``python -m tests_support.notifier`` must exit on SIGTERM.
+
+    The integration compose stack runs this entrypoint as PID 1 inside
+    its container. The Linux kernel ignores signals for which PID 1
+    has no handler installed (``SIG_DFL`` is *ignore*, not terminate,
+    when the receiver is PID 1), which is why every ``compose_stop``
+    sat at the 5 s ``stop_grace_period`` ceiling before this fix —
+    docker had to SIGKILL the notifier on every test teardown.
+
+    Spawn the script as a real child process, send SIGTERM, and assert
+    it exits with status 0 within a tight budget. A deadlock or a
+    missing handler would tip the test into the wall-time guard rather
+    than letting it slide past unnoticed.
+    """
+    port = _free_port()
+    cmd = [
+        sys.executable,
+        "-m",
+        "tests_support.notifier",
+        "approve",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+    ]
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        # Wait for the notifier to print its ``listening on`` line so
+        # we know the signal handlers have been registered before we
+        # send SIGTERM (signals can arrive earlier, but a ready stdout
+        # line is the minimum guarantee of a stable steady state).
+        deadline = time.monotonic() + 5.0
+        ready = False
+        assert proc.stdout is not None
+        while time.monotonic() < deadline:
+            line = proc.stdout.readline()
+            if not line:
+                time.sleep(0.01)
+                continue
+            if "listening on" in line:
+                ready = True
+                break
+        assert ready, "notifier did not print listening line in 5s"
+
+        signal_at = time.monotonic()
+        os.kill(proc.pid, signal.SIGTERM)
+        # Allow generous headroom on a slow CI runner but stay well
+        # under the 5 s ``stop_grace_period`` so a regression here
+        # surfaces as a test failure, not a SIGKILL after-effect.
+        try:
+            exit_code = proc.wait(timeout=3.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2.0)
+            pytest.fail(
+                "notifier did not exit within 3s of SIGTERM — the "
+                "PID-1-in-container shutdown handler regressed (#294)"
+            )
+        elapsed = time.monotonic() - signal_at
+        assert exit_code == 0, f"notifier exited {exit_code}, expected 0"
+        assert elapsed < 3.0, f"notifier took {elapsed:.2f}s to exit on SIGTERM"
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=2.0)
 
 
 def test_approve_notifier_body_shape_is_minimal():


### PR DESCRIPTION
Closes #294.

## Story

After #288 dropped the harness's ``-t 30`` override and the SIGTERM handlers from #154 took over, every per-test ``compose_stop`` still clustered tightly at ~5.7-6.7 s — the per-service ``stop_grace_period: 5s`` ceiling. The first commit instrumented the harness so we could find out which container was the bottleneck; the second fixes it.

## Diagnostic — first commit (``test(harness): split compose teardown into stop+ps+down``)

The integration plugin's ``save_logs_to`` runs *before* ``compose down``, so shutdown-time stderr (where #154's watchdog ``force-exiting`` line would appear) is never captured. Without per-container exit codes, "compose_stop took 6 s" tells us nothing about which service is the cause.

This commit splits the harness teardown into:

```
docker compose stop      # SIGTERM → grace → SIGKILL
docker compose ps -a     # capture per-container exit codes (still in metadata)
docker compose logs <svc> # tail stderr for any non-clean exit
docker compose down -v   # cleanup; containers already stopped, this just removes
```

Each container's exit code lands on the ``integration.harness`` logger as ``compose_stop_diag service=<name> exit_code=<n>``, with a 20-line stderr tail when the exit code isn't clean. ``0`` = clean SIGTERM exit, ``1`` = #154's watchdog called ``os._exit(1)``, ``137`` = docker SIGKILL at the grace boundary.

CI ran this and the pattern was unambiguous — every test, every project:

```
compose_stop_diag service=agent-auth     exit_code=0
compose_stop_diag service=things-bridge  exit_code=0
compose_stop_diag service=notifier       exit_code=137  ← every single one
```

The diagnostic instrumentation is permanent — a future regression of this class (a service silently failing to handle SIGTERM) will leave the same artefact in CI logs without anyone needing to add tooling first.

## Fix — second commit (``fix(test-support): install SIGTERM handler in notifier``)

The notifier had no SIGTERM handler, on the assumption that Python's default ``SIG_DFL`` would terminate the process. That assumption is wrong when the process is **PID 1 inside a container**: the Linux kernel treats PID 1 specially — signals with no installed handler are silently *ignored*, not default-action. So the notifier sat through SIGTERM until docker SIGKILLed it at the 5 s grace boundary on every teardown. The agent-auth and things-bridge containers don't hit this because they install handlers explicitly via #154.

The fix mirrors the #154 pattern: install SIGTERM/SIGINT handlers in ``run_fixed_notifier`` that dispatch ``server.shutdown()`` onto a daemon thread (calling ``shutdown()`` from the signal frame would deadlock against ``serve_forever``). Handler installation is opt-in via ``install_signal_handlers=True`` so the in-process unit tests, which run the notifier from a daemon thread, can keep calling ``run_fixed_notifier`` directly without tripping ``signal.signal``'s "main thread of the main interpreter only" rule. The script entrypoint at ``__main__.py`` opts in.

A subprocess-level test mirrors the #163 pattern: spawn ``python -m tests_support.notifier`` as a real child, send SIGTERM, assert it exits 0 within 3 s. A regression of the PID-1-in-container shutdown path will tip that test into the wall-time guard rather than sliding past unnoticed.

With all three services now exiting cleanly, ``COMPOSE_STOP_BUDGET_SECONDS`` ratchets from 10 s to 3 s — the 10 s budget added by #288 absorbed the full 5 s grace ceiling that this commit removes. 3 s leaves margin for slow-CI noise without surrendering the regression-detection that lets the gate catch a future #288- or #294-class slowdown before it lands.

## Test plan

- [x] ``./scripts/test.sh --unit`` — all suites pass; per-package coverage floors satisfied.
- [x] ``./scripts/typecheck.sh`` / ``./scripts/lint.sh`` — clean (161 source files).
- [x] New unit test ``test_notifier_subprocess_exits_cleanly_on_sigterm`` confirms the notifier subprocess exits 0 within 3 s of SIGTERM.
- [x] Two new harness tests pin the diagnostic ``stop`` → ``ps`` → ``down`` ordering and the per-service exit-code log shape.
- [x] Existing ``test_compose_down_does_not_pass_explicit_timeout_flag`` widened to assert ``-t`` is absent on **both** ``stop`` and ``down``.
- [ ] CI integration jobs will run end-to-end. Expected: all four slices green; ``compose_stop`` p99 well under the new 3 s budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)