### PR TITLE
fix(merge-bot): dedupe statusCheckRollup by latest run per check

### DIFF
--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -247,8 +247,30 @@ jobs:
           # merge gating supersedes its own historical check
           # outcomes; only the substantive required checks should
           # gate the merge decision.
+          #
+          # Dedupe-by-latest-run: `statusCheckRollup` returns one
+          # entry per check *run*, not per check *name*. A retried
+          # check (workflow rerun, fix-then-push, close+reopen
+          # retrigger) appears multiple times. Without the dedupe a
+          # historical FAILURE for a check that has since passed
+          # would keep the failure / pending predicates true forever
+          # on the same head SHA — the fail-then-pass workflow that
+          # GitHub's "Re-run failed jobs" UI is built for would
+          # wedge merge-bot indefinitely (origin: PR #346 / issue
+          # #347, where `changelog-lint` failed on the first run,
+          # passed on the rerun, and kept the bot in
+          # FAILED_CHECKS:changelog-lint until the stale run was
+          # manually deleted via `gh run delete`). Group by
+          # name+context, keep the entry with the most recent
+          # startedAt, then apply the failure / pending predicates
+          # so they read the *current* status of each check, not
+          # every historical run. The same dedupe applies to the
+          # pending selector below — a stale IN_PROGRESS entry from
+          # a cancelled run must not pin the wait-clean-exit path.
           failed="$(jq -r '
             map(select((.workflowName // "") != "Merge Bot"))
+            | group_by(.name // .context // "<unnamed>")
+            | map(max_by(.startedAt // ""))
             | map(select(
               ((.conclusion // "") | ascii_upcase | IN("FAILURE","TIMED_OUT","CANCELLED","STARTUP_FAILURE","ACTION_REQUIRED"))
               or ((.state // "") | ascii_upcase | IN("FAILURE","ERROR"))
@@ -257,6 +279,8 @@ jobs:
           ' <<<"${rollup}")"
           pending="$(jq -r '
             map(select((.workflowName // "") != "Merge Bot"))
+            | group_by(.name // .context // "<unnamed>")
+            | map(max_by(.startedAt // ""))
             | map(select(
               ((.conclusion // "") == ""
                 and ((.status // "") | ascii_upcase | IN("QUEUED","IN_PROGRESS","WAITING","PENDING","REQUESTED")))

--- a/changelog/@unreleased/pr-350-merge-bot-rollup-dedupe.yml
+++ b/changelog/@unreleased/pr-350-merge-bot-rollup-dedupe.yml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+type: fix
+fix:
+  description: |
+    `merge-bot` no longer wedges on a fail-then-pass for the same
+    required check on a single head SHA. The `Inspect required checks`
+    step now groups `statusCheckRollup` entries by check name (falling
+    back to `.context` for legacy commit statuses) and evaluates only
+    the most-recent run per name, so a check that failed on the first
+    workflow attempt and passed on a rerun reads as "currently passing"
+    instead of carrying its historical FAILURE entry forward forever.
+    The same dedupe applies to the pending selector — a stale
+    `IN_PROGRESS` from a cancelled rerun no longer pins the bot in the
+    wait-clean-exit path.
+  links:
+    - https://github.com/aidanns/agent-auth/issues/347
+    - https://github.com/aidanns/agent-auth/pull/350

--- a/tests/test_merge_bot_rollup_dedupe.py
+++ b/tests/test_merge_bot_rollup_dedupe.py
@@ -1,0 +1,289 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the rollup dedupe predicate in merge-bot.yml.
+
+The merge bot (`.github/workflows/merge-bot.yml`) classifies required
+checks into `failed` / `pending` / `success` by piping the GraphQL
+`statusCheckRollup` payload through a jq filter. `statusCheckRollup`
+returns one entry per check *run*, not per check *name* — a retried
+check (workflow rerun, fix-then-push, close+reopen retrigger) appears
+multiple times, and the historical FAILURE entry never disappears
+from the rollup for the lifetime of the head SHA.
+
+The dedupe step (group by name+context, keep latest by startedAt)
+collapses each check name down to its most recent run before the
+failure / pending predicates evaluate the rollup. Without it, a
+fail-then-pass on the same SHA wedges merge-bot indefinitely — the
+bug surfaced on PR #346 / issue #347, where `changelog-lint` failed
+on the original `opened` event, was retriggered green via close+reopen,
+and the merge call was refused with `FAILED_CHECKS: changelog-lint`
+until the stale failed run was manually deleted via `gh run delete`.
+
+The tests pin both selectors (failed *and* pending) by extracting the
+jq blocks straight out of the workflow YAML and feeding them
+hand-rolled rollup payloads. Pinning the predicates against the
+workflow file (rather than copy-pasting them into the test) means a
+future edit to the dedupe-or-predicate logic that drifts from this
+test will fail at the assert site, not at "the workflow keeps running
+green but the bug is back".
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "merge-bot.yml"
+
+
+def _load_inspect_required_checks_step() -> str:
+    """Return the bash body of the `Inspect required checks` step."""
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["merge"]["steps"]
+    for step in steps:
+        if step.get("name") == "Inspect required checks":
+            run = step["run"]
+            assert isinstance(run, str)
+            return run
+    raise AssertionError("Inspect required checks step not found in merge-bot.yml")
+
+
+_STEP_BODY = _load_inspect_required_checks_step()
+
+
+def _extract_jq_filter(variable: str) -> str:
+    """Pull a `<variable>="$(jq -r '...' <<<"${rollup}")"` filter body.
+
+    The bot writes both selectors as multi-line jq programs assigned
+    to `failed=` and `pending=`. Pulling them out via a regex keeps the
+    test honest — the test exercises the *actual* filter the bot runs,
+    not a hand-typed copy that can silently drift.
+    """
+    pattern = (
+        rf"{re.escape(variable)}=\"\$\(jq -r '\n"
+        r"(?P<filter>.*?)\n"
+        r"\s*' <<<\"\$\{rollup\}\"\)\""
+    )
+    match = re.search(pattern, _STEP_BODY, flags=re.DOTALL)
+    assert match is not None, f"could not find jq filter for `{variable}=` in workflow"
+    return match.group("filter")
+
+
+_FAILED_FILTER = _extract_jq_filter("failed")
+_PENDING_FILTER = _extract_jq_filter("pending")
+
+
+def _run_jq(filter_body: str, rollup: list[dict[str, Any]]) -> list[str]:
+    """Run jq -r over `rollup` with the workflow's filter; return name lines."""
+    proc = subprocess.run(
+        ["jq", "-r", filter_body],
+        input=json.dumps(rollup),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # The filter emits one name per line via `... | .[]`. An empty stdout
+    # means no entries matched (e.g. nothing failed, nothing pending).
+    return [line for line in proc.stdout.splitlines() if line]
+
+
+# Reference rollup entries used across the table-driven cases. Mirroring
+# the shape `gh pr view --json statusCheckRollup` returns: `name`,
+# `conclusion`, `status`, `startedAt` for Actions check-runs;
+# `context`, `state` for legacy commit statuses.
+
+# --- failure selector --------------------------------------------------
+
+
+def test_failed_empty_when_latest_run_per_name_succeeded() -> None:
+    """The bug from issue #347: fail-then-pass must read as 'currently passing'.
+
+    `changelog-lint` failed on the first run and passed on the
+    retrigger. With dedupe, the latest entry per name is the SUCCESS,
+    so `failed` is empty and the bot proceeds to merge.
+    """
+    rollup = [
+        {
+            "name": "changelog-lint",
+            "conclusion": "FAILURE",
+            "status": "COMPLETED",
+            "startedAt": "2026-04-26T04:04:06Z",
+        },
+        {
+            "name": "changelog-lint",
+            "conclusion": "SUCCESS",
+            "status": "COMPLETED",
+            "startedAt": "2026-04-26T04:16:24Z",
+        },
+        {
+            "name": "pr-lint",
+            "conclusion": "SUCCESS",
+            "status": "COMPLETED",
+            "startedAt": "2026-04-26T04:00:00Z",
+        },
+    ]
+    assert _run_jq(_FAILED_FILTER, rollup) == []
+
+
+def test_failed_reports_name_when_latest_run_is_failure() -> None:
+    """Inverse of the dedupe case: pass-then-fail must still hard-fail.
+
+    The dedupe must not become a "drop FAILUREs blindly" filter — if
+    the most recent run for a name is a FAILURE, the bot must still
+    refuse the merge.
+    """
+    rollup = [
+        {
+            "name": "pytest",
+            "conclusion": "SUCCESS",
+            "status": "COMPLETED",
+            "startedAt": "2026-04-26T04:00:00Z",
+        },
+        {
+            "name": "pytest",
+            "conclusion": "FAILURE",
+            "status": "COMPLETED",
+            "startedAt": "2026-04-26T04:30:00Z",
+        },
+    ]
+    assert _run_jq(_FAILED_FILTER, rollup) == ["pytest"]
+
+
+def test_failed_handles_mixed_names_with_multiple_history_each() -> None:
+    """Only one entry per name is evaluated, even with deep history.
+
+    Three names, each with two historical runs:
+      - alpha: FAILURE then SUCCESS   -> ok, drops out of `failed`.
+      - beta:  SUCCESS then FAILURE   -> latest is FAILURE, surfaces.
+      - gamma: FAILURE then FAILURE   -> latest is FAILURE, surfaces.
+    """
+    rollup = [
+        {"name": "alpha", "conclusion": "FAILURE", "startedAt": "2026-04-26T04:00:00Z"},
+        {"name": "alpha", "conclusion": "SUCCESS", "startedAt": "2026-04-26T04:10:00Z"},
+        {"name": "beta", "conclusion": "SUCCESS", "startedAt": "2026-04-26T04:00:00Z"},
+        {"name": "beta", "conclusion": "FAILURE", "startedAt": "2026-04-26T04:10:00Z"},
+        {"name": "gamma", "conclusion": "FAILURE", "startedAt": "2026-04-26T04:00:00Z"},
+        {"name": "gamma", "conclusion": "FAILURE", "startedAt": "2026-04-26T04:10:00Z"},
+    ]
+    assert sorted(_run_jq(_FAILED_FILTER, rollup)) == ["beta", "gamma"]
+
+
+def test_failed_excludes_merge_bot_own_runs() -> None:
+    """The dedupe must run *after* the merge-bot self-filter.
+
+    A previous merge-bot run that failed must not be considered a
+    failure, regardless of how recent its startedAt is. Without the
+    self-filter the bot would refuse to merge forever after its own
+    first failure; the dedupe being upstream of it would not change
+    that — but a future edit that swaps the order should still pass
+    this test.
+    """
+    rollup = [
+        {
+            "name": "Merge ==COMMIT_MSG== block as squash body",
+            "workflowName": "Merge Bot",
+            "conclusion": "FAILURE",
+            "startedAt": "2026-04-26T05:00:00Z",
+        },
+        {
+            "name": "pr-lint",
+            "conclusion": "SUCCESS",
+            "startedAt": "2026-04-26T04:00:00Z",
+        },
+    ]
+    assert _run_jq(_FAILED_FILTER, rollup) == []
+
+
+def test_failed_includes_legacy_commit_status_via_context() -> None:
+    """Legacy commit statuses use `context` + `state`, not `name` + `conclusion`.
+
+    The dedupe falls back to `.context` for the group key so legacy
+    statuses get the same fail-then-pass treatment as Actions check-runs.
+    """
+    rollup = [
+        {"context": "ci/jenkins", "state": "FAILURE", "startedAt": "2026-04-26T04:00:00Z"},
+        {"context": "ci/jenkins", "state": "SUCCESS", "startedAt": "2026-04-26T04:10:00Z"},
+    ]
+    assert _run_jq(_FAILED_FILTER, rollup) == []
+
+
+# --- pending selector --------------------------------------------------
+
+
+def test_pending_empty_when_stale_in_progress_was_superseded_by_success() -> None:
+    """Stale IN_PROGRESS from a cancelled run must not pin the wait path.
+
+    The bot exits cleanly (and waits for `check_suite.completed`) when
+    `pending` is non-empty. Without dedupe on the pending selector, an
+    abandoned IN_PROGRESS entry — common after a cancelled rerun —
+    keeps the bot in the wait-clean-exit branch even though every
+    check has since completed. With dedupe, the latest SUCCESS entry
+    wins and the bot proceeds to merge.
+    """
+    rollup = [
+        {
+            "name": "pytest",
+            "conclusion": "",
+            "status": "IN_PROGRESS",
+            "startedAt": "2026-04-26T03:00:00Z",
+        },
+        {
+            "name": "pytest",
+            "conclusion": "SUCCESS",
+            "status": "COMPLETED",
+            "startedAt": "2026-04-26T04:00:00Z",
+        },
+    ]
+    assert _run_jq(_PENDING_FILTER, rollup) == []
+
+
+def test_pending_reports_name_when_latest_run_is_in_progress() -> None:
+    """A genuinely-running rerun after an old completion is still pending."""
+    rollup = [
+        {
+            "name": "pytest",
+            "conclusion": "SUCCESS",
+            "status": "COMPLETED",
+            "startedAt": "2026-04-26T04:00:00Z",
+        },
+        {
+            "name": "pytest",
+            "conclusion": "",
+            "status": "IN_PROGRESS",
+            "startedAt": "2026-04-26T04:30:00Z",
+        },
+    ]
+    assert _run_jq(_PENDING_FILTER, rollup) == ["pytest"]
+
+
+# --- regression-pin: filters extracted, not invented -------------------
+
+
+def test_dedupe_step_present_in_both_selectors() -> None:
+    """Defence-in-depth: the test relies on the dedupe being in *both* filters.
+
+    A future edit that removes the dedupe from one selector (say,
+    pending) but leaves the other intact would pass the
+    fail-then-pass case but reintroduce the stale-IN_PROGRESS bug.
+    Pin the structural shape so the only way to silence this test is
+    to keep the dedupe in both filters — exactly the invariant issue
+    #347 calls out.
+    """
+    for name, filter_body in [("failed", _FAILED_FILTER), ("pending", _PENDING_FILTER)]:
+        assert "group_by" in filter_body, f"{name} filter is missing group_by"
+        assert "max_by" in filter_body, f"{name} filter is missing max_by"
+
+
+@pytest.mark.parametrize("filter_body", [_FAILED_FILTER, _PENDING_FILTER])
+def test_filters_handle_empty_rollup(filter_body: str) -> None:
+    """Empty rollup is valid input; both selectors must return zero names."""
+    assert _run_jq(filter_body, []) == []


### PR DESCRIPTION
==COMMIT_MSG==
fix(merge-bot): dedupe statusCheckRollup by latest run per check

`statusCheckRollup` returns one entry per check *run*, not per check
*name*. A retried check — workflow rerun, fix-then-push, close+reopen
retrigger — appears multiple times in the rollup, and the historical
FAILURE entry never disappears for the lifetime of the head SHA. The
existing failure / pending predicates in `Inspect required checks`
selected every entry blindly, so once a check had ever failed on a
SHA the bot refused to merge forever (origin: PR #346, where
`changelog-lint` failed on the first run, passed on the close+reopen
retrigger, and kept the bot pinned at `FAILED_CHECKS: changelog-lint`
until the stale failed run was manually deleted via `gh run delete`).

Group rollup entries by `name` (falling back to `.context` for legacy
commit statuses) and keep only the most-recent entry per group via
`max_by(.startedAt // "")` before applying the failure / pending
predicates. The dedupe is applied to *both* selectors — without it on
the pending side, a stale `IN_PROGRESS` from a cancelled rerun would
pin the bot in the wait-clean-exit branch indefinitely.

Closes #347

Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

## Review notes

### Files touched

- `.github/workflows/merge-bot.yml` — `Inspect required checks` step gains a `group_by(.name // .context // "<unnamed>") | map(max_by(.startedAt // ""))` step on both the `failed` and `pending` jq filters. Surrounding comment expanded to document the WHY (rollup carries one entry per *run*, fail-then-pass would otherwise wedge the bot indefinitely) and references issue #347 for archaeologists.
- `tests/test_merge_bot_rollup_dedupe.py` — new pytest module pinning the dedupe predicate. Extracts the `failed=` / `pending=` jq blocks straight out of the workflow YAML (so the test cannot drift from a hand-typed copy) and feeds hand-rolled rollup payloads through real `jq -r`. Asserts on the structural invariant (`group_by` + `max_by` present in *both* filters) plus the behavioural cases.

### Internal decisions

- **Test placement**: `tests/test_merge_bot_rollup_dedupe.py` (workspace-level), mirroring `tests/test_extract_commit_msg_block.py` and `tests/test_setup_devcontainer_signing.py`. The root `tests/` tree is the documented home for cross-service / scripted-CI tests (`scripts/test.sh` lists it explicitly under `UNIT_TEST_PATHS`), so no harness wiring is needed — `task test`, `scripts/test.sh --unit`, and the `lefthook` `test-fast` already cover it.
- **Test shape**: Python (subprocess to real `jq`) instead of a pure-bash fixture script. The repo has zero `tests/*.sh` files and a deep pytest investment; mirroring the existing `subprocess.run(["jq", ...])` pattern from `test_setup_devcontainer_signing.py` keeps this change inside one harness.
- **Filter extraction via regex** (rather than copy-pasting the jq into the test): a future edit that tweaks the filter — or accidentally removes the dedupe — would otherwise pass the test silently while breaking the bot. The `test_dedupe_step_present_in_both_selectors` belt-and-braces case is the structural pin.

### Test plan

- [x] New test covers the four cases from the issue: fail-then-pass, pass-then-fail, stale `IN_PROGRESS` superseded by `SUCCESS`, mixed-name multi-history. Plus a legacy-commit-status case (`.context` fallback) and an empty-rollup edge case.
- [x] `scripts/lint.sh` green.
- [x] `scripts/format.sh --check` green.
- [x] `scripts/typecheck.sh` green (mypy + pyright across all 168 source files).
- [x] `uv run pytest tests/ --no-cov` green (66 passed including 10 new cases).
- [x] `yq . .github/workflows/merge-bot.yml > /dev/null` parses cleanly.