### PR TITLE
fix(merge-bot): trigger on workflow_run when CI goes green

### DIFF
--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -242,8 +242,22 @@ jobs:
 
       - name: Skip if PR is not in scope
         if: steps.pr.outputs.pr != '' && (steps.meta.outputs.state != 'OPEN' || steps.meta.outputs.has_automerge_label != 'true')
+        env:
+          # Pass step outputs via env rather than `${{ }}` interpolation
+          # into the shell. CodeQL js/actions/command-injection treats
+          # `workflow_run` / `workflow_dispatch` triggers as external
+          # sources, so any value derived from them (even via gh-API
+          # outputs like `steps.meta.outputs.state`) becomes a tainted
+          # input the moment it lands in a `run:` block via inline
+          # interpolation. Binding through `env:` puts the value in the
+          # process environment and lets bash quote it normally — the
+          # same defensive shape every other run-block in this file
+          # already uses.
+          PR_NUMBER: ${{ steps.pr.outputs.pr }}
+          PR_STATE: ${{ steps.meta.outputs.state }}
+          HAS_AUTOMERGE_LABEL: ${{ steps.meta.outputs.has_automerge_label }}
         run: |
-          echo "merge-bot: PR #${{ steps.pr.outputs.pr }} state=${{ steps.meta.outputs.state }} label=${{ steps.meta.outputs.has_automerge_label }}; nothing to do."
+          echo "merge-bot: PR #${PR_NUMBER} state=${PR_STATE} label=${HAS_AUTOMERGE_LABEL}; nothing to do."
           exit 0
 
       # Inspect required-check status. We classify each required

--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -14,8 +14,16 @@ name: Merge Bot
 #
 # Triggers:
 #   - pull_request: labeled — proceed when the new label == `automerge`.
-#   - check_suite: completed — sticky-label retry once the last check
-#     turns green AFTER the label was set.
+#   - workflow_run: completed — sticky-label retry once the last
+#     watched CI workflow completes AFTER the label was set. We list
+#     every PR-gating workflow by name so each one's completion fires
+#     the bot. `workflow_run` is used here (not `check_suite`) because
+#     `check_suite` events are suppressed by GitHub's anti-recursion
+#     rule when the upstream workflow runs under the default
+#     `GITHUB_TOKEN` — every CI workflow in this repo does, so
+#     `check_suite: completed` never delivered. `workflow_run` is the
+#     documented escape hatch and fires regardless of the upstream
+#     authenticating token. Origin: issue #348.
 #   - workflow_dispatch — maintainer break-glass against a specific
 #     PR number.
 #
@@ -35,13 +43,35 @@ name: Merge Bot
 #   - PR is not mergeable (conflict, missing reviews, etc.).
 #
 # The label stays sticky on lint/check failure so the
-# check_suite.completed retrigger picks up the recovered run
+# workflow_run.completed retrigger picks up the recovered run
 # automatically.
 
 on:
   pull_request:
     types: [labeled]
-  check_suite:
+  # Every PR-gating workflow listed by name so each completion fires
+  # the bot. Adding a new required-check workflow requires updating
+  # this list — that's intentional. Excludes:
+  #   - Merge Bot itself (anti-recursion).
+  #   - Release / publish / scorecard / dependency-submission /
+  #     mutation / benchmark workflows that don't run on PRs.
+  #   - Release Tag (only fires on PR `closed`, well after merge).
+  workflow_run:
+    workflows:
+      - Test
+      - Check
+      - Typecheck
+      - CodeQL
+      - PR Lint
+      - DCO
+      - Changelog Lint
+      - REUSE
+      - Dependency Review
+      - Verify Design
+      - Verify Function Tests
+      - Verify Standards
+      - Verify Token CLI / HTTP Parity
+      - Changelog Bot
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -59,14 +89,14 @@ permissions:
   contents: read
   checks: read
 
-# Prevent two triggers (label + check_suite) from racing on the same
+# Prevent two triggers (label + workflow_run) from racing on the same
 # PR. Group key includes the PR/SHA so different PRs still run in
 # parallel; cancellation is OFF because we want each trigger to run
 # to completion (an early-exit on "already merged" is cheap, and
 # losing a trigger could leave the PR stuck waiting for the next
 # event).
 concurrency:
-  group: merge-bot-${{ github.event.pull_request.number || github.event.check_suite.head_sha || inputs.pr_number }}
+  group: merge-bot-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || inputs.pr_number }}
   cancel-in-progress: false
 
 jobs:
@@ -75,12 +105,12 @@ jobs:
     runs-on: ubuntu-latest
     # Cheap pre-filter so we don't burn a runner on every label
     # event (`labeled` fires for *every* label, not just `automerge`),
-    # and so `check_suite.completed` only proceeds when the suite
-    # itself succeeded. Per-PR sticky-label and required-check checks
-    # happen in the steps below.
+    # and so `workflow_run.completed` only proceeds when the upstream
+    # workflow itself succeeded. Per-PR sticky-label and required-check
+    # checks happen in the steps below.
     if: |
       (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'automerge')
-      || (github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success')
+      || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
       || github.event_name == 'workflow_dispatch'
     steps:
       # The merge call needs to satisfy the `main` ruleset's
@@ -100,11 +130,12 @@ jobs:
           private-key: ${{ secrets.MERGE_BOT_PRIVATE_KEY }}
 
       # Resolve the PR number for each trigger. `pull_request`
-      # carries it directly. `check_suite` carries a list of PRs the
-      # suite was run for; we pick the first one carrying the
-      # `automerge` label. `workflow_dispatch` takes it as input.
-      # Surface the resolved number as a step output so later steps
-      # don't have to re-derive it from the event payload.
+      # carries it directly. `workflow_run` carries the head SHA of
+      # the upstream workflow's run; we resolve the same-repo PR by
+      # `automerge` label and matching head SHA. `workflow_dispatch`
+      # takes it as input. Surface the resolved number as a step
+      # output so later steps don't have to re-derive it from the
+      # event payload.
       - name: Resolve target PR
         id: pr
         env:
@@ -112,11 +143,13 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           DISPATCH_PR: ${{ inputs.pr_number }}
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-          # check_suite payload — need the head SHA to enumerate PRs
+          # workflow_run payload — need the head SHA to enumerate PRs
           # in the same repo carrying the `automerge` label. Cross-
-          # repo PRs (forks) don't appear in `check_suite.pull_requests`
-          # by design; this bot only operates on same-repo PRs.
-          CHECK_SUITE_HEAD_SHA: ${{ github.event.check_suite.head_sha }}
+          # repo workflow runs (forks) carry the contributor's head
+          # SHA, but `gh pr list --search <SHA>` still locates the
+          # same-repo PR row that owns it; the search is by SHA, not
+          # by repo of authorship.
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
           case "${EVENT_NAME}" in
@@ -126,20 +159,20 @@ jobs:
             workflow_dispatch)
               echo "pr=${DISPATCH_PR}" >> "${GITHUB_OUTPUT}"
               ;;
-            check_suite)
+            workflow_run)
               # `gh pr list --search` returns same-repo PRs whose head
               # SHA matches and whose labels include `automerge`. If
-              # no such PR exists, exit cleanly — the suite likely
+              # no such PR exists, exit cleanly — the workflow likely
               # ran for a PR that hasn't been queued for the bot.
               found="$(gh pr list \
                 --repo "${GITHUB_REPOSITORY}" \
                 --state open \
                 --label automerge \
-                --search "${CHECK_SUITE_HEAD_SHA}" \
+                --search "${WORKFLOW_RUN_HEAD_SHA}" \
                 --json number \
                 --jq '.[0].number // empty')"
               if [[ -z "${found}" ]]; then
-                echo "merge-bot: no automerge-labeled PR for head sha ${CHECK_SUITE_HEAD_SHA}; nothing to do"
+                echo "merge-bot: no automerge-labeled PR for head sha ${WORKFLOW_RUN_HEAD_SHA}; nothing to do"
                 echo "pr=" >> "${GITHUB_OUTPUT}"
               else
                 echo "pr=${found}" >> "${GITHUB_OUTPUT}"
@@ -161,7 +194,7 @@ jobs:
           # (the head ref of a PR carries the contributor's changes;
           # checking out the head would make the extractor self-
           # mutable). pr-lint.yml uses the same defensive pin via the
-          # PR base SHA — `main` is even safer because `check_suite`
+          # PR base SHA — `main` is even safer because `workflow_run`
           # has no PR base SHA in its event payload.
           ref: main
 
@@ -216,7 +249,7 @@ jobs:
       # Inspect required-check status. We classify each required
       # check into FAILURE / PENDING / SUCCESS and react:
       #   - FAILURE: hard-fail with a Claude comment.
-      #   - PENDING: clean exit; the check_suite.completed retrigger
+      #   - PENDING: clean exit; the workflow_run.completed retrigger
       #     will run the bot again once everything settles.
       #   - All SUCCESS: proceed.
       # Uses the GraphQL `statusCheckRollup` so legacy commit-status
@@ -319,7 +352,7 @@ jobs:
           PENDING_CHECKS: ${{ steps.checks.outputs.pending }}
         run: |
           names="$(printf '%s\n' "${PENDING_CHECKS}" | awk 'NF' | paste -sd ', ' -)"
-          echo "merge-bot: pending checks (${names}); will retry on check_suite.completed."
+          echo "merge-bot: pending checks (${names}); will retry on workflow_run.completed."
           exit 0
 
       - name: Extract ==COMMIT_MSG== block

--- a/changelog/@unreleased/pr-354-merge-bot-workflow-run-trigger.yml
+++ b/changelog/@unreleased/pr-354-merge-bot-workflow-run-trigger.yml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+type: fix
+fix:
+  description: |
+    `merge-bot` now refires automatically when CI goes green after the
+    `automerge` label was already applied. The bot's old
+    `check_suite: completed` trigger never delivered because GitHub's
+    anti-recursion rule suppresses `check_suite` events for upstream
+    workflows authenticated with the default `GITHUB_TOKEN` — which
+    every CI workflow in this repo uses. The trigger has been swapped
+    for `workflow_run: completed` with each PR-gating CI workflow
+    listed by name; `workflow_run` events fire regardless of the
+    upstream's authenticating token, so contributors no longer have
+    to remove and re-add the `automerge` label as an undocumented
+    kick once CI completes.
+  links:
+    - https://github.com/aidanns/agent-auth/issues/348
+    - https://github.com/aidanns/agent-auth/pull/354

--- a/tests/test_merge_bot_workflow_run_trigger.py
+++ b/tests/test_merge_bot_workflow_run_trigger.py
@@ -39,6 +39,7 @@ shape, same regression-pin pattern.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, cast
 
 import yaml
 
@@ -74,18 +75,20 @@ EXPECTED_WORKFLOWS: frozenset[str] = frozenset(
 )
 
 
-def _load_workflow() -> dict:
-    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+def _load_workflow() -> dict[Any, Any]:
+    return cast("dict[Any, Any]", yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8")))
 
 
 # `on` is parsed as the Python boolean key `True` by PyYAML 1.1 semantics
 # (the YAML 1.1 spec treats `on` / `off` / `yes` / `no` as booleans).
 # Look it up via either key so the test is robust to PyYAML version drift.
-def _on_block(workflow: dict) -> dict:
+# Hence the dict key type is Any: a string under modern PyYAML, the
+# boolean True under YAML 1.1 strict parsers.
+def _on_block(workflow: dict[Any, Any]) -> dict[str, Any]:
     if "on" in workflow:
-        return workflow["on"]
+        return cast("dict[str, Any]", workflow["on"])
     if True in workflow:
-        return workflow[True]
+        return cast("dict[str, Any]", workflow[True])
     raise AssertionError("merge-bot.yml has no `on:` block")
 
 

--- a/tests/test_merge_bot_workflow_run_trigger.py
+++ b/tests/test_merge_bot_workflow_run_trigger.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Static-pin tests for the merge-bot's workflow_run trigger surface.
+
+The merge bot (`.github/workflows/merge-bot.yml`) used to trigger on
+`check_suite: completed` to refire once CI went green AFTER the
+`automerge` label was applied. In practice that event never fired
+for this repo: GitHub's documented anti-recursion rule suppresses
+`check_suite` events for workflows authenticated with the default
+`GITHUB_TOKEN`, and every CI workflow in this repo runs under that
+token. The bug surfaced on PR #346 — the bot only ran when the
+contributor's label-add coincidentally landed after CI was already
+green — and was tracked as issue #348.
+
+The fix swapped `check_suite: completed` for `workflow_run: completed`
+with each PR-gating CI workflow listed by name. `workflow_run` events
+fire from `GITHUB_TOKEN`-authenticated workflows; the watched-workflows
+list is enumerated explicitly so adding a new CI workflow requires
+conscious wiring into the merge-bot trigger surface.
+
+These tests pin the public-facing shape of that fix:
+  - `on:` declares `workflow_run: types: [completed]` and lists every
+    expected workflow.
+  - `on:` no longer declares `check_suite`.
+  - The pre-filter `if:` recognises the `workflow_run` event and gates
+    on `workflow_run.conclusion == 'success'`.
+  - The `Resolve target PR` step has a `workflow_run)` case arm that
+    reads `github.event.workflow_run.head_sha`.
+  - The concurrency-group key includes `workflow_run.head_sha` as a
+    fallback (so two triggers on the same SHA serialise correctly).
+
+Test placement: tests/ alongside test_merge_bot_rollup_dedupe.py
+(merged in PR #350) — same merge-bot.yml surface, same yaml-loading
+shape, same regression-pin pattern.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "merge-bot.yml"
+
+# Every workflow name expected to feed merge-bot via workflow_run. The
+# list MUST stay in sync with merge-bot.yml. Drift in either direction
+# (workflow renamed, new required workflow added without updating the
+# merge-bot list) breaks the bot's refire-on-CI-green path silently —
+# pinning the exact set here surfaces the drift at test time. See
+# issue #348 for the rationale; the list excludes Merge Bot itself
+# (anti-recursion), release / publish / scorecard / dependency-
+# submission / mutation / benchmark workflows that don't run on PRs,
+# and Release Tag (only fires on PR `closed`, well after merge).
+EXPECTED_WORKFLOWS: frozenset[str] = frozenset(
+    {
+        "Test",
+        "Check",
+        "Typecheck",
+        "CodeQL",
+        "PR Lint",
+        "DCO",
+        "Changelog Lint",
+        "REUSE",
+        "Dependency Review",
+        "Verify Design",
+        "Verify Function Tests",
+        "Verify Standards",
+        "Verify Token CLI / HTTP Parity",
+        "Changelog Bot",
+    }
+)
+
+
+def _load_workflow() -> dict:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+# `on` is parsed as the Python boolean key `True` by PyYAML 1.1 semantics
+# (the YAML 1.1 spec treats `on` / `off` / `yes` / `no` as booleans).
+# Look it up via either key so the test is robust to PyYAML version drift.
+def _on_block(workflow: dict) -> dict:
+    if "on" in workflow:
+        return workflow["on"]
+    if True in workflow:
+        return workflow[True]
+    raise AssertionError("merge-bot.yml has no `on:` block")
+
+
+def test_on_block_declares_workflow_run_completed() -> None:
+    """The bot must trigger on `workflow_run: types: [completed]`.
+
+    `workflow_run` is the only trigger that fires from upstream
+    workflows authenticated with the default `GITHUB_TOKEN`; without it
+    the bot never refires when CI goes green and the `automerge` label
+    becomes a footgun (issue #348).
+    """
+    on_block = _on_block(_load_workflow())
+    assert "workflow_run" in on_block, (
+        "merge-bot.yml must declare `workflow_run` in its `on:` block; "
+        "without it, CI-green retriggers never fire (issue #348)."
+    )
+    workflow_run = on_block["workflow_run"]
+    assert workflow_run.get("types") == [
+        "completed"
+    ], "merge-bot.yml `workflow_run` must subscribe to `[completed]`."
+
+
+def test_on_block_does_not_declare_check_suite() -> None:
+    """Belt-and-braces is rejected: `check_suite` never delivered.
+
+    Keeping `check_suite` alongside `workflow_run` is just clutter
+    because GitHub's anti-recursion rule suppresses `check_suite` for
+    GITHUB_TOKEN-authenticated upstream workflows. Drop it.
+    """
+    on_block = _on_block(_load_workflow())
+    assert "check_suite" not in on_block, (
+        "merge-bot.yml must NOT declare `check_suite` — it never "
+        "delivers for GITHUB_TOKEN-authenticated upstream workflows "
+        "and is just clutter (issue #348)."
+    )
+
+
+def test_workflow_run_lists_every_expected_workflow() -> None:
+    """The watched-workflows set must match the curated list exactly.
+
+    Adding a new required-check workflow without wiring it into the
+    merge-bot's `workflow_run.workflows` list silently regresses the
+    bot back to the "only fires on label toggle" failure mode for that
+    workflow. Removing one without updating this test lets dead
+    entries accumulate. Pin the set so drift in either direction
+    surfaces here.
+    """
+    on_block = _on_block(_load_workflow())
+    workflows = on_block["workflow_run"].get("workflows")
+    assert isinstance(
+        workflows, list
+    ), "merge-bot.yml `workflow_run.workflows` must be a YAML list."
+    actual = set(workflows)
+    missing = EXPECTED_WORKFLOWS - actual
+    extra = actual - EXPECTED_WORKFLOWS
+    assert not missing and not extra, (
+        f"merge-bot.yml watched-workflows drift: "
+        f"missing={sorted(missing)} extra={sorted(extra)}. "
+        f"Update both merge-bot.yml and EXPECTED_WORKFLOWS in this test."
+    )
+
+
+def test_every_expected_workflow_exists_in_repo() -> None:
+    """Each watched workflow name must resolve to a real workflow file.
+
+    `workflow_run` matches by the upstream workflow's `name:` field;
+    a typo here means the bot silently doesn't refire for that
+    workflow. Walk `.github/workflows/*.yml` and confirm every name
+    in the watched list has a matching `name:`.
+    """
+    workflows_dir = REPO_ROOT / ".github" / "workflows"
+    actual_names = set()
+    for path in workflows_dir.glob("*.yml"):
+        if path.name == "merge-bot.yml":
+            continue
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict) and isinstance(data.get("name"), str):
+            actual_names.add(data["name"])
+    missing = EXPECTED_WORKFLOWS - actual_names
+    assert not missing, (
+        f"merge-bot.yml watches workflows that don't exist (renamed "
+        f"or deleted?): {sorted(missing)}. `workflow_run` matches by "
+        f"the upstream workflow's `name:` field — a typo here means "
+        f"the bot silently won't refire for that workflow."
+    )
+
+
+def test_pre_filter_recognises_workflow_run_success() -> None:
+    """The job `if:` must gate `workflow_run` on `conclusion == 'success'`.
+
+    The pre-filter saves us from burning a runner on every label
+    event and every workflow_run event — only the `automerge` label
+    add and successful workflow_run completions should reach the
+    steps. Pin the exact predicate so a regression in the boolean
+    structure (e.g. dropping the conclusion check, or matching on
+    `status` instead of `conclusion`) shows up here.
+    """
+    workflow = _load_workflow()
+    job = workflow["jobs"]["merge"]
+    if_clause = job["if"]
+    assert (
+        "github.event_name == 'workflow_run'" in if_clause
+    ), "merge-bot.yml job `if:` must recognise `workflow_run` events."
+    assert "github.event.workflow_run.conclusion == 'success'" in if_clause, (
+        "merge-bot.yml job `if:` must gate `workflow_run` events on "
+        "`workflow_run.conclusion == 'success'`."
+    )
+    # The old `check_suite` predicate must not linger.
+    assert "check_suite" not in if_clause, (
+        "merge-bot.yml job `if:` still references `check_suite`; "
+        "it should reference `workflow_run` only (issue #348)."
+    )
+
+
+def test_resolve_target_pr_step_handles_workflow_run() -> None:
+    """The `Resolve target PR` case block must have a `workflow_run)` arm.
+
+    The arm sources the head SHA from `github.event.workflow_run.head_sha`
+    and reuses the same `gh pr list --search <sha> --label automerge`
+    lookup the old `check_suite)` arm used. Without the rename, the
+    bot's case statement drops through to the default and resolves no
+    PR — every refire becomes a silent no-op.
+    """
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["merge"]["steps"]
+    resolve_step = next((s for s in steps if s.get("name") == "Resolve target PR"), None)
+    assert resolve_step is not None, "merge-bot.yml is missing the `Resolve target PR` step."
+    run_body = resolve_step["run"]
+    assert "workflow_run)" in run_body, (
+        "merge-bot.yml `Resolve target PR` must have a `workflow_run)` " "case arm."
+    )
+    # The head-SHA env var must be wired from the workflow_run payload.
+    env = resolve_step.get("env", {})
+    head_sha_value = env.get("WORKFLOW_RUN_HEAD_SHA", "")
+    assert "github.event.workflow_run.head_sha" in head_sha_value, (
+        "merge-bot.yml `Resolve target PR` must read the head SHA from "
+        "`github.event.workflow_run.head_sha`."
+    )
+    # The stale `check_suite)` arm must be gone.
+    assert "check_suite)" not in run_body, (
+        "merge-bot.yml `Resolve target PR` still has a `check_suite)` "
+        "case arm; it should be `workflow_run)` (issue #348)."
+    )
+
+
+def test_concurrency_group_includes_workflow_run_head_sha() -> None:
+    """The concurrency-group key must fall back to `workflow_run.head_sha`.
+
+    Two simultaneous triggers on the same head SHA (one from a label
+    add, one from a workflow_run completion) must serialise on the
+    same group key. Without the `workflow_run.head_sha` fallback, the
+    workflow_run trigger's group key collapses to `merge-bot-` (the
+    PR number is unset on workflow_run events) and every workflow_run
+    trigger contends on the same singleton group regardless of PR.
+    """
+    workflow = _load_workflow()
+    group_expr = workflow["concurrency"]["group"]
+    assert "github.event.workflow_run.head_sha" in group_expr, (
+        "merge-bot.yml concurrency-group key must include "
+        "`github.event.workflow_run.head_sha` as a fallback."
+    )
+    assert "github.event.check_suite.head_sha" not in group_expr, (
+        "merge-bot.yml concurrency-group key still references "
+        "`check_suite.head_sha`; it should reference "
+        "`workflow_run.head_sha` (issue #348)."
+    )


### PR DESCRIPTION
==COMMIT_MSG==
fix(merge-bot): trigger on workflow_run when CI goes green

GitHub's anti-recursion rule suppresses `check_suite` events for any
upstream workflow authenticated with the default `GITHUB_TOKEN`, and
every CI workflow in this repo runs under that token. The bot's
`check_suite: completed` trigger therefore never delivered: every
merge-bot run on PR #346 was triggered by `pull_request` (label
toggles), zero by `check_suite`. Contributors had to remove and
re-add the `automerge` label as an undocumented kick to get the bot
to refire after CI went green — a race-prone, opaque footgun.

Swap `check_suite: completed` for `workflow_run: completed` and
enumerate every PR-gating CI workflow by name. `workflow_run` events
fire regardless of the upstream's authenticating token, so the bot
refires automatically as each watched workflow completes. The
explicit list (excluding Merge Bot itself, release / publish /
scorecard / dependency-submission / mutation / benchmark workflows
that don't run on PRs, and Release Tag which only fires on PR
`closed`) makes adding a new required-check workflow a conscious
two-file change instead of silently regressing the bot for that
workflow.

Knock-on edits: pre-filter `if:` now gates `workflow_run.conclusion ==
'success'`; concurrency-group key falls back to
`workflow_run.head_sha` so triggers serialise per-SHA; the
`Resolve target PR` step's `check_suite)` case arm is renamed
`workflow_run)` and reads the head SHA from
`github.event.workflow_run.head_sha`. The comment block at the top
of the file now explains the GITHUB_TOKEN / anti-recursion rationale
inline so archaeologists don't have to grep issue history.

Static-pin tests under `tests/test_merge_bot_workflow_run_trigger.py`
assert the public-facing shape of the fix: presence of `workflow_run`,
absence of `check_suite`, the watched-workflows set matching the
curated EXPECTED_WORKFLOWS frozenset, every name in that set
resolving to a real workflow file, and the four downstream knock-on
edits (pre-filter, concurrency, case arm, env-var). Same regression-
pin pattern as `test_merge_bot_rollup_dedupe.py` (PR #350).

Closes #348

Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

## Review notes

### Files touched

- `.github/workflows/merge-bot.yml` — `check_suite` -> `workflow_run` trigger with explicit watched-workflows list, pre-filter `if:`, concurrency-group key, `Resolve target PR` case arm + env-var, plus comments throughout (top-of-file rationale block, `Inspect required checks` retrigger note, wait-pending log message, checkout-step base-SHA comment).
- `tests/test_merge_bot_workflow_run_trigger.py` — new static-pin test (7 cases) for the trigger surface.
- `changelog/@unreleased/pr-<PR>-merge-bot-workflow-run-trigger.yml` — `fix:` entry, hand-authored after PR creation.

### Internal decisions

- **Watched-workflows list verification.** Cross-checked the issue's list against `.github/workflows/*.yml` by enumerating every workflow's `name:` field. The full issue list is correct; no additions, no removals. Excluded (verified by reading each `on:` block): `Benchmark` (workflow_dispatch + schedule only), `Mutation` (workflow_dispatch + schedule only), `Scorecard` (push + schedule + workflow_dispatch on default branch), `Dependency Submission` (push + schedule + workflow_dispatch on default branch), `Release PR` / `Release Publish` (release-path-only, push trigger), `Release Tag` (only fires on `pull_request: closed` for release branches, well after merge), and `Merge Bot` itself (anti-recursion). `PR Lint` uses `pull_request_target` rather than `pull_request` but still produces a check run that gates on PRs, so it's included. The exclusions are documented inline in the YAML next to the watched list.
- **Test placement.** Co-located with `tests/test_merge_bot_rollup_dedupe.py` (just merged in PR #350) under root `tests/`. Same workflow-YAML loading shape, same regression-pin convention. Kept as a separate file rather than appending to the dedupe test file because the test concerns are orthogonal (rollup-jq behaviour vs. trigger-surface declarations) and the dedupe file's docstring is tightly scoped.
- **Verification approach.** Went with static-fixture (a) only — the test parses `merge-bot.yml`, asserts the trigger / pre-filter / concurrency / case-arm shape, and confirms each watched workflow name resolves to a real `.yml` file. Did NOT cross-check against the repo's branch-protection required-checks list (option b); that would need either `gh api repos/.../branches/main/protection` (gated by token) or a hand-curated allowlist that itself drifts. The current shape catches the failure modes that matter most: missing trigger, lingering `check_suite`, watched-workflows drift in either direction, knock-on edits missed.
- **Trigger-payload semantics for forks.** `workflow_run` for a fork-authored PR fires from the upstream `pull_request`-triggered run on `aidanns/agent-auth`, not from the fork. The head SHA in the payload is still the contributor's, and `gh pr list --search <SHA>` resolves the same-repo PR row, so no fork-specific handling is needed. Comment in the env-var block calls this out so future readers don't assume forks are an edge case.

### Test plan

- [x] `pytest tests/test_merge_bot_workflow_run_trigger.py` — 7 passed.
- [x] `pytest tests/test_merge_bot_rollup_dedupe.py` — 10 passed (no regression on the dedupe pin from PR #350).
- [x] `task check` — green.
- [x] `yq . .github/workflows/merge-bot.yml` — parses cleanly.
- [x] Manual: every workflow in the watched list exists under `.github/workflows/` with the matching `name:` field.
- [x] Manual: no remaining functional `check_suite` references in the file (only the rationale paragraph at the top and inside the `not in on_block` test assertion).
- [ ] Post-merge: confirm a `workflow_run`-triggered bot run fires after each watched workflow completes on the next PR. Cannot verify pre-merge — the bot is still on the old `check_suite` trigger surface until this PR lands.

### Self-review only

The orchestrator's pipeline asked the implementing agent to spawn a review subagent. The Task / general-purpose subagent type isn't available in this harness; I self-reviewed the diff against `CLAUDE.md`, `.claude/instructions/*.md`, and `CONTRIBUTING.md` for scope creep, undocumented decisions, missing test cases, dead code, naming, breaking-change disclosure, and convention compliance (Palantir prefix, `==COMMIT_MSG==` block, DCO sign-off, changelog entry will be hand-authored after this PR is open). Findings: none.
