### PR TITLE
fix(release-pr): format generated CHANGELOG.md before committing

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -80,6 +80,15 @@ jobs:
         # this workflow only needs the changelog tooling.
         run: pip install --no-cache-dir 'pyyaml>=6'
 
+      # mdformat (and uv, which provisions it) lives behind the shared
+      # toolchain action. Needed for the post-apply CHANGELOG.md format
+      # step below — without it the rendered CHANGELOG drifts from the
+      # repo's mdformat conventions and the next-push `Check` job fails
+      # `scripts/format.sh --check` on the release PR. See issue #356.
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+
       - name: Resolve current version
         id: current
         shell: bash
@@ -128,6 +137,20 @@ jobs:
           python3 scripts/changelog/build_release.py apply \
             --repo-root . \
             --current-version "${CURRENT_VERSION}"
+
+      - name: Format generated CHANGELOG.md
+        # The apply step's renderer doesn't match the repo's mdformat
+        # conventions (wrap, list-numbering, blank-line rules) byte for
+        # byte, so without this step the next-push `Check` job fails
+        # `scripts/format.sh --check` on the release PR and the maintainer
+        # has to hand-reformat. Keep this narrowly scoped to CHANGELOG.md
+        # rather than running `task format` over the full tree — only
+        # CHANGELOG.md was just rewritten, and the subsequent
+        # `git add changelog CHANGELOG.md` would drop any other rewrites
+        # anyway. mdformat picks up `.mdformat.toml` automatically. See
+        # issue #356.
+        if: steps.plan.outputs.skip == 'false'
+        run: mdformat CHANGELOG.md
 
       - name: Configure git identity
         # Look up the App's bot user ID at runtime so the

--- a/changelog/@unreleased/pr-360-format-release-changelog.yml
+++ b/changelog/@unreleased/pr-360-format-release-changelog.yml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+type: fix
+fix:
+  description: |
+    The `Release PR` workflow now runs `mdformat CHANGELOG.md` after
+    rendering the next release section, so the generated `CHANGELOG.md`
+    matches the repo's mdformat conventions byte for byte. Without this
+    pass, the release PR's `Check` job failed `scripts/format.sh
+    --check` and the maintainer had to hand-reformat before merging —
+    a regression introduced when the release flow moved from
+    semantic-release (which had this pass via its prepare step) to the
+    YAML-driven workflow in #321. The shared
+    `./.github/actions/setup-toolchain` action provisions the
+    manifest-pinned mdformat the new step depends on.
+  links:
+    - https://github.com/aidanns/agent-auth/issues/356
+    - https://github.com/aidanns/agent-auth/pull/360


### PR DESCRIPTION
==COMMIT_MSG==
fix(release-pr): format generated CHANGELOG.md before committing

The `Apply moves and rewrite CHANGELOG.md` step in `release-pr.yml`
emits a `CHANGELOG.md` that doesn't match the repo's mdformat
conventions (wrap, list-numbering, blank-line rules), so the
next-push `Check` job fails `scripts/format.sh --check` on the
release PR and the maintainer has to hand-reformat. This is the
regression `release.yml` used to avoid by shelling out to
`task format` from semantic-release's prepare step (removed in #321
when the release flow moved to the YAML-driven workflow).

Re-instate that pass by adding `./.github/actions/setup-toolchain`
to provision uv + mdformat (and the rest of the shared toolchain)
on the runner, then inserting a `Format generated CHANGELOG.md`
step that runs `mdformat CHANGELOG.md` between the apply step and
the git identity / branch-create steps. The new step is narrowly
scoped to CHANGELOG.md rather than running `task format` over the
full tree because only CHANGELOG.md was just rewritten and the
subsequent `git add changelog CHANGELOG.md` would drop any other
rewrites anyway. mdformat picks up `.mdformat.toml` automatically.

`scripts/format.sh` doesn't accept positional file arguments
(unknown args exit 2), so neither `scripts/format.sh CHANGELOG.md`
nor `task format -- CHANGELOG.md` from the issue body would have
worked. Using `mdformat` directly with the manifest-pinned version
the toolchain action installs is equivalent to what `task format`
would do for that one file and avoids touching the foundational
formatter script.

Closes #356

Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

## Review notes

### Test plan

- [ ] CI: `Check` workflow passes on this PR (no behaviour change to gated paths).
- [ ] Post-merge: next push to `main` triggers `Release PR`. The opened/refreshed `release/<X.Y.Z>` PR's `Check` job goes green without a hand-reformat.
- [ ] Existing #355 (the stuck release PR) is superseded automatically by the next computed version (or refreshed for the same version via force-push) — no manual close needed.

### Implementation notes

- The `setup-toolchain` action was the issue's recommended path. Alternative considered: minimal `uv tool install mdformat` install. Rejected because `setup-toolchain` is the single source of truth for tool versions in this repo (per `.github/tool-versions.yaml`), and the per-job cost (~1-2 min) sits comfortably inside the 10-minute timeout.
- The new step is gated on `steps.plan.outputs.skip == 'false'` to mirror the apply step it follows — when there are no unreleased entries to ship, nothing to format.