### PR TITLE
improvement(setup-devcontainer-signing): smoke-test the sign path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -919,32 +919,64 @@ To wire a fresh devcontainer to the host's `gpg-bridge`:
 
    Copy the `access_token` field. It's shown once.
 
-2. **In the devcontainer**, run the setup task with the token and
-   the bridge URL:
+2. **In the devcontainer**, run the setup task with the token, the
+   bridge URL, and the GPG fingerprint git should sign with:
 
    ```bash
    task setup-devcontainer-signing -- \
      --token <ACCESS_TOKEN> \
-     --bridge-url https://host.docker.internal:8443
+     --bridge-url https://host.docker.internal:8443 \
+     --signing-key <FINGERPRINT>
    ```
 
    Optional flags: `--ca-cert-path <PATH>` if the bridge's TLS
    certificate is signed by a CA the container's trust store doesn't
-   include, and `--timeout-seconds <N>` to override the per-request
-   timeout (default 30s).
+   include; `--timeout-seconds <N>` to override the per-request
+   timeout (default 30s); `--skip-smoke` to bypass the post-install
+   end-to-end smoke test (only useful in constrained environments
+   like CI provisioning where the bridge isn't up at install time —
+   the install is unverified, see the smoke-test description below).
+
+   `--signing-key` is optional if the clone already has a local
+   `user.signingkey` set (`git config --local user.signingkey <FP>`); the script reuses that value. Otherwise the smoke test
+   fails because git has no key to sign the trial payload with.
 
 The setup task writes the `gpg-cli` config to
-`$XDG_CONFIG_HOME/gpg-cli/config.yaml` (mode `0600`) and runs two
-`git config --local` calls in the current clone:
+`$XDG_CONFIG_HOME/gpg-cli/config.yaml` (mode `0600`) and runs the
+relevant `git config --local` calls in the current clone:
 
 - `gpg.program = gpg-cli` — git delegates sign / verify to the
   bridge instead of looking for `gpg` on `PATH`.
 - `commit.gpgsign = true` — every `git commit` signs without needing
   `-S`.
+- `user.signingkey = <FINGERPRINT>` — only when `--signing-key`
+  was passed.
 
 Override per-commit with `git -c commit.gpgsign=false commit` when
 you need an unsigned commit (e.g. an in-flight rebase that doesn't
 touch `main`).
+
+After writing config, the script runs an end-to-end **smoke test**
+that fails fast at install time rather than at first `git commit`.
+Probes (in order):
+
+| #   | Probe                          | Failure surfaces as                                                                                                                                                                                                |
+| --- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | `gpg-cli` is on `PATH`         | `probe failed: gpg.program unresolved` — install gpg-cli inside the devcontainer.                                                                                                                                  |
+| 2   | `git config user.signingkey`   | `probe failed: user.signingkey is unset` — re-run with `--signing-key <FP>`.                                                                                                                                       |
+| 3   | bridge URL is reachable        | `probe failed: bridge unreachable at <URL>` — check the bridge is running on the host and the URL is reachable from the container. On Docker Desktop, prefer `host.docker.internal` over `127.0.0.1`.              |
+| 4   | end-to-end trial sign succeeds | gpg-cli exit 3 → token unauthorized; exit 4 → forbidden (token lacks `gpg:sign=allow` or key not in `allowed_signing_keys`); exit 5 → bridge unavailable (often host gpg-agent / `allow-loopback-pinentry` issue). |
+
+Probe 4's failure modes are documented end-to-end in
+`docs/operations/gpg-bridge-host-setup.md`. The smoke test is
+idempotent — re-running the script after a successful run re-runs
+the smoke test against the existing config without rewriting it
+beyond chmod-ing the file back to 0600.
+
+To bypass the smoke test (e.g. in CI provisioning where the bridge
+isn't running at install time), pass `--skip-smoke`. The script
+prints a warning that the install is unverified and exits 0; the
+operator finds out at first `git commit`.
 
 The setup is idempotent — re-running with the same arguments
 overwrites the config file and reasserts the git-config values.

--- a/changelog/@unreleased/pr-336-setup-signing-smoke-test.yml
+++ b/changelog/@unreleased/pr-336-setup-signing-smoke-test.yml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+type: improvement
+improvement:
+  description: |
+    `setup-devcontainer-signing.sh` now runs an end-to-end smoke
+    test before exiting 0. Verifies (1) `gpg-cli` is on PATH, (2)
+    `git config user.signingkey` is set, (3) the bridge URL is
+    reachable, and (4) a trial sign through gpg-cli succeeds —
+    each failure mode prints a named cause and a remediation hint
+    so operators don't discover the breakage at first `git commit`.
+    Adds `--signing-key <FP>` to write `git config --local
+    user.signingkey` and `--skip-smoke` to bypass the probes for
+    constrained environments. New troubleshooting page at
+    `docs/operations/gpg-bridge-host-setup.md`.
+  links:
+    - https://github.com/aidanns/agent-auth/issues/333
+    - https://github.com/aidanns/agent-auth/pull/336

--- a/docs/operations/gpg-bridge-host-setup.md
+++ b/docs/operations/gpg-bridge-host-setup.md
@@ -1,0 +1,153 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# Host-side gpg-bridge setup and troubleshooting
+
+This page is for operators wiring the host's `gpg-bridge` to a
+devcontainer's `gpg-cli`. The architecture is described in
+[ADR 0033](../../design/decisions/0033-gpg-bridge-cli-split.md) and
+the wiring procedure in CONTRIBUTING.md §
+"Signed commits inside the devcontainer". This page focuses on the
+specific failure modes that
+`scripts/setup-devcontainer-signing.sh`'s smoke test surfaces, and
+how to remediate each on the host side.
+
+## Smoke-test failure-mode catalogue
+
+The setup script's smoke test runs four probes. Failures here map
+back to the script's named failure messages (issue #333).
+
+### Probe 3: bridge unreachable
+
+Symptom — the script prints:
+
+```
+setup-devcontainer-signing: probe failed: bridge unreachable at <URL>.
+```
+
+Causes, in rough decreasing order of likelihood:
+
+1. **Bridge not running on the host.** Start it with
+   `task gpg-bridge -- serve`. Confirm it bound a port with
+   `lsof -i -P -n | grep gpg-bridge` or by looking at the bridge's
+   stdout/stderr.
+2. **Wrong URL from the devcontainer's perspective.** Docker
+   Desktop and most container runtimes route the host as
+   `host.docker.internal`. `127.0.0.1` resolves to the
+   container's own loopback, where nothing is listening. Use
+   `host.docker.internal` (or whatever the runtime documents) in
+   `--bridge-url`.
+3. **Bridge bound to a host-only interface.** If the bridge is
+   serving on `127.0.0.1` (the default) but the container reaches
+   it via a Docker bridge network, the connection is refused. Set
+   the bridge's `bind_host` config to `0.0.0.0` (or to the
+   docker-network gateway interface) and restart it.
+4. **TLS handshake failure (`HTTP 000` from curl).** The bridge
+   serves https; if the container can't validate the cert, the
+   request never completes. Pass `--ca-cert-path <PATH>` to the
+   setup script with the CA that signed the bridge cert, or — for
+   self-signed dev certs — copy the cert into the container's
+   trust store and rebuild.
+
+### Probe 4: trial sign — `unauthorized` (gpg-cli exit 3)
+
+Symptom — the script prints:
+
+```
+setup-devcontainer-signing: probe failed: bridge rejected the token (unauthorized).
+setup-devcontainer-signing: mint a new one on the host with 'task agent-auth -- token create --scope gpg:sign=allow --json'.
+```
+
+The token is valid HTTP-wise (the bridge accepted the request) but
+agent-auth rejected it. Common causes:
+
+- **Token expired or revoked.** Mint a fresh one on the host:
+  `task agent-auth -- token create --scope gpg:sign=allow --json`,
+  copy the `access_token` value into a re-run of the setup script.
+- **Token format corrupted in transit.** A misplaced newline or
+  extra whitespace can break the HMAC. Re-paste from the JSON
+  output.
+
+### Probe 4: trial sign — `forbidden` (gpg-cli exit 4)
+
+Symptom — the script prints:
+
+```
+setup-devcontainer-signing: probe failed: bridge accepted the token but denied the request (forbidden).
+setup-devcontainer-signing: causes: token lacks gpg:sign=allow, or signing key <FP> is not in the bridge's allowed_signing_keys list.
+```
+
+Two distinct causes:
+
+- **Token lacks `gpg:sign=allow`.** The token's scopes were
+  scoped narrower at mint time, e.g. `gpg:sign=prompt` (which
+  requires JIT approval, not in scope for an automated devcontainer
+  flow). Re-mint with `--scope gpg:sign=allow`.
+- **Signing key not in `allowed_signing_keys`.** The bridge
+  enforces a per-key allowlist *before* asking agent-auth. Edit
+  the bridge's `config.yaml` `allowed_signing_keys` list to
+  include the fingerprint, then restart the bridge. The
+  fingerprint must match the form gpg uses (typically the long
+  fingerprint, no spaces).
+
+### Probe 4: trial sign — `bridge unavailable` (gpg-cli exit 5)
+
+Symptom — the script prints:
+
+```
+setup-devcontainer-signing: probe failed: bridge unavailable (host gpg-bridge or its backend could not complete the request).
+setup-devcontainer-signing: causes: bridge subprocess timed out, host gpg-agent passphrase prompt blocked, or no 'allow-loopback-pinentry'.
+```
+
+This almost always means the bridge invoked the host `gpg`
+backend, but the backend wedged or timed out. Causes:
+
+- **Host gpg-agent is prompting for a passphrase that nothing can
+  answer.** The bridge runs as a background service, so an
+  interactive pinentry has no terminal to draw on. Add
+  `allow-loopback-pinentry` to `~/.gnupg/gpg-agent.conf` and
+  restart the agent (`gpgconf --kill gpg-agent`). The bridge's
+  backend uses `--pinentry-mode loopback` to feed the passphrase
+  through the agent socket.
+- **Passphrase not cached.** Even with `allow-loopback-pinentry`,
+  the agent needs to know the passphrase. Either pre-warm the
+  cache (sign a dummy payload manually before starting the
+  bridge: `echo | gpg --clearsign > /dev/null`) or move the key
+  to a passphrase-less subkey reserved for signing.
+- **Host `gpg` binary missing.** `command -v gpg` on the host
+  must succeed and resolve to a 2.x binary. Install via
+  `brew install gnupg` on macOS or `apt-get install gnupg2` on
+  Debian/Ubuntu.
+- **Bridge's backend subprocess wedged on stdin.** Tracked in
+  issue #331 — the bridge currently waits the full request
+  timeout before giving up, so a backend that blocks on a
+  passphrase prompt manifests as a 30-second hang. The fail-fast
+  fix shortens this to seconds and surfaces a structured
+  `signing_backend_unavailable` error code; until that lands,
+  this failure mode looks identical to a backend timeout.
+
+## Verifying the host bridge in isolation
+
+If a smoke-test failure isn't obviously a config problem, check
+the bridge's behaviour without the devcontainer in the loop. From
+the host:
+
+```bash
+# Health probe — should return 200 with a {"status":"ok"} body
+# (requires a token with the gpg-bridge:health scope).
+curl -fsS \
+  -H "Authorization: Bearer $(task agent-auth -- token create --scope gpg-bridge:health=allow --json | jq -r .access_token)" \
+  https://127.0.0.1:8443/gpg-bridge/health
+
+# Trial sign — same payload the smoke test uses.
+echo 'host-side smoke test' | gpg -bsau <FP>
+```
+
+If the trial sign hangs from the host as well, the issue is on
+the host side (gpg / gpg-agent / passphrase) and the devcontainer
+wiring is fine. If it succeeds on the host but fails through the
+devcontainer, the issue is in the bridge wiring or in the agent's
+loopback-pinentry config.

--- a/scripts/setup-devcontainer-signing.sh
+++ b/scripts/setup-devcontainer-signing.sh
@@ -11,8 +11,18 @@
 # 0600 permissions, then runs `git config --local` to point git at
 # `gpg-cli` and turn on auto-signing for every commit.
 #
+# After writing the config, runs an end-to-end smoke test that
+# verifies (1) gpg-cli is on PATH, (2) git is configured with a
+# signing-key fingerprint, (3) the bridge URL is reachable, and (4)
+# a trial sign through gpg-cli succeeds. Each failure mode prints a
+# named cause and a remediation hint, and exits non-zero so the
+# operator does not discover the breakage at first `git commit`.
+# Pass `--skip-smoke` to bypass the smoke test (e.g. when the
+# bridge is not yet running, or in CI provisioning).
+#
 # Idempotent: re-running with the same inputs produces the same
-# config file and git-config state.
+# config file and git-config state, and re-runs the smoke test
+# against the existing config.
 #
 # The agent-auth keyring lives on the host, so the bearer token is
 # minted on the host (e.g. `task agent-auth -- token create
@@ -25,8 +35,10 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage: setup-devcontainer-signing.sh --token <TOKEN> --bridge-url <URL> \
+                                     [--signing-key <FP>] \
                                      [--ca-cert-path <PATH>] \
-                                     [--timeout-seconds <N>]
+                                     [--timeout-seconds <N>] \
+                                     [--skip-smoke]
 
 Required:
   --token <TOKEN>          agent-auth access token with the
@@ -36,18 +48,32 @@ Required:
   --bridge-url <URL>       https URL of the host's gpg-bridge.
 
 Optional:
+  --signing-key <FP>       GPG key fingerprint git should sign with.
+                           Written via `git config --local
+                           user.signingkey`. If git already has a
+                           local user.signingkey set, this flag is
+                           optional. Required for the smoke test
+                           when no local user.signingkey exists.
   --ca-cert-path <PATH>    Path to a CA cert that signs the bridge's
                            TLS certificate. Forwarded to gpg-cli.
   --timeout-seconds <N>    Per-request timeout for gpg-cli -> gpg-bridge.
                            Defaults to gpg-cli's built-in default.
+  --skip-smoke             Skip the post-install smoke test. Use only
+                           when the bridge is not reachable at install
+                           time (e.g. CI provisioning); the install is
+                           unverified and the operator finds out at
+                           first `git commit`. See CONTRIBUTING.md §
+                           "Signed commits inside the devcontainer".
   -h | --help              Show this help.
 EOF
 }
 
 token=""
 bridge_url=""
+signing_key=""
 ca_cert_path=""
 timeout_seconds=""
+skip_smoke=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -67,6 +93,14 @@ while [[ $# -gt 0 ]]; do
       bridge_url="$2"
       shift 2
       ;;
+    --signing-key)
+      [[ $# -ge 2 ]] || {
+        echo "setup-devcontainer-signing: --signing-key requires a value." >&2
+        exit 1
+      }
+      signing_key="$2"
+      shift 2
+      ;;
     --ca-cert-path)
       [[ $# -ge 2 ]] || {
         echo "setup-devcontainer-signing: --ca-cert-path requires a value." >&2
@@ -82,6 +116,10 @@ while [[ $# -gt 0 ]]; do
       }
       timeout_seconds="$2"
       shift 2
+      ;;
+    --skip-smoke)
+      skip_smoke=1
+      shift
       ;;
     -h | --help)
       usage
@@ -161,7 +199,171 @@ trap - EXIT
 git config --local gpg.program gpg-cli
 git config --local commit.gpgsign true
 
+# If the operator passed --signing-key, write it now (overwriting any
+# existing value) so the smoke test below has a key to sign with and
+# subsequent `git commit` calls don't fail before reaching gpg-cli.
+if [[ -n "${signing_key}" ]]; then
+  git config --local user.signingkey "${signing_key}"
+fi
+
 echo "setup-devcontainer-signing: wrote ${config_path}"
 echo "setup-devcontainer-signing: set git config --local gpg.program=gpg-cli, commit.gpgsign=true"
+
+if [[ "${skip_smoke}" -eq 1 ]]; then
+  echo "setup-devcontainer-signing: WARNING --skip-smoke set; install is unverified." >&2
+  echo "setup-devcontainer-signing: every 'git commit' in this clone now signs through gpg-bridge."
+  echo "setup-devcontainer-signing: override per-commit with 'git -c commit.gpgsign=false commit'."
+  exit 0
+fi
+
+# ----------------------------------------------------------------------
+# Smoke test — probes 1..4. Each probe fails loudly with a named cause
+# rather than letting the operator discover the breakage at first
+# `git commit`. See issue #333 for the failure-mode catalogue.
+# ----------------------------------------------------------------------
+
+# Probe 1: gpg.program resolution. We just told git to use `gpg-cli`,
+# which means git's child process will look it up on PATH. If the
+# binary isn't on PATH, every future `git commit` blows up before it
+# can talk to the bridge.
+if ! command -v gpg-cli >/dev/null 2>&1; then
+  echo "setup-devcontainer-signing: probe failed: gpg.program unresolved." >&2
+  echo "setup-devcontainer-signing: 'gpg-cli' is not on PATH; git's gpg.program=gpg-cli will fail at commit time." >&2
+  echo "setup-devcontainer-signing: install gpg-cli inside the devcontainer (see CONTRIBUTING.md § 'Signed commits inside the devcontainer')." >&2
+  exit 1
+fi
+
+# Probe 2: user.signingkey. Without this, `git commit` fails before
+# gpg-cli is even invoked — git can't pass `-u <key>` to its
+# gpg.program if it doesn't know which key to sign with.
+configured_signing_key="$(git config --local --get user.signingkey || true)"
+if [[ -z "${configured_signing_key}" ]]; then
+  echo "setup-devcontainer-signing: probe failed: user.signingkey is unset." >&2
+  echo "setup-devcontainer-signing: pass --signing-key <FP> so this script can write 'git config --local user.signingkey'." >&2
+  echo "setup-devcontainer-signing: without it, 'git commit' fails before reaching gpg-cli." >&2
+  exit 1
+fi
+
+# Probe 3: bridge reachability. Any HTTP response (200, 401, 403, ...)
+# proves the URL is reachable from this container; a connection error
+# or timeout means the URL is wrong (e.g. 127.0.0.1 instead of
+# host.docker.internal on Docker Desktop) or the bridge is down. We
+# deliberately *don't* check the response code — the operator's token
+# is `gpg:sign`-scoped, not `gpg-bridge:health`, so a 403 here is
+# expected and not a failure. Probe 4 (trial sign) checks auth.
+if ! command -v curl >/dev/null 2>&1; then
+  echo "setup-devcontainer-signing: probe failed: 'curl' is not on PATH (needed for the bridge reachability probe)." >&2
+  exit 1
+fi
+
+# All probe temp files live under one directory so a single trap
+# tears every one down on any exit path (success, failure, signal).
+# Using a directory rather than tracking individual paths keeps the
+# trap idempotent across the multiple probes below.
+probe_tmpdir="$(mktemp -d)"
+# shellcheck disable=SC2064 # capture path at trap-set time, not when fired
+trap "rm -rf '${probe_tmpdir}'" EXIT
+
+reachability_url="${bridge_url%/}/gpg-bridge/health"
+curl_args=(
+  --silent
+  --output /dev/null
+  --connect-timeout 5
+  --max-time 10
+  --write-out '%{http_code}'
+)
+if [[ -n "${ca_cert_path}" ]]; then
+  curl_args+=(--cacert "${ca_cert_path}")
+fi
+
+# Write the auth header to a 0600 temp file and pass it to curl via
+# `--header @file` so the bearer token never appears on the curl argv
+# (where every local account could see it via `ps auxww`). /health
+# doesn't strictly need the header (probe only cares about
+# reachability, not status code), but attaching it keeps the request
+# shape identical to a real probe and proves the cert chain works for
+# an authenticated request too.
+auth_header_path="${probe_tmpdir}/auth-header"
+(umask 0077 && printf 'Authorization: Bearer %s\n' "${token}" >"${auth_header_path}")
+
+http_status=""
+if ! http_status="$(curl "${curl_args[@]}" \
+  --header "@${auth_header_path}" \
+  "${reachability_url}" 2>/dev/null)"; then
+  echo "setup-devcontainer-signing: probe failed: bridge unreachable at ${bridge_url}." >&2
+  echo "setup-devcontainer-signing: check the bridge is running on the host and the URL is reachable from this container." >&2
+  echo "setup-devcontainer-signing: on Docker Desktop, prefer 'host.docker.internal' over '127.0.0.1' (which resolves to the container's loopback)." >&2
+  echo "setup-devcontainer-signing: see docs/operations/gpg-bridge-host-setup.md for host-side troubleshooting." >&2
+  exit 1
+fi
+
+if [[ -z "${http_status}" || "${http_status}" == "000" ]]; then
+  echo "setup-devcontainer-signing: probe failed: bridge unreachable at ${bridge_url} (no HTTP response)." >&2
+  echo "setup-devcontainer-signing: check the bridge is running and TLS is configured (HTTP 000 means curl could not complete the request)." >&2
+  echo "setup-devcontainer-signing: see docs/operations/gpg-bridge-host-setup.md for host-side troubleshooting." >&2
+  exit 1
+fi
+
+# Probe 4: end-to-end trial sign. Drives the full path that `git
+# commit` will use — gpg-cli reads the config we just wrote, dials
+# the bridge, the bridge re-checks the token's scope and key
+# allowlist, and the host gpg signs a constant payload. Each gpg-cli
+# exit code below maps to a specific failure mode; see ADR 0033 and
+# packages/gpg-cli/src/gpg_cli/cli.py for the exit code catalogue.
+trial_payload="setup-devcontainer-signing smoke test"
+trial_stderr_path="${probe_tmpdir}/trial-stderr"
+trial_stdout_path="${probe_tmpdir}/trial-stdout"
+
+trial_exit=0
+printf '%s\n' "${trial_payload}" \
+  | gpg-cli --status-fd 2 -bsau "${configured_signing_key}" \
+    >"${trial_stdout_path}" 2>"${trial_stderr_path}" \
+  || trial_exit=$?
+
+case "${trial_exit}" in
+  0)
+    if ! grep -q '\[GNUPG:\] SIG_CREATED' "${trial_stderr_path}"; then
+      echo "setup-devcontainer-signing: probe failed: trial sign exited 0 but produced no SIG_CREATED status line." >&2
+      echo "--- gpg-cli stderr ---" >&2
+      cat "${trial_stderr_path}" >&2
+      echo "----------------------" >&2
+      exit 1
+    fi
+    echo "setup-devcontainer-signing: trial sign succeeded with key ${configured_signing_key}"
+    ;;
+  3)
+    echo "setup-devcontainer-signing: probe failed: bridge rejected the token (unauthorized)." >&2
+    echo "setup-devcontainer-signing: mint a new one on the host with 'task agent-auth -- token create --scope gpg:sign=allow --json'." >&2
+    exit 1
+    ;;
+  4)
+    echo "setup-devcontainer-signing: probe failed: bridge accepted the token but denied the request (forbidden)." >&2
+    echo "setup-devcontainer-signing: causes: token lacks gpg:sign=allow, or signing key ${configured_signing_key} is not in the bridge's allowed_signing_keys list." >&2
+    echo "setup-devcontainer-signing: see docs/operations/gpg-bridge-host-setup.md § 'allowed_signing_keys'." >&2
+    exit 1
+    ;;
+  5)
+    # TODO(#331): once the fail-fast on wedged backend subprocess
+    # change lands, gpg-cli will surface a distinct
+    # `signing_backend_unavailable` code; remap the message here to
+    # point specifically at host gpg-agent / `allow-loopback-pinentry`.
+    echo "setup-devcontainer-signing: probe failed: bridge unavailable (host gpg-bridge or its backend could not complete the request)." >&2
+    echo "setup-devcontainer-signing: causes: bridge subprocess timed out, host gpg-agent passphrase prompt blocked, or no 'allow-loopback-pinentry'." >&2
+    echo "setup-devcontainer-signing: see docs/operations/gpg-bridge-host-setup.md for host-side gpg-agent troubleshooting." >&2
+    exit 1
+    ;;
+  *)
+    echo "setup-devcontainer-signing: probe failed: gpg-cli exited ${trial_exit}." >&2
+    echo "--- gpg-cli stderr ---" >&2
+    cat "${trial_stderr_path}" >&2
+    echo "----------------------" >&2
+    echo "setup-devcontainer-signing: see docs/operations/gpg-bridge-host-setup.md for known failure modes." >&2
+    exit 1
+    ;;
+esac
+
+# Probe-temp directory is cleaned up by the EXIT trap installed at
+# the top of the smoke test.
+
 echo "setup-devcontainer-signing: every 'git commit' in this clone now signs through gpg-bridge."
 echo "setup-devcontainer-signing: override per-commit with 'git -c commit.gpgsign=false commit'."

--- a/tests/test_setup_devcontainer_signing.py
+++ b/tests/test_setup_devcontainer_signing.py
@@ -8,16 +8,26 @@ The script wires devcontainer commit signing to the host's
 gpg-bridge. It writes the gpg-cli config file at the canonical
 ``$XDG_CONFIG_HOME/gpg-cli/config.yaml`` path (the same path
 ``packages/gpg-cli/src/gpg_cli/config.py`` reads) and runs two
-``git config --local`` calls. These tests exercise that contract
-through the script's argv interface only — they do not import the
-shell.
+``git config --local`` calls. After issue #333 it also runs an
+end-to-end smoke test (probes 1..4) before exiting 0. These tests
+exercise that contract through the script's argv interface only —
+they do not import the shell.
+
+The smoke-test probes are exercised by stubbing ``gpg-cli`` and
+``curl`` on a synthetic ``PATH`` that points at the test's temp
+directory. Each fake binary is a tiny bash script whose behaviour
+(exit code, stdout, stderr, status-fd output) is parametrised by
+files in the same temp dir, so a single test can flip the fakes'
+behaviour without rewriting the binary.
 """
 
 from __future__ import annotations
 
 import os
+import shutil
 import stat
 import subprocess
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -32,18 +42,25 @@ def _run(
     *,
     cwd: Path,
     xdg_config_home: Path,
+    extra_path: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run the setup script with a controlled environment.
 
     ``cwd`` must be a git working tree so ``git config --local`` has
     somewhere to write. ``xdg_config_home`` redirects the gpg-cli
-    config file off the developer's real ``~/.config``.
+    config file off the developer's real ``~/.config``. ``extra_path``
+    is prepended to ``PATH`` so the test's fake ``gpg-cli`` / ``curl``
+    binaries shadow any real ones; passing ``None`` keeps the host
+    ``PATH`` (used by the smoke-test-skipping happy paths and the
+    arg-parsing tests that exit before any probe runs).
     """
     env = os.environ.copy()
     env["XDG_CONFIG_HOME"] = str(xdg_config_home)
     # HOME redirection guards the fallback path in the script's
     # ``${XDG_CONFIG_HOME:-${HOME}/.config}`` expression.
     env["HOME"] = str(xdg_config_home.parent)
+    if extra_path is not None:
+        env["PATH"] = f"{extra_path}{os.pathsep}{env.get('PATH', '')}"
     return subprocess.run(
         [str(SCRIPT), *args],
         cwd=str(cwd),
@@ -63,7 +80,117 @@ def git_repo(tmp_path: Path) -> Path:
     return repo
 
 
-class TestSetupDevcontainerSigning:
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _make_fake_bin_dir(
+    tmp_path: Path,
+    *,
+    gpg_cli_exit: int = 0,
+    gpg_cli_status_text: str = "[GNUPG:] SIG_CREATED B foo bar baz\n",
+    gpg_cli_stdout: str = "-----BEGIN PGP SIGNATURE-----\nfake\n-----END PGP SIGNATURE-----\n",
+    gpg_cli_stderr_extra: str = "",
+    curl_exit: int = 0,
+    curl_http_status: str = "200",
+    omit_gpg_cli: bool = False,
+) -> Path:
+    """Build a directory with fake ``gpg-cli`` and ``curl`` binaries.
+
+    The fakes record their argv in ``$bindir/calls/<name>`` for tests
+    that need to assert on what the script invoked. ``gpg-cli`` writes
+    its parametrised stdout to its stdout, the parametrised status
+    text to fd 2 (the script always passes ``--status-fd 2``), then
+    exits with ``gpg_cli_exit``. ``curl`` echoes the parametrised HTTP
+    status to stdout (the script invokes curl with
+    ``--write-out '%{http_code}'``) and exits with ``curl_exit``.
+    """
+    bindir = tmp_path / "fake-bin"
+    bindir.mkdir()
+    calls_dir = bindir / "calls"
+    calls_dir.mkdir()
+
+    # Re-use the host's git binary so the script's ``git config --local``
+    # calls hit a real git executable. We can't ship a fake git here
+    # because the script does meaningful work with it.
+    real_git = shutil.which("git")
+    assert real_git, "git must be on PATH to run the test suite"
+    (bindir / "git").symlink_to(real_git)
+
+    # Symlink mktemp/grep/cat/printf etc. through to the host so the
+    # script's helpers keep working under a stripped PATH (the
+    # probe-1-fail test sets PATH to bindir alone, so bash itself
+    # has to be findable here too).
+    for tool in (
+        "bash",
+        "cat",
+        "chmod",
+        "env",
+        "grep",
+        "mkdir",
+        "mktemp",
+        "mv",
+        "printf",
+        "rm",
+        "umask",
+    ):
+        host = shutil.which(tool)
+        if host is not None:
+            (bindir / tool).symlink_to(host)
+
+    if not omit_gpg_cli:
+        _write_executable(
+            bindir / "gpg-cli",
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                # Fake gpg-cli for setup-devcontainer-signing tests.
+                printf '%s' "$*" >'{calls_dir}/gpg-cli'
+                # Drain stdin so the upstream pipe doesn't break with EPIPE.
+                cat >/dev/null
+                printf '%s' {gpg_cli_stdout!r}
+                # Status text always goes to stderr; the production script
+                # passes --status-fd 2.
+                printf '%s' {gpg_cli_status_text!r} >&2
+                if [[ -n {gpg_cli_stderr_extra!r} ]]; then
+                  printf '%s' {gpg_cli_stderr_extra!r} >&2
+                fi
+                exit {gpg_cli_exit}
+                """
+            ),
+        )
+
+    _write_executable(
+        bindir / "curl",
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            # Fake curl for setup-devcontainer-signing tests.
+            printf '%s\\n' "$*" >'{calls_dir}/curl'
+            # The script asks for --write-out '%{{http_code}}'; emit the
+            # parametrised status to stdout. curl's --silent --output
+            # /dev/null makes everything else go to /dev/null in prod,
+            # so stdout-only is the right surface to mimic.
+            printf '%s' {curl_http_status!r}
+            exit {curl_exit}
+            """
+        ),
+    )
+
+    return bindir
+
+
+def _required_args() -> list[str]:
+    return [
+        "--token",
+        "aa_test_token",
+        "--bridge-url",
+        "https://host.docker.internal:8443",
+    ]
+
+
+class TestSetupDevcontainerSigningArgvAndConfig:
     """Argv -> config-file + git-config contract for the setup script."""
 
     def test_writes_canonical_config_and_sets_git_config(
@@ -72,14 +199,12 @@ class TestSetupDevcontainerSigning:
         xdg = tmp_path / "xdg-config"
         result = _run(
             [
-                "--token",
-                "aa_test_token",
-                "--bridge-url",
-                "https://host.docker.internal:8443",
+                *_required_args(),
                 "--ca-cert-path",
                 "/tmp/ca.pem",
                 "--timeout-seconds",
                 "20",
+                "--skip-smoke",
             ],
             cwd=git_repo,
             xdg_config_home=xdg,
@@ -124,12 +249,7 @@ class TestSetupDevcontainerSigning:
     ) -> None:
         xdg = tmp_path / "xdg-config"
         result = _run(
-            [
-                "--token",
-                "aa_test_token",
-                "--bridge-url",
-                "https://host.docker.internal:8443",
-            ],
+            [*_required_args(), "--skip-smoke"],
             cwd=git_repo,
             xdg_config_home=xdg,
         )
@@ -144,14 +264,29 @@ class TestSetupDevcontainerSigning:
             "token": "aa_test_token",
         }
 
+    def test_signing_key_flag_writes_local_user_signingkey(
+        self, tmp_path: Path, git_repo: Path
+    ) -> None:
+        xdg = tmp_path / "xdg-config"
+        result = _run(
+            [*_required_args(), "--signing-key", "ABCDEF1234567890", "--skip-smoke"],
+            cwd=git_repo,
+            xdg_config_home=xdg,
+        )
+        assert result.returncode == 0, result.stderr
+
+        configured = subprocess.run(
+            ["git", "config", "--local", "user.signingkey"],
+            cwd=git_repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert configured == "ABCDEF1234567890"
+
     def test_idempotent_rerun_preserves_state(self, tmp_path: Path, git_repo: Path) -> None:
         xdg = tmp_path / "xdg-config"
-        args = [
-            "--token",
-            "aa_test_token",
-            "--bridge-url",
-            "https://host.docker.internal:8443",
-        ]
+        args = [*_required_args(), "--skip-smoke"]
         first = _run(args, cwd=git_repo, xdg_config_home=xdg)
         assert first.returncode == 0, first.stderr
 
@@ -201,10 +336,7 @@ class TestSetupDevcontainerSigning:
         xdg = tmp_path / "xdg-config"
         result = _run(
             [
-                "--token",
-                "aa_test_token",
-                "--bridge-url",
-                "https://x.invalid",
+                *_required_args(),
                 "--bogus",
                 "x",
             ],
@@ -218,10 +350,7 @@ class TestSetupDevcontainerSigning:
         xdg = tmp_path / "xdg-config"
         result = _run(
             [
-                "--token",
-                "aa_test_token",
-                "--bridge-url",
-                "https://x.invalid",
+                *_required_args(),
                 "--timeout-seconds",
                 "fast",
             ],
@@ -236,12 +365,7 @@ class TestSetupDevcontainerSigning:
         not_a_repo.mkdir()
         xdg = tmp_path / "xdg-config"
         result = _run(
-            [
-                "--token",
-                "aa_test_token",
-                "--bridge-url",
-                "https://x.invalid",
-            ],
+            _required_args(),
             cwd=not_a_repo,
             xdg_config_home=xdg,
         )
@@ -264,14 +388,12 @@ class TestSetupDevcontainerSigning:
         xdg = tmp_path / "xdg-config"
         result = _run(
             [
-                "--token",
-                "aa_test_token",
-                "--bridge-url",
-                "https://host.docker.internal:8443",
+                *_required_args(),
                 "--ca-cert-path",
                 "/tmp/ca.pem",
                 "--timeout-seconds",
                 "12.5",
+                "--skip-smoke",
             ],
             cwd=git_repo,
             xdg_config_home=xdg,
@@ -283,3 +405,282 @@ class TestSetupDevcontainerSigning:
         assert cfg.token == "aa_test_token"
         assert cfg.ca_cert_path == "/tmp/ca.pem"
         assert cfg.timeout_seconds == 12.5
+
+
+class TestSetupDevcontainerSigningSmokeTest:
+    """Probes 1..4 from issue #333 and the ``--skip-smoke`` bypass."""
+
+    def test_skip_smoke_emits_warning_and_exits_zero(self, tmp_path: Path, git_repo: Path) -> None:
+        xdg = tmp_path / "xdg-config"
+        result = _run(
+            [*_required_args(), "--skip-smoke"],
+            cwd=git_repo,
+            xdg_config_home=xdg,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "--skip-smoke set; install is unverified" in result.stderr
+
+    def test_happy_path_succeeds_and_reports_resolved_fingerprint(
+        self, tmp_path: Path, git_repo: Path
+    ) -> None:
+        bindir = _make_fake_bin_dir(tmp_path)
+        xdg = tmp_path / "xdg-config"
+        result = _run(
+            [*_required_args(), "--signing-key", "ABCDEF1234567890"],
+            cwd=git_repo,
+            xdg_config_home=xdg,
+            extra_path=bindir,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "trial sign succeeded with key ABCDEF1234567890" in result.stdout
+
+        # Confirm gpg-cli was invoked with the local-user fingerprint
+        # the script just wrote.
+        gpg_cli_call = (bindir / "calls" / "gpg-cli").read_text()
+        assert "-bsau ABCDEF1234567890" in gpg_cli_call
+        assert "--status-fd 2" in gpg_cli_call
+
+        # Confirm curl was pointed at /gpg-bridge/health under the
+        # configured bridge URL, with the bearer header set, and that
+        # the token never appeared on argv (visible via `ps`).
+        curl_call = (bindir / "calls" / "curl").read_text()
+        assert "https://host.docker.internal:8443/gpg-bridge/health" in curl_call
+        assert (
+            "aa_test_token" not in curl_call
+        ), "bearer token must travel via header, never argv (ps would expose it)"
+
+    def test_probe1_fails_when_gpg_cli_missing(self, tmp_path: Path, git_repo: Path) -> None:
+        bindir = _make_fake_bin_dir(tmp_path, omit_gpg_cli=True)
+        xdg = tmp_path / "xdg-config"
+        # Strip /usr/local/bin etc. so a system-installed gpg-cli (if
+        # any) doesn't shadow the missing fake. PATH is just our bindir.
+        env = os.environ.copy()
+        env["XDG_CONFIG_HOME"] = str(xdg)
+        env["HOME"] = str(xdg.parent)
+        env["PATH"] = str(bindir)
+        result = subprocess.run(
+            [
+                str(SCRIPT),
+                *_required_args(),
+                "--signing-key",
+                "ABCDEF1234567890",
+            ],
+            cwd=str(git_repo),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode != 0
+        assert "probe failed: gpg.program unresolved" in result.stderr
+        assert "gpg-cli" in result.stderr
+
+    def test_probe2_fails_when_signing_key_missing(self, tmp_path: Path, git_repo: Path) -> None:
+        bindir = _make_fake_bin_dir(tmp_path)
+        xdg = tmp_path / "xdg-config"
+        # No --signing-key, no preexisting git config user.signingkey →
+        # the script must fail probe 2 with a clear diagnostic.
+        result = _run(
+            _required_args(),
+            cwd=git_repo,
+            xdg_config_home=xdg,
+            extra_path=bindir,
+        )
+        assert result.returncode != 0
+        assert "user.signingkey is unset" in result.stderr
+        assert "--signing-key" in result.stderr
+
+    def test_probe2_passes_when_git_already_has_signingkey(
+        self, tmp_path: Path, git_repo: Path
+    ) -> None:
+        # Pre-seed git config so the script can use the existing value.
+        subprocess.run(
+            ["git", "config", "--local", "user.signingkey", "DEADBEEFCAFE0000"],
+            cwd=git_repo,
+            check=True,
+        )
+        bindir = _make_fake_bin_dir(tmp_path)
+        xdg = tmp_path / "xdg-config"
+        result = _run(
+            _required_args(),
+            cwd=git_repo,
+            xdg_config_home=xdg,
+            extra_path=bindir,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "trial sign succeeded with key DEADBEEFCAFE0000" in result.stdout
+
+    def test_probe3_fails_when_curl_returns_nonzero(self, tmp_path: Path, git_repo: Path) -> None:
+        # curl exit 7 = connection refused; exit 28 = timeout. Either
+        # surfaces as "bridge unreachable".
+        bindir = _make_fake_bin_dir(tmp_path, curl_exit=7, curl_http_status="")
+        xdg = tmp_path / "xdg-config"
+        result = _run(
+            [*_required_args(), "--signing-key", "ABCDEF1234567890"],
+            cwd=git_repo,
+            xdg_config_home=xdg,
+            extra_path=bindir,
+        )
+        assert result.returncode != 0
+        assert "bridge unreachable" in result.stderr
+        assert "host.docker.internal" in result.stderr
+
+    def test_probe3_fails_on_http_000(self, tmp_path: Path, git_repo: Path) -> None:
+        # curl exits 0 but writes 000 (no response received) — e.g.
+        # TLS handshake error. Treated as unreachable, not 4xx.
+        bindir = _make_fake_bin_dir(tmp_path, curl_exit=0, curl_http_status="000")
+        xdg = tmp_path / "xdg-config"
+        result = _run(
+            [*_required_args(), "--signing-key", "ABCDEF1234567890"],
+            cwd=git_repo,
+            xdg_config_home=xdg,
+            extra_path=bindir,
+        )
+        assert result.returncode != 0
+        assert "bridge unreachable" in result.stderr
+
+    def test_probe3_passes_on_403(self, tmp_path: Path, git_repo: Path) -> None:
+        # The token is gpg:sign-scoped, not gpg-bridge:health-scoped,
+        # so a 403 here is *expected* — it still proves the network
+        # path is open. Probe 4 (trial sign) is the auth check.
+        bindir = _make_fake_bin_dir(tmp_path, curl_exit=0, curl_http_status="403")
+        xdg = tmp_path / "xdg-config"
+        result = _run(
+            [*_required_args(), "--signing-key", "ABCDEF1234567890"],
+            cwd=git_repo,
+            xdg_config_home=xdg,
+            extra_path=bindir,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_probe4_fails_on_unauthorized(self, tmp_path: Path, git_repo: Path) -> None:
+        # gpg-cli exit 3 = BridgeUnauthorizedError (token rejected).
+        bindir = _make_fake_bin_dir(
+            tmp_path,
+            gpg_cli_exit=3,
+            gpg_cli_status_text="",
+            gpg_cli_stderr_extra="gpg-cli: unauthorized: token rejected\n",
+        )
+        xdg = tmp_path / "xdg-config"
+        result = _run(
+            [*_required_args(), "--signing-key", "ABCDEF1234567890"],
+            cwd=git_repo,
+            xdg_config_home=xdg,
+            extra_path=bindir,
+        )
+        assert result.returncode != 0
+        assert "bridge rejected the token (unauthorized)" in result.stderr
+        assert "gpg:sign=allow" in result.stderr
+
+    def test_probe4_fails_on_forbidden(self, tmp_path: Path, git_repo: Path) -> None:
+        # gpg-cli exit 4 = BridgeForbiddenError (scope or key denied).
+        bindir = _make_fake_bin_dir(
+            tmp_path,
+            gpg_cli_exit=4,
+            gpg_cli_status_text="",
+            gpg_cli_stderr_extra="gpg-cli: forbidden: key not allowlisted\n",
+        )
+        xdg = tmp_path / "xdg-config"
+        result = _run(
+            [*_required_args(), "--signing-key", "ABCDEF1234567890"],
+            cwd=git_repo,
+            xdg_config_home=xdg,
+            extra_path=bindir,
+        )
+        assert result.returncode != 0
+        assert "forbidden" in result.stderr
+        assert "allowed_signing_keys" in result.stderr
+
+    def test_probe4_fails_on_bridge_unavailable(self, tmp_path: Path, git_repo: Path) -> None:
+        # gpg-cli exit 5 = BridgeUnavailableError (bridge or backend).
+        bindir = _make_fake_bin_dir(
+            tmp_path,
+            gpg_cli_exit=5,
+            gpg_cli_status_text="",
+            gpg_cli_stderr_extra="gpg-cli: bridge unavailable: timed out\n",
+        )
+        xdg = tmp_path / "xdg-config"
+        result = _run(
+            [*_required_args(), "--signing-key", "ABCDEF1234567890"],
+            cwd=git_repo,
+            xdg_config_home=xdg,
+            extra_path=bindir,
+        )
+        assert result.returncode != 0
+        assert "bridge unavailable" in result.stderr
+        assert "gpg-agent" in result.stderr
+
+    def test_probe4_fails_on_unknown_exit_code(self, tmp_path: Path, git_repo: Path) -> None:
+        # Any exit code outside the documented set surfaces gpg-cli's
+        # stderr verbatim and points at the operator runbook.
+        bindir = _make_fake_bin_dir(
+            tmp_path,
+            gpg_cli_exit=42,
+            gpg_cli_status_text="",
+            gpg_cli_stderr_extra="gpg-cli: unexpected error: nuclear meltdown\n",
+        )
+        xdg = tmp_path / "xdg-config"
+        result = _run(
+            [*_required_args(), "--signing-key", "ABCDEF1234567890"],
+            cwd=git_repo,
+            xdg_config_home=xdg,
+            extra_path=bindir,
+        )
+        assert result.returncode != 0
+        assert "gpg-cli exited 42" in result.stderr
+        assert "nuclear meltdown" in result.stderr
+        assert "docs/operations/gpg-bridge-host-setup.md" in result.stderr
+
+    def test_probe4_fails_on_zero_exit_without_sig_created(
+        self, tmp_path: Path, git_repo: Path
+    ) -> None:
+        # gpg-cli exited 0 but emitted no SIG_CREATED status line —
+        # treat as a contract violation, not a success, so we don't
+        # ship a broken setup.
+        bindir = _make_fake_bin_dir(
+            tmp_path,
+            gpg_cli_exit=0,
+            gpg_cli_status_text="[GNUPG:] BEGIN_SIGNING\n",
+        )
+        xdg = tmp_path / "xdg-config"
+        result = _run(
+            [*_required_args(), "--signing-key", "ABCDEF1234567890"],
+            cwd=git_repo,
+            xdg_config_home=xdg,
+            extra_path=bindir,
+        )
+        assert result.returncode != 0
+        assert "no SIG_CREATED status line" in result.stderr
+
+    def test_smoke_test_idempotent_on_rerun(self, tmp_path: Path, git_repo: Path) -> None:
+        bindir = _make_fake_bin_dir(tmp_path)
+        xdg = tmp_path / "xdg-config"
+        args = [*_required_args(), "--signing-key", "ABCDEF1234567890"]
+
+        first = _run(args, cwd=git_repo, xdg_config_home=xdg, extra_path=bindir)
+        assert first.returncode == 0, first.stderr
+        second = _run(args, cwd=git_repo, xdg_config_home=xdg, extra_path=bindir)
+        assert second.returncode == 0, second.stderr
+        assert "trial sign succeeded" in second.stdout
+
+    def test_token_does_not_leak_via_argv(self, tmp_path: Path, git_repo: Path) -> None:
+        """Bearer token must not appear on any subprocess argv.
+
+        A token on ``ps``-visible argv leaks to every other local
+        account on the system. The script must pass it via stdin, env
+        var, or HTTP header — never as a positional/argument string
+        to a sibling binary.
+        """
+        bindir = _make_fake_bin_dir(tmp_path)
+        xdg = tmp_path / "xdg-config"
+        result = _run(
+            [*_required_args(), "--signing-key", "ABCDEF1234567890"],
+            cwd=git_repo,
+            xdg_config_home=xdg,
+            extra_path=bindir,
+        )
+        assert result.returncode == 0, result.stderr
+        curl_call = (bindir / "calls" / "curl").read_text()
+        gpg_call = (bindir / "calls" / "gpg-cli").read_text()
+        assert "aa_test_token" not in curl_call
+        assert "aa_test_token" not in gpg_call


### PR DESCRIPTION
==COMMIT_MSG==
improvement(setup-devcontainer-signing): smoke-test the sign path

Verify gpg-cli resolution, user.signingkey, bridge reachability
and auth, and a trial sign before declaring success. Add
--skip-smoke for constrained environments. Map gpg-cli's known
exit codes to remediation messages that name the most likely
cause. Add a new --signing-key flag and a host-side troubleshooting
page at docs/operations/gpg-bridge-host-setup.md.

Closes #333

Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

## Review notes

### Files touched

- `scripts/setup-devcontainer-signing.sh` — adds `--signing-key`,
  `--skip-smoke`, and the four-probe smoke test. Bearer token never
  appears on any subprocess argv (passed to `curl` via
  `--header @<temp-file>` with 0600 perms; gpg-cli reads the token
  from its config file, not argv).
- `tests/test_setup_devcontainer_signing.py` — extended to cover all
  four probe-failure paths plus the bypass and idempotency. Stubs
  `gpg-cli` and `curl` via PATH manipulation; fakes are bash scripts
  written into a tmp dir, parametrised by exit code / stdout /
  stderr / status text. Symlinks essential utilities (bash, env,
  cat, grep, mktemp, ...) into the tmp dir so the probe-1-fail test
  can run with PATH set to *only* the fake-bin dir.
- `docs/operations/gpg-bridge-host-setup.md` — new page seeded with
  the failure-mode catalogue the smoke test references.
- `CONTRIBUTING.md` § "Signed commits inside the devcontainer" —
  documents the new flags and the failure-mode table.
- `changelog/@unreleased/pr-336-setup-signing-smoke-test.yml` —
  hand-authored `improvement` entry (changelog-bot App secrets not
  yet provisioned, per project memory).

### Self-resolved internal decisions

- **Probe 3 reads /health for *reachability only*, ignoring the
  status code.** The operator's token is `gpg:sign`-scoped, but
  `/gpg-bridge/health` requires `gpg-bridge:health`. A 403 there
  would always fire on a correctly-scoped token. Treating any HTTP
  response (including 403) as "reachable" matches the issue's
  intent (catch wrong URL / unreachable bridge) without forcing a
  scope change. Probe 4 (trial sign) is the actual auth check and
  distinguishes 401 / 403 / 5xx through gpg-cli's exit codes.
- **`--signing-key` is a named flag, not positional**, for
  consistency with the existing `--token` / `--bridge-url`. It is
  optional when the local clone already has `user.signingkey` set.
- **No interactive TTY prompt for `user.signingkey`.** The issue
  allowed either prompt-or-flag. Flag-only keeps stdin handling
  simple, avoids a second CLI surface, and matches the
  non-interactive devcontainer setup flow.
- **Test fakes layout**: `<tmp_path>/fake-bin/{gpg-cli,curl,git,bash,...}`
  with a `calls/` subdir capturing each fake's argv. The test fixture
  symlinks real `bash`, `env`, `cat`, `grep`, `mkdir`, `mktemp`, `mv`,
  `printf`, `rm`, `umask` from the host so a stripped PATH still
  lets the script run.
- **#331 (fail-fast on wedged backend) status**: not yet merged;
  left a `# TODO(#331)` comment in the gpg-cli exit-5 branch. Future
  remap to `signing_backend_unavailable` is a 5-minute follow-up.
- **Bearer token never on argv** verified by a dedicated test
  (`test_token_does_not_leak_via_argv`). Curl reads the auth header
  via `--header @<file>`; the file is 0600 and lives under a
  `mktemp -d` directory cleaned by an `EXIT` trap.
- **Operator doc location**: created `docs/operations/`
  (didn't exist) with the troubleshooting page. Existing docs only
  carried `docs/release/`.

### Test plan

- [x] All existing argv / config-file tests still pass.
- [x] New probe-failure tests cover gpg-cli missing, signing-key
      unset, curl failure, HTTP 000, 401-shape (gpg-cli exit 3),
      403-shape (gpg-cli exit 4), 5xx-shape (gpg-cli exit 5),
      unknown exit, zero-exit-without-SIG_CREATED.
- [x] `--skip-smoke` bypass tested.
- [x] Idempotency: smoke-test rerun against existing config still
      passes.
- [x] Token leak guard: `aa_test_token` does not appear in any
      subprocess argv.
- [x] `task lint` clean (shellcheck + ruff + keep-sorted).
- [x] `task format -- --check` clean.
- [x] `task typecheck` clean.
- [x] `scripts/reuse-lint.sh` clean.
- [x] CONTRIBUTING.md updated with flag and failure-mode table.