### PR TITLE
feature(ci): changelog YAML schema + PR-time lint

### DIFF
--- a/.github/workflows/changelog-lint.yml
+++ b/.github/workflows/changelog-lint.yml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+name: Changelog Lint
+
+# PR-time enforcement of the changelog/@unreleased/*.yml schema. See
+# scripts/changelog/lint.py for the four checks (file presence, file
+# naming, schema validation, release-as invariant). This is the
+# foundation for #289's release-workflow rewrite (#296).
+#
+# The job name `changelog-lint` is the value the maintainer must add
+# to the `main` branch ruleset's required-check list (this PR cannot
+# update the ruleset itself).
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  changelog-lint:
+    name: changelog-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Need full history so `git diff base...head` resolves and
+          # `git describe --tags` finds the latest vX.Y.Z tag.
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Bootstrap the workspace venv (provides PyYAML for the lint).
+      # `task` would normally trigger this implicitly via a venv-backed
+      # task, but the lint runs as a one-shot Python entrypoint so we
+      # call uv directly.
+      - name: Bootstrap workspace venv
+        env:
+          UV_PROJECT_ENVIRONMENT: .venv-Linux-x86_64
+        run: uv sync --extra dev
+
+      - name: Run changelog lint over PR diff
+        env:
+          UV_PROJECT_ENVIRONMENT: .venv-Linux-x86_64
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: uv run --no-sync python scripts/changelog/lint.py
+
+      - name: Run version_logic + lint unit tests
+        # Tests are gated on every PR rather than nightly because the
+        # lint logic is the only thing standing between malformed
+        # YAML and the release workflow (#296). A regression here
+        # would silently let bad entries land.
+        env:
+          UV_PROJECT_ENVIRONMENT: .venv-Linux-x86_64
+        run: scripts/changelog/test.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -313,6 +313,85 @@ signing are sibling requirements, not the same thing. And
 [DCO sign-off](#dco-sign-off) — legal provenance via `Signed-off-by:`,
 distinct from both conventional-commit format and cryptographic signing.
 
+## Changelog entries (`changelog/@unreleased/*.yml`)
+
+Every PR adds at least one YAML file under `changelog/@unreleased/`
+describing the user-visible change, OR carries the `no changelog`
+label to opt out (typo fixes, internal refactors with no behaviour
+change, etc.). The PR-time
+[`Changelog Lint`](.github/workflows/changelog-lint.yml) workflow
+enforces this on every push. The release workflow (#296, in flight)
+will consume these files, compute the next version, and render
+`CHANGELOG.md` + GitHub Release notes from them — replacing the
+commit-message-derived flow described under
+[Release process](#release-process).
+
+Filename: `pr-<N>-<slug>.yml` where `<N>` is the PR number and
+`<slug>` is a short word-or-two identifier (lowercase letters, digits,
+dashes, underscores). Example: `pr-295-yaml-schema.yml`. Multiple
+files per PR are allowed when the change has more than one logically
+distinct user-visible effect.
+
+Schema (the lint rejects unknown keys, so this is the full surface):
+
+```yaml
+type: feature      # required: feature | improvement | fix | break | deprecation | migration
+feature:           # required: nested key matches `type:` for parser disambiguation
+  description: |   # required: free-text release note. Markdown allowed.
+    First-class line that becomes the bullet in CHANGELOG.md.
+  links:           # optional: extra URLs surfaced in the release notes
+    - https://github.com/aidanns/agent-auth/issues/295
+packages:          # optional: omit for a workspace-wide change
+  - agent-auth
+  - agent-auth-common
+release-as: 1.0.0  # optional: force a specific next version (must be > inferred)
+```
+
+### Picking a `type:`
+
+Mirrors the conventional-commit prefixes used in PR titles. The
+release-impact column is the source of truth in
+`scripts/changelog/version_logic.py` (the lint and the upcoming
+release workflow share it):
+
+| `type:`       | 0.x impact      | 1.x+ impact | Use for                                                            |
+| ------------- | --------------- | ----------- | ------------------------------------------------------------------ |
+| `feature`     | minor           | minor       | New user-visible feature or capability.                            |
+| `improvement` | patch           | patch       | Enhancement to an existing feature.                                |
+| `fix`         | patch           | patch       | Bug fix visible to users.                                          |
+| `break`       | minor (demoted) | major       | Backwards-incompatible change to a user-facing surface.            |
+| `deprecation` | patch           | patch       | Marking a feature deprecated (without removing it yet).            |
+| `migration`   | patch           | patch       | Schema, config, or filesystem migration that requires user action. |
+
+`break` demotes to a minor bump while the project is in the `0.x`
+range (per ADR 0026 § Pre-1.0 behaviour). Force the graduation to
+`1.0.0` with `release-as: 1.0.0` on the breaking change's YAML.
+
+### `packages:` and `release-as:`
+
+- **`packages:`** — list workspace members the change affects. Omit
+  the field for a workspace-wide change. The lint validates each
+  entry against `packages/*/pyproject.toml` `[project].name`. Today
+  every entry contributes to a single workspace-level bump (#275
+  graduates to per-package release trains).
+- **`release-as:`** — set when forcing a specific next version
+  (typically the `1.0.0` graduation). The lint requires the value
+  to be strictly greater than the version inferred from all
+  unreleased entries — equal or lower fails. Multiple entries
+  with conflicting `release-as` values also fail; multiple entries
+  with the same value pass (idempotent agreement).
+
+### Authoring path
+
+Hand-write the YAML for now and commit it alongside the diff. A
+scaffolding helper (`task changelog-add`) lands in #297; bot-mediated
+authoring via `==CHANGELOG_MSG==` markers in the PR body lands in
+#298. Both build on the same schema enforced here.
+
+The `no changelog` label opt-out skips the file-presence check but
+schema validation still runs over any files that *are* present, so
+an opt-out PR can't sneak in malformed YAML.
+
 ## Release process
 
 Two release paths exist:

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -60,3 +60,12 @@ SPDX-License-Identifier = "MIT"
 path = "uv.lock"
 SPDX-FileCopyrightText = "2026 Aidan Nagorcka-Smith"
 SPDX-License-Identifier = "MIT"
+
+# changelog/@unreleased/.gitkeep is an empty placeholder that materialises
+# the directory consumed by .github/workflows/changelog-lint.yml and the
+# upcoming release workflow (#296). An inline SPDX comment would defeat
+# the "empty placeholder" purpose, so the licensing metadata lives here.
+[[annotations]]
+path = "changelog/@unreleased/.gitkeep"
+SPDX-FileCopyrightText = "2026 Aidan Nagorcka-Smith"
+SPDX-License-Identifier = "MIT"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -41,6 +41,11 @@ tasks:
     cmds:
       - scripts/test.sh {{.CLI_ARGS}}
 
+  changelog:test:
+    desc: Run the unit tests for the workspace-level changelog tooling under scripts/changelog/. Kept separate from `task test` so the workspace coverage gate stays scoped to packages/*/src/.
+    cmds:
+      - scripts/changelog/test.sh {{.CLI_ARGS}}
+
   benchmark:
     desc: Run the pytest-benchmark suite under packages/agent-auth/benchmarks/. See packages/agent-auth/benchmarks/README.md for the regression threshold and baseline refresh procedure.
     cmds:

--- a/changelog/@unreleased/pr-303-yaml-schema-lint.yml
+++ b/changelog/@unreleased/pr-303-yaml-schema-lint.yml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+type: feature
+feature:
+  description: |
+    Introduce the file-per-change YAML schema for `changelog/@unreleased/`
+    entries and a PR-time CI lint that enforces file presence, naming,
+    schema validity, and the `release-as` invariant. Foundation for the
+    upcoming release workflow rewrite.
+  links:
+    - https://github.com/aidanns/agent-auth/issues/295
+    - https://github.com/aidanns/agent-auth/pull/303

--- a/plans/changelog-yaml-schema-issue-295.md
+++ b/plans/changelog-yaml-schema-issue-295.md
@@ -1,0 +1,266 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# Plan: Changelog YAML Schema + CI Lint (#295)
+
+Closes #295. Sub-issue of #289 (clean PR-to-commit + release flow).
+
+## Summary
+
+Introduce a file-per-change YAML schema under `changelog/@unreleased/`
+that future PRs author and the upcoming release workflow consumes.
+Land the supporting building blocks now so dependent sub-issues
+(#296 release workflow, #297 CLI helper, #298 bot-mediated authoring)
+have a stable surface to bind against:
+
+1. A shared `version_logic` library — bump table, version inference,
+   and `release-as` validation. Co-owned by the lint here and by the
+   release workflow in #296.
+2. A CI lint that runs on every PR (`pull_request: opened, synchronize`)
+   and enforces file presence, naming, schema validity, type validity,
+   packages validity, and the `release-as` invariant. Documented in
+   the PR body so the maintainer can register it as a required check
+   on the `main` ruleset post-merge.
+3. The empty `changelog/@unreleased/` directory (`.gitkeep`).
+4. A short CONTRIBUTING.md section on hand-authoring the YAML.
+
+## Out of scope (deferred to other sub-issues)
+
+- The release workflow that consumes the YAML (#296).
+- The `task changelog-add` CLI helper (#297).
+- Bot-mediated authoring via `==CHANGELOG_MSG==` markers (#298).
+- Decommissioning `@semantic-release/*` and `.releaserc.mjs` (handled
+  by #296 once the release workflow lands).
+
+## Design verification
+
+No new ADR — this PR implements the schema decided in #289's design
+section and the type → bump mapping spelled out in the issue body.
+The ADR for the overall flow lives with the umbrella issue (#289)
+and the ADR for the release-workflow plumbing belongs to #296.
+
+Decisions captured here:
+
+- **Schema versioning** — defer the Palantir `.v2.yml` filename
+  suffix until a real schema break appears. Single-version schema
+  for now; future migration writes a sibling `.v2.yml` and a
+  migrator. Recorded in the issue.
+- **`packages:` field** — parsed and validated against the workspace
+  member set, but not yet load-bearing. Single-train versioning
+  means every entry contributes to one workspace-level bump.
+  Capturing the field now avoids a schema migration when #275
+  graduates to per-package release trains.
+- **`scripts/changelog/version_logic.py` over a workspace package** —
+  the issue suggests "or similar" and explicitly prefers a script
+  if there's no other consumer in `packages/`. The release workflow
+  (#296) and the CLI helper (#297) will both invoke it; both run
+  outside the per-package src/test boundary; promoting it to a full
+  workspace package would force a `[project]` block, version pin,
+  and dep-graph entry for what is essentially a tooling library.
+  Live under `scripts/changelog/` with its own `tests/` tree, mirroring
+  the existing `scripts/verify_workspace_deps.py` precedent.
+- **PyYAML availability** — already pulled in transitively via the
+  workspace lockfile; the lint can `import yaml`. No new dependency
+  needed.
+
+## Implementation
+
+### `scripts/changelog/`
+
+```text
+scripts/changelog/
+  __init__.py
+  version_logic.py
+  lint.py
+  tests/
+    __init__.py
+    conftest.py
+    test_version_logic.py
+    test_lint.py
+```
+
+- `version_logic.py` — public API:
+  - `BumpType` enum: `MAJOR | MINOR | PATCH | NONE`.
+  - `EntryType` enum (the six allowed values).
+  - `ChangelogEntry` dataclass with `entry_type`, `description`,
+    `links`, `packages`, `release_as`, plus a `source_path` for
+    error provenance.
+  - `parse_entry_file(path: Path) -> ChangelogEntry` — reads, parses,
+    and validates a single YAML file. Raises `ChangelogValidationError`
+    with `path` + `field` + reason on any deviation.
+  - `bump_for(entry_type: EntryType, current_version: Version) -> BumpType`
+    — single source of truth for the bump table.
+  - `infer_next_version(current_version: str, entries: list[ChangelogEntry]) -> str`
+    — applies the largest implied bump; respects the demote-to-minor
+    rule when `current_version` is in the 0.x range.
+  - `validate_release_as(entries: list[ChangelogEntry], current_version: str) -> None`
+    — raises on conflicting `release-as` values across files; raises
+    when a `release-as` is `<= infer_next_version(...)` ignoring overrides.
+  - Module docstring documents the public API for downstream callers.
+- `lint.py` — CLI driver invoked from the GitHub Action. Reads the
+  PR number, head SHA, base SHA from env (or argv), enumerates added
+  files via `git diff --name-only --diff-filter=A <base>...<head>`,
+  applies the four checks from the issue, and exits non-zero with a
+  human-readable error per failure (path + field + reason).
+
+### `changelog/@unreleased/.gitkeep`
+
+Empty file with no SPDX header (its function is to materialise the
+directory; the surrounding REUSE annotation block carries the
+licensing override). REUSE.toml gets an entry covering
+`changelog/@unreleased/.gitkeep`.
+
+### `.github/workflows/changelog-lint.yml`
+
+`pull_request: types: [opened, synchronize, reopened]` (mirrors the
+DCO workflow's trigger set). Single job:
+
+- Checks out the PR head with `fetch-depth: 0` so `git diff` against
+  `base.sha` resolves.
+- Sets up Python (uses the project's setup-toolchain composite action
+  for consistency, even though only `python3` + the stdlib + `yaml`
+  are needed; `pyyaml` is already present via the workspace venv).
+- Runs `python scripts/changelog/lint.py` with PR metadata in env
+  vars: `PR_NUMBER`, `PR_LABELS`, `BASE_SHA`, `HEAD_SHA`.
+- Fails with annotations on any error.
+
+The label-based bypass: if the PR carries `no changelog`, the file
+presence check is skipped but schema validation still runs over any
+files that *are* present (so an opt-out PR can't sneak in malformed
+YAML).
+
+### CONTRIBUTING.md
+
+New section under "Commit conventions" titled
+"Changelog entries (`changelog/@unreleased/*.yml`)" covering:
+
+- The schema with a worked example.
+- The six `type:` values and what each means.
+- When to use `packages:` and when to omit it.
+- When to use `release-as:` and when not to.
+- The `no changelog` label opt-out.
+- Pointer that #297 will add a `task changelog-add` helper.
+
+### Not changing yet
+
+- `.releaserc.mjs` keeps its `releaseRules`. The new `version_logic`
+  library mirrors the table independently — this PR doesn't touch
+  the existing release workflow. #296 retires `@semantic-release/*`
+  and `.releaserc.mjs` together.
+- No new task in `Taskfile.yml` for the lint itself — it runs in CI
+  off `pull_request:` events. The `version_logic` module is callable
+  via `python -m scripts.changelog.lint` from the worktree if a
+  contributor wants to dry-run locally.
+
+## Tests
+
+Per `.claude/instructions/testing-standards.md` "Tests exercise public
+APIs only" — write tests against `parse_entry_file`,
+`infer_next_version`, `validate_release_as`, and the `lint.py` CLI's
+argv/exit-code surface. Do not reach into private parser state.
+
+`scripts/changelog/tests/test_version_logic.py`:
+
+- One test per row of the bump table (six rows × the shape of the
+  table).
+- The 0.x demote-to-minor rule for `break`.
+- `infer_next_version` aggregating multiple entries (largest bump wins).
+- `validate_release_as` happy path: single override > inferred, returns
+  cleanly.
+- `validate_release_as` failure: override `<=` inferred (boundary cases
+  `==` and `<`).
+- `validate_release_as` failure: two files with conflicting overrides.
+- `validate_release_as` happy path: two files with the same override
+  (idempotent agreement passes).
+- Parser tests: required fields, type/nested-key mismatch, unknown
+  type, unknown package, malformed YAML — each produces a
+  `ChangelogValidationError` whose message names the file and field.
+
+`scripts/changelog/tests/test_lint.py`:
+
+- File-presence check — passes when at least one matching file is in
+  the diff; fails otherwise; bypassed by `no changelog` label.
+- Filename `pr-<N>-*.yml` regex with `<N>` matching the PR number.
+- Schema lint over multiple files — first failure stops the run with
+  a clear message.
+- `release-as` lint integration — wires through to the version_logic
+  validator with a current-tag fixture.
+
+These tests need to run with the project's pytest collection. Two
+options: (a) move them under an existing package's tests/ tree, or
+(b) add `scripts/changelog/tests/` to `pyproject.toml` `pythonpath`
+
+- `scripts/test.sh` UNIT_TEST_PATHS. Pick (b) — keeps the
+  script self-contained alongside its source and matches the
+  `scripts/verify_workspace_deps.py` pattern (its tests live under
+  `tests/test_verify_workspace_deps.py` because there was no
+  `scripts/tests/`; adding the convention here is the cleaner path).
+
+If pytest collection from outside `packages/*/tests/` proves to need
+larger plumbing changes (`scripts/check-package-coverage.sh` walks
+`packages/*/pyproject.toml`), fall back to placing the tests under
+an existing tests tree and document the indirection. Coverage on
+the `scripts/changelog/` tree itself is out of scope for the
+per-package floors — these are tooling scripts, not shipped service
+code.
+
+**Update during implementation:** keeping `scripts/changelog/tests/`
+self-contained avoided touching `scripts/check-package-coverage.sh`
+and the per-package pytest configs. The tests run via a dedicated
+`task changelog:test` invocation from `scripts/changelog/test.sh`,
+mirrored as a CI job in `.github/workflows/changelog-lint.yml`.
+This keeps script-tooling tests off the workspace coverage gate
+(no shipped-code measurement) while still gating them on every
+PR. The typecheck gate (`task typecheck`) intentionally scopes
+mypy/pyright to `packages/*/` and the workspace `tests/` tree —
+matching the existing precedent for `scripts/verify_workspace_deps.py`.
+Manually verified `scripts/changelog/version_logic.py` and
+`scripts/changelog/lint.py` clean under `mypy --strict`; pyright
+strict flags `Any`-leakage from `yaml.safe_load`'s untyped return,
+which the existing workspace mypy override (`yaml` →
+`ignore_missing_imports`) deliberately accepts. Bringing
+`scripts/` under the typecheck gate is a sweeping change worth
+its own PR (would also pull in `verify_workspace_deps.py` and
+`design-generate.sh`'s python helpers).
+
+## Required check registration
+
+The new workflow's job name (`changelog-lint`) must be added to the
+`main` branch ruleset's required-check list. This requires repo
+admin and cannot land in this PR — flag it in the PR body for the
+maintainer to flip post-merge.
+
+## Standards review
+
+- **Coding standards** — types annotated, dataclasses used for
+  structured values, enum for the type field, validation function
+  named with a verb.
+- **Service design** — N/A (no service surface). PyYAML uses
+  `safe_load`.
+- **Release and hygiene** — REUSE.toml entry for `.gitkeep`; all new
+  files carry SPDX headers.
+- **Testing** — public-API-only tests; coverage of every bump table
+  row plus the `release-as` boundary cases.
+- **Tooling and CI** — workflow runs the lint; no new tools needed
+  (uses `python3` and stdlib + the already-available `pyyaml` from
+  the workspace venv via `uv run`). New `task changelog:test` task is
+  workspace-specific and intentionally excluded from
+  `verify-standards.sh` REQUIRED_TASKS.
+
+## Acceptance checklist
+
+- [ ] `changelog/@unreleased/.gitkeep` committed.
+- [ ] `scripts/changelog/version_logic.py` with documented public
+  API and unit tests for every bump table row + release-as
+  invariant cases.
+- [ ] `scripts/changelog/lint.py` CLI used by the workflow.
+- [ ] `.github/workflows/changelog-lint.yml` enforcing the four checks.
+- [ ] `CONTRIBUTING.md` section on the YAML schema.
+- [ ] `changelog/@unreleased/pr-<N>-*.yml` for this PR (added once the
+  PR number is known).
+- [ ] Required-check registration documented in PR body.
+- [ ] PR title uses the new Palantir prefix list (`feature(ci): ...`).
+- [ ] DCO sign-off on every commit.

--- a/scripts/changelog/__init__.py
+++ b/scripts/changelog/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Changelog tooling shared by the CI lint and the future release workflow.
+
+See ``version_logic`` for the bump-table / version-inference public API
+that downstream sub-issues (#296 release workflow, #297 CLI helper,
+#298 bot-mediated authoring) bind against.
+"""

--- a/scripts/changelog/lint.py
+++ b/scripts/changelog/lint.py
@@ -1,0 +1,415 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""PR-time lint over ``changelog/@unreleased/*.yml`` entries.
+
+Invoked from ``.github/workflows/changelog-lint.yml`` on every
+``pull_request: opened, synchronize, reopened`` event. The four checks
+mirror #295's acceptance criteria:
+
+1. **File presence** — at least one *added* file under
+   ``changelog/@unreleased/`` matching ``pr-<N>-*.yml``, OR the PR
+   carries the ``no changelog`` label.
+2. **File naming** — every YAML under ``changelog/@unreleased/`` (in
+   the PR diff) matches ``pr-<N>-<slug>.yml`` with ``<N>`` equal to
+   the PR number.
+3. **Schema validation** — every YAML parses, required fields are
+   present, the nested key matches ``type:``, and ``packages:``
+   entries name real workspace members.
+4. **release-as invariant** — any ``release-as`` value is strictly
+   greater than the version inferred from all unreleased YAMLs
+   against the current ``vX.Y.Z`` tag; conflicting values across
+   files fail.
+
+The CLI surface is intentionally thin: it consumes PR metadata from
+env vars (``PR_NUMBER``, ``PR_LABELS``, ``BASE_SHA``, ``HEAD_SHA``,
+``CURRENT_VERSION``) so the workflow YAML only has to forward the
+values it already knows. Local dry-runs can pass them as flags.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+# Keep ``version_logic`` importable both when this file is invoked as a
+# script (``python scripts/changelog/lint.py`` — Python puts the
+# script's directory on sys.path automatically) and when imported from
+# a parent package (``python -m scripts.changelog.lint``). The
+# explicit insert handles the third case: a future caller that imports
+# ``lint`` from another working directory.
+_MODULE_DIR = Path(__file__).resolve().parent
+if str(_MODULE_DIR) not in sys.path:
+    sys.path.insert(0, str(_MODULE_DIR))
+
+from version_logic import (  # noqa: E402  -- after sys.path setup
+    ENTRY_FILENAME_PATTERN,
+    ChangelogEntry,
+    ChangelogValidationError,
+    infer_next_version,
+    parse_entry_file,
+    validate_packages_against_workspace,
+    validate_release_as,
+)
+
+UNRELEASED_DIR = Path("changelog/@unreleased")
+NO_CHANGELOG_LABEL = "no changelog"
+
+
+# Errors are accumulated and reported together so a contributor sees
+# every problem in one CI run, rather than fixing one and waiting for
+# the next failure.
+class LintReport:
+    """Accumulates lint errors so the CLI can exit once with all findings."""
+
+    def __init__(self) -> None:
+        self._errors: list[str] = []
+
+    def fail(self, message: str) -> None:
+        self._errors.append(message)
+
+    def fail_for(self, error: ChangelogValidationError) -> None:
+        self._errors.append(str(error))
+
+    @property
+    def has_errors(self) -> bool:
+        return bool(self._errors)
+
+    def render(self) -> str:
+        return "\n".join(self._errors)
+
+
+def list_workspace_packages(repo_root: Path) -> list[str]:
+    """Return the names of every workspace member under ``packages/``.
+
+    Reads each ``packages/*/pyproject.toml`` ``[project].name`` so the
+    lint stays in sync with the on-disk workspace without a separate
+    allowlist. Skips directories without a ``pyproject.toml``.
+    """
+    import tomllib
+
+    packages_root = repo_root / "packages"
+    if not packages_root.is_dir():
+        return []
+    names: list[str] = []
+    for child in sorted(packages_root.iterdir()):
+        pyproject = child / "pyproject.toml"
+        if not pyproject.is_file():
+            continue
+        with pyproject.open("rb") as handle:
+            data = tomllib.load(handle)
+        project = data.get("project")
+        if not isinstance(project, dict):
+            continue
+        name = project.get("name")
+        if isinstance(name, str):
+            names.append(name)
+    return names
+
+
+def list_added_changelog_files(
+    base_sha: str,
+    head_sha: str,
+    *,
+    repo_root: Path,
+) -> list[Path]:
+    """Return paths added in the PR that live under ``changelog/@unreleased/``.
+
+    Uses ``git diff --diff-filter=A`` so renames and modifications
+    don't count toward the file-presence check — the issue's rule is
+    that a PR must *add* a new entry.
+    """
+    cmd = [
+        "git",
+        "diff",
+        "--name-only",
+        "--diff-filter=A",
+        f"{base_sha}...{head_sha}",
+    ]
+    completed = subprocess.run(
+        cmd,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    paths: list[Path] = []
+    prefix = str(UNRELEASED_DIR) + "/"
+    for line in completed.stdout.splitlines():
+        if not line.strip():
+            continue
+        if line.startswith(prefix) and line.endswith(".yml"):
+            paths.append(repo_root / line)
+    return paths
+
+
+def list_present_changelog_files(repo_root: Path) -> list[Path]:
+    """Return every YAML currently under ``changelog/@unreleased/``.
+
+    Used by the ``release-as`` check, which has to consider all
+    unreleased entries (not just the ones added in this PR).
+    """
+    target = repo_root / UNRELEASED_DIR
+    if not target.is_dir():
+        return []
+    return sorted(p for p in target.iterdir() if p.suffix == ".yml" and p.is_file())
+
+
+def parse_pr_labels(env_value: str | None) -> set[str]:
+    """Parse a comma-separated label list from the workflow env.
+
+    GitHub Actions exposes labels as ``${{ join(github.event.pull_request.labels.*.name, ',') }}``.
+    Empty input yields an empty set.
+    """
+    if not env_value:
+        return set()
+    return {label.strip() for label in env_value.split(",") if label.strip()}
+
+
+def check_file_presence(
+    pr_number: int,
+    added_files: Sequence[Path],
+    labels: Iterable[str],
+    report: LintReport,
+) -> None:
+    """Enforce: at least one matching added file, OR the bypass label."""
+    if NO_CHANGELOG_LABEL in labels:
+        return
+    matching = [path for path in added_files if _filename_matches_pr(path.name, pr_number)]
+    if not matching:
+        report.fail(
+            f"PR #{pr_number}: no changelog entry added under "
+            f"`{UNRELEASED_DIR}/pr-{pr_number}-<slug>.yml`. "
+            f"Add a YAML entry per CONTRIBUTING.md, or apply the "
+            f"`{NO_CHANGELOG_LABEL}` label to bypass."
+        )
+
+
+def check_file_naming(
+    pr_number: int,
+    added_files: Sequence[Path],
+    report: LintReport,
+) -> None:
+    """Enforce: every added YAML matches ``pr-<N>-<slug>.yml`` for *this* PR."""
+    for path in added_files:
+        match = ENTRY_FILENAME_PATTERN.match(path.name)
+        if match is None:
+            report.fail(
+                f"{path}: filename must match `pr-<N>-<slug>.yml` "
+                f"(letters, digits, dashes, underscores in the slug)"
+            )
+            continue
+        embedded_pr = int(match["pr_number"])
+        if embedded_pr != pr_number:
+            report.fail(
+                f"{path}: embedded PR number `{embedded_pr}` does not match "
+                f"the current PR number `{pr_number}`"
+            )
+
+
+def _filename_matches_pr(name: str, pr_number: int) -> bool:
+    match = ENTRY_FILENAME_PATTERN.match(name)
+    if match is None:
+        return False
+    return int(match["pr_number"]) == pr_number
+
+
+def check_schema(
+    files: Sequence[Path],
+    workspace_packages: Sequence[str],
+    report: LintReport,
+) -> list[ChangelogEntry]:
+    """Parse + validate every file. Returns the successfully-parsed entries."""
+    parsed: list[ChangelogEntry] = []
+    for path in files:
+        try:
+            entry = parse_entry_file(path)
+        except ChangelogValidationError as exc:
+            report.fail_for(exc)
+            continue
+        try:
+            validate_packages_against_workspace(entry, workspace_packages)
+        except ChangelogValidationError as exc:
+            report.fail_for(exc)
+            continue
+        parsed.append(entry)
+    return parsed
+
+
+def check_release_as_invariant(
+    entries: Sequence[ChangelogEntry],
+    current_version: str,
+    report: LintReport,
+) -> None:
+    """Run the ``release-as`` validator and surface errors via the report."""
+    try:
+        validate_release_as(entries, current_version)
+    except ChangelogValidationError as exc:
+        report.fail_for(exc)
+
+
+def detect_current_version(repo_root: Path, override: str | None) -> str:
+    """Resolve the current ``vX.Y.Z`` tag.
+
+    ``override`` (from ``--current-version`` or ``$CURRENT_VERSION``)
+    wins; otherwise ``git describe --tags --abbrev=0 --match 'v*.*.*'``
+    is used. Falls back to ``0.0.0`` when no tag exists yet.
+    """
+    if override:
+        return override.lstrip("v")
+    try:
+        completed = subprocess.run(
+            ["git", "describe", "--tags", "--abbrev=0", "--match", "v*.*.*"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return "0.0.0"
+    return completed.stdout.strip().lstrip("v")
+
+
+def run_lint(
+    *,
+    pr_number: int,
+    base_sha: str,
+    head_sha: str,
+    labels: Iterable[str],
+    current_version: str,
+    repo_root: Path,
+) -> LintReport:
+    """Run all four checks. Returns the report; caller decides exit code."""
+    report = LintReport()
+    workspace_packages = list_workspace_packages(repo_root)
+
+    added_files = list_added_changelog_files(base_sha, head_sha, repo_root=repo_root)
+
+    # Check 1: file presence (skipped under the bypass label).
+    check_file_presence(pr_number, added_files, labels, report)
+
+    # Check 2: file naming on every added file.
+    check_file_naming(pr_number, added_files, report)
+
+    # Check 3: schema over the union of (added in this PR) plus
+    # (already present in the directory). The release-as invariant
+    # needs every entry; the schema check catches bad files even
+    # under the `no changelog` label so a bypass PR can't sneak in
+    # malformed YAML.
+    union_files = sorted({*added_files, *list_present_changelog_files(repo_root)})
+    parsed_entries = check_schema(union_files, workspace_packages, report)
+
+    # Check 4: release-as invariant.
+    if parsed_entries:
+        next_version = infer_next_version(current_version, parsed_entries)
+        # Surface the inferred version in CI logs to make the
+        # release-as failure mode self-explanatory.
+        print(
+            f"changelog-lint: current={current_version} "
+            f"inferred-next={next_version} "
+            f"entries={len(parsed_entries)}"
+        )
+        check_release_as_invariant(parsed_entries, current_version, report)
+
+    return report
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Lint changelog/@unreleased/*.yml entries on a PR.",
+    )
+    parser.add_argument(
+        "--pr-number",
+        type=int,
+        default=_env_int("PR_NUMBER"),
+        help="GitHub PR number (default: $PR_NUMBER).",
+    )
+    parser.add_argument(
+        "--base-sha",
+        default=os.environ.get("BASE_SHA", ""),
+        help="Base SHA of the PR (default: $BASE_SHA).",
+    )
+    parser.add_argument(
+        "--head-sha",
+        default=os.environ.get("HEAD_SHA", ""),
+        help="Head SHA of the PR (default: $HEAD_SHA).",
+    )
+    parser.add_argument(
+        "--labels",
+        default=os.environ.get("PR_LABELS", ""),
+        help="Comma-separated PR labels (default: $PR_LABELS).",
+    )
+    parser.add_argument(
+        "--current-version",
+        default=os.environ.get("CURRENT_VERSION", ""),
+        help=(
+            "Current released version (default: $CURRENT_VERSION; "
+            "falls back to `git describe --tags --abbrev=0 --match v*.*.*`)."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=os.environ.get("REPO_ROOT", "."),
+        help="Repository root (default: $REPO_ROOT or `.`).",
+    )
+    return parser.parse_args(argv)
+
+
+def _env_int(name: str) -> int | None:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return None
+    return int(raw)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    if args.pr_number is None:
+        print(
+            "changelog-lint: --pr-number (or $PR_NUMBER) is required",
+            file=sys.stderr,
+        )
+        return 2
+    if not args.base_sha or not args.head_sha:
+        print(
+            "changelog-lint: --base-sha and --head-sha (or $BASE_SHA / $HEAD_SHA) are required",
+            file=sys.stderr,
+        )
+        return 2
+
+    repo_root = Path(args.repo_root).resolve()
+    current_version = detect_current_version(repo_root, args.current_version or None)
+    labels = parse_pr_labels(args.labels)
+
+    report = run_lint(
+        pr_number=args.pr_number,
+        base_sha=args.base_sha,
+        head_sha=args.head_sha,
+        labels=labels,
+        current_version=current_version,
+        repo_root=repo_root,
+    )
+
+    if report.has_errors:
+        # Render each finding as a GitHub Actions error annotation so
+        # they surface in the PR Files Changed view alongside the offending lines.
+        for line in report.render().splitlines():
+            print(f"::error::{line}")
+        print(
+            f"\nchangelog-lint: {len(report.render().splitlines())} "
+            f"error(s); see annotations above.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("changelog-lint: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/changelog/test.sh
+++ b/scripts/changelog/test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Run the unit tests for the workspace-level changelog tooling under
+# scripts/changelog/. Kept self-contained (separate from `task test`)
+# so the workspace coverage gate stays scoped to packages/*/src/ —
+# scripts/changelog/ is tooling code, not shipped service code.
+#
+# Usage:
+#   scripts/changelog/test.sh          # default: scripts/changelog/tests
+#   scripts/changelog/test.sh -- -k x  # extra args forwarded to pytest
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+# shellcheck source=../_bootstrap_venv.sh
+source "${REPO_ROOT}/scripts/_bootstrap_venv.sh"
+
+# `--no-cov` keeps these tests off the workspace `.coverage` database
+# so `scripts/check-package-coverage.sh`'s per-package floors don't
+# pick them up (they aren't under packages/*/src/, but skipping the
+# instrumentation is the safer guard against future drift).
+exec uv run --no-sync pytest --no-cov scripts/changelog/tests "$@"

--- a/scripts/changelog/tests/__init__.py
+++ b/scripts/changelog/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT

--- a/scripts/changelog/tests/conftest.py
+++ b/scripts/changelog/tests/conftest.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Add ``scripts/changelog/`` to ``sys.path`` so tests can import the modules.
+
+The changelog tooling lives outside the ``packages/*/src/`` layout (it
+is a workspace-level script, not a published package), so pytest's
+default discovery doesn't put it on ``sys.path``. Adding it here keeps
+the production code free of the path manipulation.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+CHANGELOG_DIR = Path(__file__).resolve().parent.parent
+if str(CHANGELOG_DIR) not in sys.path:
+    sys.path.insert(0, str(CHANGELOG_DIR))

--- a/scripts/changelog/tests/test_lint.py
+++ b/scripts/changelog/tests/test_lint.py
@@ -1,0 +1,474 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for ``scripts/changelog/lint.py``.
+
+Exercise the public CLI surface (``main`` + ``run_lint``) against
+fixture git repos rather than reaching into private state. ``main`` is
+exercised via argv + exit code; ``run_lint`` is exercised via
+keyword args + report inspection so failure messages can be asserted
+without parsing stderr.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from lint import (
+    NO_CHANGELOG_LABEL,
+    LintReport,
+    detect_current_version,
+    list_added_changelog_files,
+    list_present_changelog_files,
+    list_workspace_packages,
+    main,
+    parse_pr_labels,
+    run_lint,
+)
+
+# --- fixture helpers ---------------------------------------------------------
+
+
+def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> str:
+    """Run ``git`` in ``repo`` with deterministic identity and date config."""
+    base_env = os.environ.copy()
+    base_env.update(
+        {
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+            "GIT_AUTHOR_DATE": "2026-01-01T00:00:00Z",
+            "GIT_COMMITTER_DATE": "2026-01-01T00:00:00Z",
+        }
+    )
+    if env:
+        base_env.update(env)
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        env=base_env,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """Initialise a throwaway git repo with a workspace-shaped layout."""
+    if shutil.which("git") is None:
+        pytest.skip("git not on PATH")
+    _git(tmp_path, "init", "--initial-branch=main")
+    _git(tmp_path, "config", "commit.gpgsign", "false")
+
+    # Minimal workspace layout: two packages so list_workspace_packages
+    # has real names to validate against.
+    for name in ("agent-auth", "agent-auth-common"):
+        pkg_dir = tmp_path / "packages" / name
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "pyproject.toml").write_text(
+            f'[project]\nname = "{name}"\n',
+            encoding="utf-8",
+        )
+
+    (tmp_path / "changelog" / "@unreleased").mkdir(parents=True)
+    (tmp_path / "changelog" / "@unreleased" / ".gitkeep").write_text("", encoding="utf-8")
+
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "init")
+    return tmp_path
+
+
+def _commit_added(repo: Path, relpath: str, content: str, message: str) -> str:
+    target = repo / relpath
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    _git(repo, "add", relpath)
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+# --- list_workspace_packages -------------------------------------------------
+
+
+def test_list_workspace_packages_reads_each_pyproject(repo: Path):
+    names = list_workspace_packages(repo)
+    assert names == ["agent-auth", "agent-auth-common"]
+
+
+def test_list_workspace_packages_returns_empty_when_packages_missing(tmp_path: Path):
+    assert list_workspace_packages(tmp_path) == []
+
+
+# --- list_added_changelog_files ----------------------------------------------
+
+
+def test_list_added_changelog_files_returns_only_added_files(repo: Path):
+    base = _git(repo, "rev-parse", "HEAD")
+    head = _commit_added(
+        repo,
+        "changelog/@unreleased/pr-7-feature.yml",
+        "type: feature\nfeature:\n  description: x.\n",
+        "add changelog entry",
+    )
+    files = list_added_changelog_files(base, head, repo_root=repo)
+    assert [p.name for p in files] == ["pr-7-feature.yml"]
+
+
+def test_list_added_changelog_files_skips_unrelated_paths(repo: Path):
+    base = _git(repo, "rev-parse", "HEAD")
+    head = _commit_added(repo, "scripts/random.txt", "x", "unrelated change")
+    files = list_added_changelog_files(base, head, repo_root=repo)
+    assert files == []
+
+
+# --- list_present_changelog_files --------------------------------------------
+
+
+def test_list_present_changelog_files_lists_only_yml_files(repo: Path):
+    target = repo / "changelog" / "@unreleased"
+    (target / "pr-1-a.yml").write_text("type: fix\nfix:\n  description: x.\n", encoding="utf-8")
+    (target / "README.md").write_text("# notes", encoding="utf-8")
+    paths = list_present_changelog_files(repo)
+    assert [p.name for p in paths] == ["pr-1-a.yml"]
+
+
+# --- parse_pr_labels ---------------------------------------------------------
+
+
+def test_parse_pr_labels_handles_empty_input():
+    assert parse_pr_labels(None) == set()
+    assert parse_pr_labels("") == set()
+    assert parse_pr_labels(",,") == set()
+
+
+def test_parse_pr_labels_strips_and_dedupes():
+    assert parse_pr_labels("a, b, a") == {"a", "b"}
+
+
+# --- detect_current_version --------------------------------------------------
+
+
+def test_detect_current_version_prefers_explicit_override(repo: Path):
+    assert detect_current_version(repo, "v1.2.3") == "1.2.3"
+    assert detect_current_version(repo, "1.2.3") == "1.2.3"
+
+
+def test_detect_current_version_falls_back_to_zero_when_no_tag(repo: Path):
+    assert detect_current_version(repo, None) == "0.0.0"
+
+
+def test_detect_current_version_reads_latest_tag(repo: Path):
+    _git(repo, "tag", "v0.4.2")
+    assert detect_current_version(repo, None) == "0.4.2"
+
+
+# --- run_lint ----------------------------------------------------------------
+
+
+def test_run_lint_passes_for_well_formed_entry(repo: Path):
+    base = _git(repo, "rev-parse", "HEAD")
+    head = _commit_added(
+        repo,
+        "changelog/@unreleased/pr-12-add-thing.yml",
+        "type: feature\nfeature:\n  description: Adds a thing.\n",
+        "add entry",
+    )
+    report = run_lint(
+        pr_number=12,
+        base_sha=base,
+        head_sha=head,
+        labels=set(),
+        current_version="0.4.2",
+        repo_root=repo,
+    )
+    assert not report.has_errors
+
+
+def test_run_lint_fails_when_no_entry_added_and_no_bypass(repo: Path):
+    base = _git(repo, "rev-parse", "HEAD")
+    head = _commit_added(repo, "scripts/random.txt", "x", "unrelated")
+    report = run_lint(
+        pr_number=12,
+        base_sha=base,
+        head_sha=head,
+        labels=set(),
+        current_version="0.4.2",
+        repo_root=repo,
+    )
+    assert report.has_errors
+    assert "no changelog entry" in report.render()
+
+
+def test_run_lint_passes_with_no_changelog_label_bypass(repo: Path):
+    base = _git(repo, "rev-parse", "HEAD")
+    head = _commit_added(repo, "scripts/random.txt", "x", "unrelated")
+    report = run_lint(
+        pr_number=12,
+        base_sha=base,
+        head_sha=head,
+        labels={NO_CHANGELOG_LABEL},
+        current_version="0.4.2",
+        repo_root=repo,
+    )
+    assert not report.has_errors
+
+
+def test_run_lint_fails_when_filename_pr_number_mismatches(repo: Path):
+    base = _git(repo, "rev-parse", "HEAD")
+    head = _commit_added(
+        repo,
+        "changelog/@unreleased/pr-99-mismatch.yml",
+        "type: fix\nfix:\n  description: x.\n",
+        "add",
+    )
+    report = run_lint(
+        pr_number=12,
+        base_sha=base,
+        head_sha=head,
+        labels=set(),
+        current_version="0.4.2",
+        repo_root=repo,
+    )
+    assert report.has_errors
+    rendered = report.render()
+    assert "embedded PR number `99`" in rendered
+    # File-presence check also fires because no PR-12 file exists.
+    assert "no changelog entry" in rendered
+
+
+def test_run_lint_fails_when_filename_does_not_match_pattern(repo: Path):
+    base = _git(repo, "rev-parse", "HEAD")
+    head = _commit_added(
+        repo,
+        "changelog/@unreleased/wrong-name.yml",
+        "type: fix\nfix:\n  description: x.\n",
+        "add",
+    )
+    report = run_lint(
+        pr_number=12,
+        base_sha=base,
+        head_sha=head,
+        labels=set(),
+        current_version="0.4.2",
+        repo_root=repo,
+    )
+    assert report.has_errors
+    assert "filename must match" in report.render()
+
+
+def test_run_lint_fails_on_schema_error_with_path_in_message(repo: Path):
+    base = _git(repo, "rev-parse", "HEAD")
+    head = _commit_added(
+        repo,
+        "changelog/@unreleased/pr-12-bad.yml",
+        "type: nonsense\n",
+        "add",
+    )
+    report = run_lint(
+        pr_number=12,
+        base_sha=base,
+        head_sha=head,
+        labels=set(),
+        current_version="0.4.2",
+        repo_root=repo,
+    )
+    assert report.has_errors
+    rendered = report.render()
+    assert "pr-12-bad.yml" in rendered
+    assert "unknown type" in rendered
+
+
+def test_run_lint_validates_packages_against_workspace_members(repo: Path):
+    base = _git(repo, "rev-parse", "HEAD")
+    head = _commit_added(
+        repo,
+        "changelog/@unreleased/pr-12-bad-pkg.yml",
+        ("type: fix\n" "fix:\n" "  description: x.\n" "packages:\n" "  - imaginary-svc\n"),
+        "add",
+    )
+    report = run_lint(
+        pr_number=12,
+        base_sha=base,
+        head_sha=head,
+        labels=set(),
+        current_version="0.4.2",
+        repo_root=repo,
+    )
+    assert report.has_errors
+    assert "imaginary-svc" in report.render()
+
+
+def test_run_lint_fails_on_release_as_not_strictly_greater(repo: Path):
+    base = _git(repo, "rev-parse", "HEAD")
+    head = _commit_added(
+        repo,
+        "changelog/@unreleased/pr-12-graduate.yml",
+        ("type: feature\n" "feature:\n" "  description: x.\n" "release-as: 0.5.0\n"),
+        "add",
+    )
+    # Inferred = 0.5.0 (FEATURE bumps minor on 0.4.2). Override == inferred fails.
+    report = run_lint(
+        pr_number=12,
+        base_sha=base,
+        head_sha=head,
+        labels=set(),
+        current_version="0.4.2",
+        repo_root=repo,
+    )
+    assert report.has_errors
+    assert "strictly greater" in report.render()
+
+
+def test_run_lint_passes_on_release_as_strictly_greater(repo: Path):
+    base = _git(repo, "rev-parse", "HEAD")
+    head = _commit_added(
+        repo,
+        "changelog/@unreleased/pr-12-graduate.yml",
+        ("type: feature\n" "feature:\n" "  description: x.\n" "release-as: 1.0.0\n"),
+        "add",
+    )
+    report = run_lint(
+        pr_number=12,
+        base_sha=base,
+        head_sha=head,
+        labels=set(),
+        current_version="0.4.2",
+        repo_root=repo,
+    )
+    assert not report.has_errors
+
+
+def test_run_lint_fails_on_conflicting_release_as_across_files(repo: Path):
+    base = _git(repo, "rev-parse", "HEAD")
+    _commit_added(
+        repo,
+        "changelog/@unreleased/pr-12-a.yml",
+        "type: feature\nfeature:\n  description: x.\nrelease-as: 1.0.0\n",
+        "add a",
+    )
+    head = _commit_added(
+        repo,
+        "changelog/@unreleased/pr-12-b.yml",
+        "type: feature\nfeature:\n  description: y.\nrelease-as: 2.0.0\n",
+        "add b",
+    )
+    report = run_lint(
+        pr_number=12,
+        base_sha=base,
+        head_sha=head,
+        labels=set(),
+        current_version="0.4.2",
+        repo_root=repo,
+    )
+    assert report.has_errors
+    assert "conflicting" in report.render()
+
+
+# --- main (CLI) --------------------------------------------------------------
+
+
+def test_main_returns_zero_on_success(repo: Path, monkeypatch: pytest.MonkeyPatch):
+    base = _git(repo, "rev-parse", "HEAD")
+    head = _commit_added(
+        repo,
+        "changelog/@unreleased/pr-12-x.yml",
+        "type: fix\nfix:\n  description: x.\n",
+        "add",
+    )
+    monkeypatch.delenv("PR_LABELS", raising=False)
+    rc = main(
+        [
+            "--pr-number",
+            "12",
+            "--base-sha",
+            base,
+            "--head-sha",
+            head,
+            "--current-version",
+            "0.4.2",
+            "--repo-root",
+            str(repo),
+        ]
+    )
+    assert rc == 0
+
+
+def test_main_returns_one_on_lint_failure(repo: Path, monkeypatch: pytest.MonkeyPatch):
+    base = _git(repo, "rev-parse", "HEAD")
+    head = _commit_added(repo, "scripts/random.txt", "x", "unrelated")
+    monkeypatch.delenv("PR_LABELS", raising=False)
+    rc = main(
+        [
+            "--pr-number",
+            "12",
+            "--base-sha",
+            base,
+            "--head-sha",
+            head,
+            "--current-version",
+            "0.4.2",
+            "--repo-root",
+            str(repo),
+        ]
+    )
+    assert rc == 1
+
+
+def test_main_returns_two_when_pr_number_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.delenv("PR_NUMBER", raising=False)
+    monkeypatch.delenv("PR_LABELS", raising=False)
+    rc = main(
+        [
+            "--base-sha",
+            "deadbeef",
+            "--head-sha",
+            "deadbeef",
+            "--current-version",
+            "0.4.2",
+            "--repo-root",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 2
+
+
+def test_main_returns_two_when_shas_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.delenv("BASE_SHA", raising=False)
+    monkeypatch.delenv("HEAD_SHA", raising=False)
+    monkeypatch.delenv("PR_LABELS", raising=False)
+    rc = main(
+        [
+            "--pr-number",
+            "12",
+            "--current-version",
+            "0.4.2",
+            "--repo-root",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 2
+
+
+# --- LintReport --------------------------------------------------------------
+
+
+def test_lint_report_has_no_errors_when_unused():
+    report = LintReport()
+    assert not report.has_errors
+    assert report.render() == ""
+
+
+def test_lint_report_accumulates_messages():
+    report = LintReport()
+    report.fail("first")
+    report.fail("second")
+    assert report.has_errors
+    assert report.render().splitlines() == ["first", "second"]

--- a/scripts/changelog/tests/test_version_logic.py
+++ b/scripts/changelog/tests/test_version_logic.py
@@ -1,0 +1,365 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for ``scripts/changelog/version_logic.py``.
+
+Public-API only: every test exercises ``parse_entry_file``,
+``bump_for``, ``infer_next_version``, ``validate_release_as``, or
+``validate_packages_against_workspace``. No tests reach into private
+parser state.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from version_logic import (
+    BumpType,
+    ChangelogEntry,
+    ChangelogValidationError,
+    EntryType,
+    apply_release_as,
+    bump_for,
+    infer_next_version,
+    parse_entry_file,
+    validate_packages_against_workspace,
+    validate_release_as,
+)
+
+
+def _entry(
+    entry_type: EntryType = EntryType.FIX,
+    *,
+    release_as: str | None = None,
+    packages: tuple[str, ...] | None = None,
+    source_path: Path | None = None,
+) -> ChangelogEntry:
+    return ChangelogEntry(
+        entry_type=entry_type,
+        description="example",
+        links=(),
+        packages=packages,
+        release_as=release_as,
+        source_path=source_path or Path("changelog/@unreleased/pr-1-fixture.yml"),
+    )
+
+
+# --- bump_for ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("entry_type", "current_version", "expected"),
+    [
+        # 0.x rows (issue's bump table column 1).
+        (EntryType.FEATURE, "0.4.0", BumpType.MINOR),
+        (EntryType.IMPROVEMENT, "0.4.0", BumpType.PATCH),
+        (EntryType.FIX, "0.4.0", BumpType.PATCH),
+        (EntryType.BREAK, "0.4.0", BumpType.MINOR),  # demoted from MAJOR
+        (EntryType.DEPRECATION, "0.4.0", BumpType.PATCH),
+        (EntryType.MIGRATION, "0.4.0", BumpType.PATCH),
+        # 1.x+ rows (issue's bump table column 2).
+        (EntryType.FEATURE, "1.0.0", BumpType.MINOR),
+        (EntryType.IMPROVEMENT, "1.0.0", BumpType.PATCH),
+        (EntryType.FIX, "1.0.0", BumpType.PATCH),
+        (EntryType.BREAK, "1.0.0", BumpType.MAJOR),
+        (EntryType.DEPRECATION, "1.0.0", BumpType.PATCH),
+        (EntryType.MIGRATION, "1.0.0", BumpType.PATCH),
+    ],
+)
+def test_bump_for_returns_bump_per_table_row(
+    entry_type: EntryType, current_version: str, expected: BumpType
+) -> None:
+    assert bump_for(entry_type, current_version) == expected
+
+
+def test_bump_for_demotes_break_to_minor_on_2x_zero_minor():
+    """Even on `2.0.0`, a `break` is MAJOR (no demotion above 0.x)."""
+    assert bump_for(EntryType.BREAK, "2.0.0") == BumpType.MAJOR
+
+
+def test_bump_for_rejects_invalid_current_version():
+    with pytest.raises(ChangelogValidationError):
+        bump_for(EntryType.FIX, "not-a-version")
+
+
+# --- infer_next_version ------------------------------------------------------
+
+
+def test_infer_next_version_picks_largest_bump_across_entries():
+    entries = [
+        _entry(EntryType.FIX),
+        _entry(EntryType.FEATURE),
+        _entry(EntryType.IMPROVEMENT),
+    ]
+    # FEATURE (MINOR) wins.
+    assert infer_next_version("0.4.2", entries) == "0.5.0"
+
+
+def test_infer_next_version_demotes_break_in_zero_x():
+    entries = [_entry(EntryType.BREAK)]
+    assert infer_next_version("0.4.2", entries) == "0.5.0"
+
+
+def test_infer_next_version_break_bumps_major_post_one_x():
+    entries = [_entry(EntryType.BREAK), _entry(EntryType.FIX)]
+    assert infer_next_version("1.2.3", entries) == "2.0.0"
+
+
+def test_infer_next_version_returns_current_when_no_entries():
+    assert infer_next_version("0.4.2", []) == "0.4.2"
+
+
+def test_infer_next_version_patch_only_increments_patch():
+    entries = [_entry(EntryType.FIX), _entry(EntryType.IMPROVEMENT)]
+    assert infer_next_version("0.4.2", entries) == "0.4.3"
+
+
+# --- validate_release_as -----------------------------------------------------
+
+
+def test_validate_release_as_passes_when_no_overrides():
+    entries = [_entry(EntryType.FIX)]
+    validate_release_as(entries, "0.4.2")  # does not raise
+
+
+def test_validate_release_as_passes_when_override_strictly_greater():
+    entries = [_entry(EntryType.FIX, release_as="1.0.0")]
+    # Inferred would be 0.4.3; 1.0.0 > 0.4.3.
+    validate_release_as(entries, "0.4.2")
+
+
+def test_validate_release_as_passes_when_overrides_agree():
+    """Same value across multiple files is idempotent agreement, not a conflict."""
+    entries = [
+        _entry(EntryType.FIX, release_as="1.0.0", source_path=Path("pr-1-a.yml")),
+        _entry(EntryType.FEATURE, release_as="1.0.0", source_path=Path("pr-1-b.yml")),
+    ]
+    validate_release_as(entries, "0.4.2")
+
+
+def test_validate_release_as_rejects_override_equal_to_inferred():
+    """Boundary: override == inferred fails (must be strictly greater)."""
+    entries = [_entry(EntryType.FEATURE, release_as="0.5.0")]
+    with pytest.raises(ChangelogValidationError) as exc_info:
+        validate_release_as(entries, "0.4.2")
+    assert "strictly greater" in str(exc_info.value)
+    assert exc_info.value.field == "release-as"
+
+
+def test_validate_release_as_rejects_override_less_than_inferred():
+    entries = [_entry(EntryType.FEATURE, release_as="0.4.3")]
+    with pytest.raises(ChangelogValidationError) as exc_info:
+        validate_release_as(entries, "0.4.2")
+    assert "strictly greater" in str(exc_info.value)
+
+
+def test_validate_release_as_rejects_conflicting_overrides():
+    entries = [
+        _entry(EntryType.FIX, release_as="1.0.0", source_path=Path("pr-1-a.yml")),
+        _entry(EntryType.FIX, release_as="2.0.0", source_path=Path("pr-1-b.yml")),
+    ]
+    with pytest.raises(ChangelogValidationError) as exc_info:
+        validate_release_as(entries, "0.4.2")
+    assert "conflicting" in str(exc_info.value)
+
+
+def test_apply_release_as_returns_inferred_when_no_override():
+    assert apply_release_as("0.5.0", [_entry(EntryType.FEATURE)]) == "0.5.0"
+
+
+def test_apply_release_as_returns_override_when_present():
+    entries = [_entry(EntryType.FEATURE, release_as="1.0.0")]
+    assert apply_release_as("0.5.0", entries) == "1.0.0"
+
+
+# --- parse_entry_file --------------------------------------------------------
+
+
+def _write(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_parse_entry_file_parses_minimal_feature(tmp_path: Path):
+    yaml = """\
+type: feature
+feature:
+  description: New thing.
+"""
+    path = _write(tmp_path / "pr-1-x.yml", yaml)
+    entry = parse_entry_file(path)
+    assert entry.entry_type is EntryType.FEATURE
+    assert entry.description == "New thing."
+    assert entry.links == ()
+    assert entry.packages is None
+    assert entry.is_workspace_wide
+    assert entry.release_as is None
+    assert entry.source_path == path
+
+
+def test_parse_entry_file_parses_full_schema(tmp_path: Path):
+    yaml = """\
+type: break
+break:
+  description: Drops /v0 endpoint.
+  links:
+    - https://github.com/aidanns/agent-auth/pull/100
+packages:
+  - agent-auth
+  - agent-auth-common
+release-as: 1.0.0
+"""
+    path = _write(tmp_path / "pr-100-graduate.yml", yaml)
+    entry = parse_entry_file(path)
+    assert entry.entry_type is EntryType.BREAK
+    assert entry.links == ("https://github.com/aidanns/agent-auth/pull/100",)
+    assert entry.packages == ("agent-auth", "agent-auth-common")
+    assert entry.release_as == "1.0.0"
+    assert not entry.is_workspace_wide
+
+
+def test_parse_entry_file_rejects_missing_type(tmp_path: Path):
+    yaml = """\
+feature:
+  description: x.
+"""
+    path = _write(tmp_path / "pr-1-x.yml", yaml)
+    with pytest.raises(ChangelogValidationError) as exc_info:
+        parse_entry_file(path)
+    assert exc_info.value.field == "type"
+
+
+def test_parse_entry_file_rejects_unknown_type(tmp_path: Path):
+    yaml = """\
+type: cleanup
+cleanup:
+  description: x.
+"""
+    path = _write(tmp_path / "pr-1-x.yml", yaml)
+    with pytest.raises(ChangelogValidationError) as exc_info:
+        parse_entry_file(path)
+    assert exc_info.value.field == "type"
+    assert "unknown type" in str(exc_info.value)
+
+
+def test_parse_entry_file_rejects_type_nested_key_mismatch(tmp_path: Path):
+    yaml = """\
+type: feature
+fix:
+  description: x.
+"""
+    path = _write(tmp_path / "pr-1-x.yml", yaml)
+    with pytest.raises(ChangelogValidationError) as exc_info:
+        parse_entry_file(path)
+    # Either the missing nested `feature:` or the sibling `fix:` collides.
+    assert "feature" in str(exc_info.value)
+
+
+def test_parse_entry_file_rejects_missing_description(tmp_path: Path):
+    yaml = """\
+type: fix
+fix:
+  links:
+    - https://example.com
+"""
+    path = _write(tmp_path / "pr-1-x.yml", yaml)
+    with pytest.raises(ChangelogValidationError) as exc_info:
+        parse_entry_file(path)
+    assert "description" in str(exc_info.value)
+
+
+def test_parse_entry_file_rejects_unknown_top_level_key(tmp_path: Path):
+    yaml = """\
+type: fix
+fix:
+  description: x.
+typo-field: oops
+"""
+    path = _write(tmp_path / "pr-1-x.yml", yaml)
+    with pytest.raises(ChangelogValidationError) as exc_info:
+        parse_entry_file(path)
+    assert "typo-field" in str(exc_info.value)
+
+
+def test_parse_entry_file_rejects_unknown_nested_key(tmp_path: Path):
+    yaml = """\
+type: fix
+fix:
+  description: x.
+  bogus: y
+"""
+    path = _write(tmp_path / "pr-1-x.yml", yaml)
+    with pytest.raises(ChangelogValidationError) as exc_info:
+        parse_entry_file(path)
+    assert "bogus" in str(exc_info.value)
+
+
+def test_parse_entry_file_rejects_empty_packages_list(tmp_path: Path):
+    yaml = """\
+type: fix
+fix:
+  description: x.
+packages: []
+"""
+    path = _write(tmp_path / "pr-1-x.yml", yaml)
+    with pytest.raises(ChangelogValidationError) as exc_info:
+        parse_entry_file(path)
+    assert "packages" in str(exc_info.value)
+    assert "ambiguous" in str(exc_info.value)
+
+
+def test_parse_entry_file_rejects_malformed_release_as(tmp_path: Path):
+    yaml = """\
+type: fix
+fix:
+  description: x.
+release-as: 1.0
+"""
+    path = _write(tmp_path / "pr-1-x.yml", yaml)
+    with pytest.raises(ChangelogValidationError) as exc_info:
+        parse_entry_file(path)
+    assert exc_info.value.field == "release-as"
+
+
+def test_parse_entry_file_rejects_empty_file(tmp_path: Path):
+    path = _write(tmp_path / "pr-1-x.yml", "")
+    with pytest.raises(ChangelogValidationError) as exc_info:
+        parse_entry_file(path)
+    assert "empty" in str(exc_info.value)
+
+
+def test_parse_entry_file_rejects_non_mapping_root(tmp_path: Path):
+    path = _write(tmp_path / "pr-1-x.yml", "- a list at the root\n")
+    with pytest.raises(ChangelogValidationError):
+        parse_entry_file(path)
+
+
+def test_parse_entry_file_rejects_malformed_yaml(tmp_path: Path):
+    # Unbalanced flow-mapping brace — guaranteed to trip yaml.safe_load.
+    path = _write(tmp_path / "pr-1-x.yml", "type: { feature\n")
+    with pytest.raises(ChangelogValidationError) as exc_info:
+        parse_entry_file(path)
+    assert "malformed YAML" in str(exc_info.value)
+
+
+# --- validate_packages_against_workspace -------------------------------------
+
+
+def test_validate_packages_passes_for_workspace_wide_entry():
+    entry = _entry(packages=None)
+    validate_packages_against_workspace(entry, ["agent-auth", "agent-auth-common"])
+
+
+def test_validate_packages_passes_when_all_known():
+    entry = _entry(packages=("agent-auth",))
+    validate_packages_against_workspace(entry, ["agent-auth", "agent-auth-common"])
+
+
+def test_validate_packages_rejects_unknown_member():
+    entry = _entry(packages=("agent-auth", "imaginary-svc"))
+    with pytest.raises(ChangelogValidationError) as exc_info:
+        validate_packages_against_workspace(entry, ["agent-auth", "agent-auth-common"])
+    assert "imaginary-svc" in str(exc_info.value)
+    assert exc_info.value.field == "packages"

--- a/scripts/changelog/version_logic.py
+++ b/scripts/changelog/version_logic.py
@@ -1,0 +1,549 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Changelog YAML schema, bump-table, and version-inference library.
+
+Shared between the PR-time lint (``scripts/changelog/lint.py``) and the
+release workflow (#296). The CLI helper (#297) and the bot-mediated
+authoring path (#298) bind against the same surface.
+
+## Public API
+
+The following names form the stable surface that downstream sub-issues
+import. Renaming or breaking the signatures requires updating those
+sub-issues simultaneously.
+
+### Enums and dataclasses
+
+- ``EntryType`` — the six allowed values of the YAML ``type:`` field
+  (feature, improvement, fix, break, deprecation, migration). String
+  enum so callers can compare against literals.
+- ``BumpType`` — the SemVer bump category implied by an entry on a
+  given current version (none, patch, minor, major).
+- ``ChangelogEntry`` — parsed representation of a single
+  ``changelog/@unreleased/*.yml`` file. Carries the ``source_path``
+  back to the file so error messages can name it.
+- ``ChangelogValidationError`` — every failure in this module raises
+  ``ChangelogValidationError``. The exception carries the offending
+  ``path``, ``field`` (or ``None`` for whole-file failures), and a
+  human-readable ``reason``.
+
+### Functions
+
+- ``parse_entry_file(path: pathlib.Path) -> ChangelogEntry`` — read
+  one YAML file, validate the schema, return a typed entry. Raises
+  ``ChangelogValidationError`` on any deviation.
+- ``bump_for(entry_type: EntryType, current_version: str) -> BumpType``
+  — single source of truth for the type-to-bump mapping. Encodes the
+  0.x demote-to-minor rule.
+- ``infer_next_version(current_version: str, entries: list[ChangelogEntry]) -> str``
+  — apply the largest implied bump across all entries against
+  ``current_version``. Honours ``release-as`` overrides only via
+  ``apply_release_as`` (kept separate so the lint can validate the
+  override against the *unoverridden* inferred version).
+- ``apply_release_as(inferred_version: str, entries: list[ChangelogEntry]) -> str``
+  — return the final release version after applying any ``release-as``
+  override. Assumes ``validate_release_as`` has already passed.
+- ``validate_release_as(entries: list[ChangelogEntry], current_version: str) -> None``
+  — raise ``ChangelogValidationError`` if any ``release-as`` override
+  is ``<=`` the inferred version, or if multiple entries carry
+  conflicting overrides.
+
+The library deliberately rejects parsing ambiguities up front so
+callers get a single failure mode (``ChangelogValidationError``)
+rather than a mix of ``ValueError``, ``KeyError``, ``TypeError``.
+"""
+
+from __future__ import annotations
+
+import enum
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Filename pattern used by both the schema parser and the lint's
+# file-presence/file-naming checks. Captures the PR number so the lint
+# can verify the embedded number matches the PR being scanned.
+ENTRY_FILENAME_PATTERN = re.compile(r"^pr-(?P<pr_number>\d+)-[A-Za-z0-9_-]+\.yml$")
+
+# Workspace member set is informational here — the actual list lives in
+# pyproject.toml ``[tool.uv.workspace]`` and is re-derived by the lint
+# from the on-disk ``packages/`` tree. Keeping the parser unaware of
+# that dynamic list lets us exercise ``parse_entry_file`` in unit tests
+# with arbitrary package names.
+
+_SEMVER_PATTERN = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$")
+
+
+class EntryType(str, enum.Enum):
+    """Allowed values of the YAML ``type:`` field.
+
+    String-valued so YAML literals compare directly: ``EntryType.FEATURE
+    == "feature"`` is ``True``.
+    """
+
+    FEATURE = "feature"
+    IMPROVEMENT = "improvement"
+    FIX = "fix"
+    BREAK = "break"
+    DEPRECATION = "deprecation"
+    MIGRATION = "migration"
+
+
+class BumpType(enum.IntEnum):
+    """SemVer bump category, ordered so ``max(bumps)`` yields the largest."""
+
+    NONE = 0
+    PATCH = 1
+    MINOR = 2
+    MAJOR = 3
+
+
+@dataclass(frozen=True)
+class ChangelogEntry:
+    """Parsed representation of a single ``@unreleased/*.yml`` file.
+
+    The ``source_path`` lets error messages name the offending file
+    when downstream callers (lint, release workflow) aggregate entries
+    across the whole directory.
+    """
+
+    entry_type: EntryType
+    description: str
+    links: tuple[str, ...]
+    packages: tuple[str, ...] | None
+    release_as: str | None
+    source_path: Path
+
+    @property
+    def is_workspace_wide(self) -> bool:
+        """Whether the entry contributes to the workspace-level bump.
+
+        ``packages: None`` (the field was absent) means a workspace-wide
+        change. An explicit empty list is rejected by the parser as
+        ambiguous.
+        """
+        return self.packages is None
+
+
+class ChangelogValidationError(ValueError):
+    """Single failure mode for every parsing / validation deviation.
+
+    Callers format the message with ``str(exc)``; the structured
+    fields (``path``, ``field``, ``reason``) are exposed so the lint
+    can render GitHub annotations with file/line provenance.
+    """
+
+    def __init__(
+        self,
+        path: Path | None,
+        field: str | None,
+        reason: str,
+    ) -> None:
+        self.path = path
+        self.field = field
+        self.reason = reason
+        location = f"{path}" if path is not None else "<input>"
+        if field is not None:
+            location = f"{location}: {field}"
+        super().__init__(f"{location}: {reason}")
+
+
+# --- Bump table ---------------------------------------------------------------
+
+# Source of truth for the type → bump mapping. Mirrors `.releaserc.mjs`
+# `releaseRules` and the table in #295's body. The 0.x demote-to-minor
+# rule for `break` is applied separately in ``bump_for``.
+_BUMP_TABLE_POST_1X: dict[EntryType, BumpType] = {
+    EntryType.FEATURE: BumpType.MINOR,
+    EntryType.IMPROVEMENT: BumpType.PATCH,
+    EntryType.FIX: BumpType.PATCH,
+    EntryType.BREAK: BumpType.MAJOR,
+    EntryType.DEPRECATION: BumpType.PATCH,
+    EntryType.MIGRATION: BumpType.PATCH,
+}
+
+
+def _parse_semver(
+    version: str, *, source: Path | None = None, field_name: str | None = None
+) -> tuple[int, int, int]:
+    """Parse ``X.Y.Z`` into an int triple. Raises ``ChangelogValidationError``."""
+    match = _SEMVER_PATTERN.match(version)
+    if match is None:
+        raise ChangelogValidationError(
+            source,
+            field_name,
+            f"version must be `X.Y.Z` (got {version!r})",
+        )
+    return int(match["major"]), int(match["minor"]), int(match["patch"])
+
+
+def bump_for(entry_type: EntryType, current_version: str) -> BumpType:
+    """Return the bump implied by ``entry_type`` against ``current_version``.
+
+    ``break`` demotes to ``MINOR`` while ``current_version`` is in the
+    ``0.x`` range (per ADR 0026 § Pre-1.0 behaviour and the issue body).
+    """
+    major, _minor, _patch = _parse_semver(current_version)
+    bump = _BUMP_TABLE_POST_1X[entry_type]
+    if major == 0 and bump == BumpType.MAJOR:
+        return BumpType.MINOR
+    return bump
+
+
+def _apply_bump(current: tuple[int, int, int], bump: BumpType) -> tuple[int, int, int]:
+    major, minor, patch = current
+    if bump == BumpType.MAJOR:
+        return (major + 1, 0, 0)
+    if bump == BumpType.MINOR:
+        return (major, minor + 1, 0)
+    if bump == BumpType.PATCH:
+        return (major, minor, patch + 1)
+    return current
+
+
+def infer_next_version(current_version: str, entries: Sequence[ChangelogEntry]) -> str:
+    """Apply the largest bump implied by ``entries`` against ``current_version``.
+
+    Returns the *natural* next version with no ``release-as`` override
+    applied. Use ``apply_release_as`` afterwards to honour overrides
+    (kept separate so the lint can validate ``release-as`` against the
+    unoverridden version, per the issue's "must be strictly greater
+    than the inferred version" rule).
+
+    Raises ``ChangelogValidationError`` if ``current_version`` is not
+    valid SemVer.
+    """
+    current = _parse_semver(current_version)
+    if not entries:
+        return current_version
+    largest = max(bump_for(entry.entry_type, current_version) for entry in entries)
+    if largest == BumpType.NONE:
+        return current_version
+    next_tuple = _apply_bump(current, largest)
+    return f"{next_tuple[0]}.{next_tuple[1]}.{next_tuple[2]}"
+
+
+def _collect_release_as(entries: Iterable[ChangelogEntry]) -> list[ChangelogEntry]:
+    return [entry for entry in entries if entry.release_as is not None]
+
+
+def validate_release_as(
+    entries: Sequence[ChangelogEntry],
+    current_version: str,
+) -> None:
+    """Validate the ``release-as`` invariant across all entries.
+
+    Two failure modes:
+
+    1. **Conflict** — two or more entries carry different
+       ``release-as`` values. The release workflow has no rule to pick
+       between them, so the lint forces the contributor to reconcile.
+    2. **Non-monotonic** — the (agreed) ``release-as`` value is not
+       strictly greater than ``infer_next_version(current_version,
+       entries)`` ignoring the override. A release-as that demotes the
+       implied version is meaningless; an equal value is also rejected
+       so the override always carries semantic intent.
+
+    Idempotent agreement (multiple entries with the same value) passes.
+    """
+    overrides = _collect_release_as(entries)
+    if not overrides:
+        return
+
+    # Check 1: conflicting values.
+    distinct = {entry.release_as for entry in overrides}
+    if len(distinct) > 1:
+        rendered = ", ".join(f"{entry.source_path.name}={entry.release_as}" for entry in overrides)
+        raise ChangelogValidationError(
+            overrides[0].source_path,
+            "release-as",
+            f"conflicting release-as values across entries ({rendered})",
+        )
+
+    # Check 2: monotonic against the natural inferred version.
+    override_value = overrides[0].release_as
+    assert override_value is not None  # narrowed by the branch above
+    inferred = infer_next_version(current_version, list(entries))
+    override_tuple = _parse_semver(
+        override_value,
+        source=overrides[0].source_path,
+        field_name="release-as",
+    )
+    inferred_tuple = _parse_semver(inferred)
+    if override_tuple <= inferred_tuple:
+        raise ChangelogValidationError(
+            overrides[0].source_path,
+            "release-as",
+            (
+                f"release-as {override_value!r} must be strictly greater than "
+                f"the inferred next version {inferred!r}"
+            ),
+        )
+
+
+def apply_release_as(inferred_version: str, entries: Sequence[ChangelogEntry]) -> str:
+    """Return the final version, applying any ``release-as`` override.
+
+    Pre-condition: ``validate_release_as`` has been called with the
+    same entries against the corresponding ``current_version`` and
+    raised nothing — so any override here is known to be greater than
+    ``inferred_version`` and consistent across files.
+    """
+    overrides = _collect_release_as(entries)
+    if not overrides:
+        return inferred_version
+    override_value = overrides[0].release_as
+    assert override_value is not None
+    return override_value
+
+
+# --- YAML parsing -------------------------------------------------------------
+
+_REQUIRED_NESTED_KEYS = {"description"}
+_ALLOWED_NESTED_KEYS = {"description", "links"}
+_ALLOWED_TOP_LEVEL_KEYS = {"type", "packages", "release-as"} | {t.value for t in EntryType}
+
+
+def parse_entry_file(path: Path) -> ChangelogEntry:
+    """Parse one ``changelog/@unreleased/*.yml`` file into a ``ChangelogEntry``.
+
+    Raises ``ChangelogValidationError`` for any deviation: malformed
+    YAML, missing or unknown ``type``, missing/extra nested key,
+    type/nested-key mismatch, malformed ``release-as``, etc.
+    """
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ChangelogValidationError(path, None, f"malformed YAML: {exc}") from exc
+    except OSError as exc:
+        raise ChangelogValidationError(path, None, f"cannot read file: {exc}") from exc
+
+    if raw is None:
+        raise ChangelogValidationError(path, None, "file is empty")
+    if not isinstance(raw, dict):
+        raise ChangelogValidationError(
+            path,
+            None,
+            f"expected a YAML mapping at the top level (got {type(raw).__name__})",
+        )
+
+    # Required: `type:`.
+    type_value = raw.get("type")
+    if type_value is None:
+        raise ChangelogValidationError(path, "type", "required field missing")
+    if not isinstance(type_value, str):
+        raise ChangelogValidationError(
+            path,
+            "type",
+            f"must be a string (got {type(type_value).__name__})",
+        )
+    try:
+        entry_type = EntryType(type_value)
+    except ValueError as exc:
+        allowed = ", ".join(sorted(t.value for t in EntryType))
+        raise ChangelogValidationError(
+            path,
+            "type",
+            f"unknown type {type_value!r}; allowed values: {allowed}",
+        ) from exc
+
+    # Reject unknown top-level keys so typos don't slip through silently.
+    unknown_top_level = set(raw.keys()) - _ALLOWED_TOP_LEVEL_KEYS
+    if unknown_top_level:
+        rendered = ", ".join(sorted(unknown_top_level))
+        raise ChangelogValidationError(
+            path,
+            None,
+            f"unknown top-level keys: {rendered}",
+        )
+
+    # Required: nested key whose name matches `type:`.
+    nested_key = entry_type.value
+    nested_value = raw.get(nested_key)
+    if nested_value is None:
+        raise ChangelogValidationError(
+            path,
+            nested_key,
+            f"required nested key {nested_key!r} missing (matches `type: {nested_key}`)",
+        )
+
+    # The nested key must be the only `EntryType`-named key — multiple
+    # would be ambiguous about which one the parser should read.
+    sibling_type_keys = {t.value for t in EntryType} & set(raw.keys()) - {nested_key}
+    if sibling_type_keys:
+        rendered = ", ".join(sorted(sibling_type_keys))
+        raise ChangelogValidationError(
+            path,
+            None,
+            (
+                f"nested key {nested_key!r} (from `type: {nested_key}`) collides with "
+                f"sibling type-named keys: {rendered}"
+            ),
+        )
+
+    if not isinstance(nested_value, dict):
+        raise ChangelogValidationError(
+            path,
+            nested_key,
+            f"must be a mapping (got {type(nested_value).__name__})",
+        )
+
+    nested_keys = set(nested_value.keys())
+    missing_nested = _REQUIRED_NESTED_KEYS - nested_keys
+    if missing_nested:
+        rendered = ", ".join(sorted(missing_nested))
+        raise ChangelogValidationError(
+            path,
+            f"{nested_key}.{rendered}",
+            "required nested field missing",
+        )
+    unknown_nested = nested_keys - _ALLOWED_NESTED_KEYS
+    if unknown_nested:
+        rendered = ", ".join(sorted(unknown_nested))
+        raise ChangelogValidationError(
+            path,
+            nested_key,
+            f"unknown nested keys: {rendered}",
+        )
+
+    description = nested_value["description"]
+    if not isinstance(description, str) or not description.strip():
+        raise ChangelogValidationError(
+            path,
+            f"{nested_key}.description",
+            "must be a non-empty string",
+        )
+
+    links_raw = nested_value.get("links", [])
+    links = _parse_links(links_raw, path=path, field_name=f"{nested_key}.links")
+
+    packages = _parse_packages(raw.get("packages", _SENTINEL_ABSENT), path=path)
+
+    release_as_raw = raw.get("release-as")
+    release_as = _parse_release_as(release_as_raw, path=path)
+
+    return ChangelogEntry(
+        entry_type=entry_type,
+        description=description,
+        links=links,
+        packages=packages,
+        release_as=release_as,
+        source_path=path,
+    )
+
+
+_SENTINEL_ABSENT = object()
+
+
+def _parse_links(value: Any, *, path: Path, field_name: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ChangelogValidationError(
+            path,
+            field_name,
+            f"must be a list of strings (got {type(value).__name__})",
+        )
+    parsed: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str):
+            raise ChangelogValidationError(
+                path,
+                f"{field_name}[{index}]",
+                f"must be a string (got {type(item).__name__})",
+            )
+        parsed.append(item)
+    return tuple(parsed)
+
+
+def _parse_packages(value: Any, *, path: Path) -> tuple[str, ...] | None:
+    """Parse the optional ``packages:`` field.
+
+    ``None`` (absent) means workspace-wide; an explicit empty list is
+    rejected as ambiguous (use the absent-key form instead).
+    """
+    if value is _SENTINEL_ABSENT or value is None:
+        return None
+    if not isinstance(value, list):
+        raise ChangelogValidationError(
+            path,
+            "packages",
+            f"must be a list of workspace member names (got {type(value).__name__})",
+        )
+    if not value:
+        raise ChangelogValidationError(
+            path,
+            "packages",
+            "explicit empty list is ambiguous; omit the field for workspace-wide entries",
+        )
+    parsed: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item:
+            raise ChangelogValidationError(
+                path,
+                f"packages[{index}]",
+                f"must be a non-empty string (got {item!r})",
+            )
+        parsed.append(item)
+    return tuple(parsed)
+
+
+def _parse_release_as(value: Any, *, path: Path) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ChangelogValidationError(
+            path,
+            "release-as",
+            f"must be a string in `X.Y.Z` form (got {type(value).__name__})",
+        )
+    # Validate the SemVer shape early so downstream callers can rely on it.
+    _parse_semver(value, source=path, field_name="release-as")
+    return value
+
+
+# --- Workspace-aware validation ------------------------------------------------
+
+
+def validate_packages_against_workspace(
+    entry: ChangelogEntry,
+    known_packages: Iterable[str],
+) -> None:
+    """Verify each ``packages:`` entry names a real workspace member.
+
+    Skips the check for workspace-wide entries (``packages: None``).
+    """
+    if entry.packages is None:
+        return
+    known = set(known_packages)
+    unknown = [name for name in entry.packages if name not in known]
+    if unknown:
+        rendered = ", ".join(sorted(unknown))
+        raise ChangelogValidationError(
+            entry.source_path,
+            "packages",
+            f"unknown workspace members: {rendered}",
+        )
+
+
+# Re-exported public surface — keeps the import-from spelling stable
+# even if internals are reshuffled.
+__all__ = [
+    "BumpType",
+    "ChangelogEntry",
+    "ChangelogValidationError",
+    "ENTRY_FILENAME_PATTERN",
+    "EntryType",
+    "apply_release_as",
+    "bump_for",
+    "infer_next_version",
+    "parse_entry_file",
+    "validate_packages_against_workspace",
+    "validate_release_as",
+]


### PR DESCRIPTION
## Summary

Sub-issue of #289. Defines the file-per-change YAML schema for `changelog/@unreleased/` entries and enforces it on every PR. The foundation that the release workflow (#296), CLI helper (#297), and bot-mediated authoring (#298) sub-issues depend on.

- `scripts/changelog/version_logic.py` is the shared library encoding the type-to-bump mapping (mirrors `.releaserc.mjs` `releaseRules`), the 0.x demote-to-minor rule for `break`, and the `release-as` invariant. Public API documented in the module docstring so #296/#297/#298 can wire to it without surprises.
- `scripts/changelog/lint.py` + `.github/workflows/changelog-lint.yml` enforce the four checks from #295: file presence (or `no changelog` label bypass), file naming (`pr-<N>-<slug>.yml`), schema validation (parse + required fields + `type` matches nested key + `packages:` against workspace members), and `release-as` invariant.
- `changelog/@unreleased/.gitkeep` materialises the directory.
- `CONTRIBUTING.md` documents the hand-authoring path.

Closes #295

## Required-check registration (action for maintainer post-merge)

The new workflow's job name is `changelog-lint`. Add it to the `main` branch ruleset's required-check list once this PR merges so PRs without a YAML entry start failing required-check enforcement (today the workflow runs but is advisory).

## Test plan

- [x] `task changelog:test` (new task) — 69 tests covering every row of the bump table, the demote-to-minor rule for `break` on 0.x, the `release-as` boundary cases (`==`, `<`, conflicting), every parser failure mode, and the lint CLI's argv/exit-code surface.
- [x] `task test --unit` — 630 passed; per-package coverage floors satisfied.
- [x] `task lint`, `task format -- --check`, `task typecheck`, `task verify-standards`, `task reuse-lint`, `task check`.
- [x] Manually dry-ran `python scripts/changelog/lint.py` against the local branch to confirm the file-presence check fires when no entry is staged.
- Will follow up with a `changelog/@unreleased/pr-<N>-*.yml` for this PR once the PR number is assigned (the lint will block merge otherwise).

==COMMIT_MSG==
Sub-issue of #289. Adds the file-per-change changelog YAML schema
and the PR-time CI lint that enforces it.

`scripts/changelog/version_logic.py` is the shared library encoding
the type-to-bump mapping (mirrors `.releaserc.mjs` `releaseRules`),
applying the 0.x demote-to-minor rule for `break`, and validating
the `release-as` invariant. Its public API is documented in the
module docstring so the release workflow (#296), CLI helper (#297),
and bot-mediated authoring (#298) sub-issues can bind against a
stable surface.

The lint runs on `pull_request: opened, synchronize, reopened` and
fails any PR that does not add a `changelog/@unreleased/pr-<N>-*.yml`
entry (or carry the `no changelog` label). Schema validation also
runs over present files under the bypass label so an opt-out PR
can't sneak in malformed YAML.

`changelog/@unreleased/.gitkeep` materialises the directory; a new
`task changelog:test` runs the lint and version_logic unit tests
without disturbing the workspace coverage gate.
==COMMIT_MSG==