### PR TITLE
chore(ci): unify release-pr commit identity with the App

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -18,18 +18,19 @@
 # under the new version, so a stale PR never lingers ahead of an
 # updated plan.
 #
-# Bot identity: PR creation goes through the `agent-auth-release-bot`
-# GitHub App (secrets `RELEASE_BOT_APP_ID` and
-# `RELEASE_BOT_PRIVATE_KEY`) via `actions/create-github-app-token`.
+# Bot identity: PR creation, the release-branch push, AND the release
+# commit's author/committer all attribute to the
+# `agent-auth-release-bot` GitHub App (secrets `RELEASE_BOT_APP_ID`
+# and `RELEASE_BOT_PRIVATE_KEY`) via `actions/create-github-app-token`.
 # The default `GITHUB_TOKEN` cannot open PRs unless the org/repo
 # setting "Allow GitHub Actions to create and approve pull requests"
 # is on, and enabling that flag would also let every workflow
 # auto-approve PRs — too broad for a repo with DCO/signing rigour. The
 # release branch push also runs under the App token so a future ruleset
 # tightening on `release/*` does not silently break the release flow.
-# Commits on the release branch keep `github-actions[bot]` as
-# author/committer because DCO auto-bypasses any
-# `[bot]@users.noreply.github.com` address (`.github/workflows/dco.yml`).
+# DCO auto-bypasses the bot's `[bot]@users.noreply.github.com` email
+# (`.github/workflows/dco.yml`) so unifying the committer identity does
+# not affect the sign-off check.
 
 name: Release PR
 
@@ -129,10 +130,24 @@ jobs:
             --current-version "${CURRENT_VERSION}"
 
       - name: Configure git identity
+        # Look up the App's bot user ID at runtime so the
+        # author/committer + Signed-off-by trailer on the release
+        # commit attribute to the same identity that opens the PR
+        # (`agent-auth-release-bot[bot]`). The `app-slug` output of
+        # `actions/create-github-app-token` plus `gh api /users/<slug>[bot]`
+        # gives the numeric ID without hardcoding it. DCO still
+        # auto-bypasses because `[bot]@users.noreply.github.com` is
+        # the suffix the check matches on.
         if: steps.plan.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        shell: bash
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          set -euo pipefail
+          user_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
 
       - name: Create or refresh release branch
         if: steps.plan.outputs.skip == 'false'


### PR DESCRIPTION
==COMMIT_MSG==
#342 wired `release-pr.yml` to mint an installation token from the
`agent-auth-release-bot` App and use it for the release-branch push
and `gh pr` calls, but kept the release commit's `git config
user.name` / `user.email` hardcoded to `github-actions[bot]`. That
left a split identity on a real release: the PR is opened by
`agent-auth-release-bot[bot]`, the squash-merge commit body's
`Signed-off-by:` trailer attributes to `github-actions[bot]`, and
the release-branch commit's author/committer is also
`github-actions[bot]`. Reviewers landing on the PR or scanning
`git log` see two distinct bot identities for what is functionally
one bot.

Replace the hardcoded values with a runtime lookup against the App
token. `actions/create-github-app-token` already exposes the App's
slug as the `app-slug` output, and `gh api /users/<slug>[bot]`
returns the numeric user ID needed for the
`<id>+<slug>[bot]@users.noreply.github.com` email format. No new
secrets, no hardcoded numeric ID. DCO continues to auto-bypass
because the `[bot]@users.noreply.github.com` suffix match in
`.github/workflows/dco.yml` is identity-agnostic.

Update the file preamble to drop the now-stale carve-out claiming
release-branch commits stay attributed to `github-actions[bot]`.

Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==
==NO_CHANGELOG==

## Review notes

### Why dynamic lookup rather than hardcoding the bot user ID

The numeric ID is stable per App-installation but would need to be
discovered manually (one-off `gh api /users/agent-auth-release-bot[bot]`)
and hardcoded into the workflow. That couples the YAML to an
out-of-band fact: if the App is ever deleted and recreated under
the same slug, the user ID changes silently and the workflow keeps
running with the wrong email format until a human notices. The
runtime lookup costs one `gh api` call per release-PR run (the
workflow already runs at most once per push to main, and the call
is against the same token already minted for everything else).

### What this does NOT change

- Secret names (`RELEASE_BOT_APP_ID` / `RELEASE_BOT_PRIVATE_KEY`) —
  still consumed unchanged.
- App permissions — still `Contents: Read & write` + `Pull requests: Read & write`.
- DCO behaviour — the `[bot]@users.noreply.github.com` suffix match
  still auto-bypasses the sign-off check.
- `release-tag.yml` — the tag pusher's identity was not the issue
  reported and is left alone.

### Out of scope (separate, GitHub-side)

The App's icon falling back to the App owner's avatar is a
display-information gap fixed by uploading a logo at
https://github.com/settings/apps/agent-auth-release-bot. No
workflow change can affect it.

### Test plan

- [x] `yq` parses the modified workflow
- [ ] On merge: confirm the next `release-pr.yml` run (the existing
      `release/0.14.0` PR will refresh, or the next push to `main`
      will compute a new plan) produces a release commit whose
      `git log` shows `Author: agent-auth-release-bot[bot]` and a
      `Signed-off-by:` trailer with the matching bot email