### PR TITLE
improvement(pr-lint): tighten numbered-list regex so 4+ digit identifier prefixes don't false-positive

### DIFF
--- a/.github/workflows/tests/pr-lint-fixtures/invalid-numbered-list.md
+++ b/.github/workflows/tests/pr-lint-fixtures/invalid-numbered-list.md
@@ -1,0 +1,9 @@
+==COMMIT_MSG==
+Add a thing.
+
+1. ran `task check`
+2. ran `task test`
+
+Closes #8
+Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
+==COMMIT_MSG==

--- a/.github/workflows/tests/pr-lint-fixtures/valid-numeric-reference-wrap.md
+++ b/.github/workflows/tests/pr-lint-fixtures/valid-numeric-reference-wrap.md
@@ -1,0 +1,11 @@
+==COMMIT_MSG==
+Honouring the contract from ADR
+0011. Subsequent prose follows.
+
+Closes #358
+Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
+==COMMIT_MSG==
+
+## Review notes
+
+- ran `task check`

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -63,13 +63,21 @@ require_tool taplo \
 
 shell_files_raw="$(list_tracked '*.sh')"
 python_files_raw="$(list_tracked '*.py')"
+markdown_files_raw_unfiltered="$(list_tracked '*.md')"
 # Exclude pr-lint validator fixtures: these are byte-exact PR-body
 # inputs and mdformat would escape literal `<n>.` / `<n>)` lines
 # (CommonMark ordered-list markers), defeating the very tests that
 # exercise the validator's numbered-list discrimination (#358). Kept
-# in lockstep with the `excludes` entry in treefmt.toml.
-markdown_files_raw="$(list_tracked '*.md' \
-  | grep -v '^\.github/workflows/tests/pr-lint-fixtures/' || true)"
+# in lockstep with the `excludes` entry in treefmt.toml. The filter
+# runs against the captured variable, not piped from `git ls-files`,
+# so a `git` failure in `list_tracked` still trips `set -e`.
+# `grep -v` exits 1 when nothing matches the filter pattern (i.e.
+# no markdown files outside the fixture dir), so swallow that with
+# `|| true` — the empty result is the legitimate "skip" signal that
+# `format_group` already handles.
+markdown_files_raw="$(grep -v \
+  '^\.github/workflows/tests/pr-lint-fixtures/' \
+  <<<"${markdown_files_raw_unfiltered}" || true)"
 toml_files_raw="$(list_tracked '*.toml')"
 
 format_group() {

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -63,7 +63,13 @@ require_tool taplo \
 
 shell_files_raw="$(list_tracked '*.sh')"
 python_files_raw="$(list_tracked '*.py')"
-markdown_files_raw="$(list_tracked '*.md')"
+# Exclude pr-lint validator fixtures: these are byte-exact PR-body
+# inputs and mdformat would escape literal `<n>.` / `<n>)` lines
+# (CommonMark ordered-list markers), defeating the very tests that
+# exercise the validator's numbered-list discrimination (#358). Kept
+# in lockstep with the `excludes` entry in treefmt.toml.
+markdown_files_raw="$(list_tracked '*.md' \
+  | grep -v '^\.github/workflows/tests/pr-lint-fixtures/' || true)"
 toml_files_raw="$(list_tracked '*.toml')"
 
 format_group() {

--- a/scripts/validate-commit-msg-block.py
+++ b/scripts/validate-commit-msg-block.py
@@ -85,7 +85,15 @@ DISALLOWED_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("markdown heading", re.compile(r"^#{1,6}\s")),
     ("task checkbox", re.compile(r"^\s*[-*+]\s+\[[ xX]\]\s")),
     ("bullet list item", re.compile(r"^\s*[-*+]\s+\S")),
-    ("numbered list item", re.compile(r"^\s*\d+[.)]\s+\S")),
+    # Cap the digit count at 3 so a wrapped 4+ digit identifier
+    # reference (e.g. `ADR\n0011. follows.` — see #358) does not
+    # false-positive as a list marker. CommonMark ordered lists in
+    # practice use 1-3 digit markers (`1.` … `999.`); a 4+ digit
+    # prefix in prose is almost always an identifier wrap (ADR /
+    # issue / RFC / CVE). Trade-off: a literal numbered list with a
+    # 4+ digit marker sneaks through; the false-positive avoidance
+    # gain is worth the false-negative.
+    ("numbered list item", re.compile(r"^\s*\d{1,3}[.)]\s+\S")),
 ]
 
 # Comment / instruction lines the contributor may leave behind by

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -12,6 +12,11 @@
 [formatter.mdformat]
 command = "mdformat"
 includes = ["*.md"]
+# pr-lint validator fixtures are byte-exact PR-body inputs — mdformat
+# would escape literal `<n>.` / `<n>)` lines (CommonMark ordered-list
+# markers) and defeat the very tests that exercise the validator's
+# numbered-list discrimination (#358). Keep these files unformatted.
+excludes = [".github/workflows/tests/pr-lint-fixtures/*.md"]
 
 [formatter.ruff]
 command = "ruff"


### PR DESCRIPTION
==COMMIT_MSG==
The DISALLOWED_PATTERNS regex for numbered lists matched any
`\d+[.)]\s+\S` line, which false-positives on wrapped identifier
references where a 4+ digit reference number lands at the start
of the next line (e.g. `ADR\n0011. follows.`). Observed on PR
#355 where `0011. ...` was a wrapped reference to ADR 0011, not
a list marker, and the validator refused the PR.

Cap the digit count at 3 so realistic CommonMark ordered-list
markers (`1.` ... `999.`, `1)` ... `999)`) still fail closed
while 4+ digit identifier wraps pass. Trade-off: a literal
numbered list with a 4+ digit marker sneaks through; the
false-negative is acceptable for the false-positive avoidance
gain.

Add two fixtures: `valid-numeric-reference-wrap.md` exercises
the new wrap path; `invalid-numbered-list.md` locks in that
small-digit ordered lists still fail (no fixture covered this
branch before — only bullet lists did).

Exclude the pr-lint-fixtures directory from mdformat (in both
scripts/format.sh and treefmt.toml). The fixtures are byte-exact
PR-body inputs and mdformat would escape literal `<n>.` lines
(CommonMark ordered-list markers), defeating the very tests
that exercise the validator's numbered-list discrimination.

The validator-self-test job globs the fixture directory rather
than enumerating each file, so no workflow edit is needed; the
new fixtures are picked up automatically.

Closes #358
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

CI plumbing only — tightens a regex in `scripts/validate-commit-msg-block.py` so wrapped identifier references (`ADR\n0011.`) stop being misclassified as list markers. No user-visible change, so opting out of the changelog with `==NO_CHANGELOG==`.

Test plan:
- [x] Ran the validator self-test loop against every `pr-lint-fixtures/*.md` (12 existing + 2 new); all passed.
- [x] Confirmed the new `valid-numeric-reference-wrap.md` fails the OLD regex (proves the fixture exercises the change) and passes the NEW regex.
- [x] Confirmed the new `invalid-numbered-list.md` (small-digit `1.`, `2.` markers) still fails after the tightening.
- [x] `bash scripts/format.sh --check` passes.
- [x] `yq . .github/workflows/pr-lint.yml > /dev/null` (YAML valid).
- [x] `pytest scripts/changelog/tests/test_build_release.py` (validator-importing tests) passes.

Companion work:
- #357 — renderer-side fix in `_wrap_paragraph` to never produce the failing wrap; defense-in-depth, lands separately.
- #345 — relaxes the `==COMMIT_MSG==` rule to allow plain bullet lists; touches the same `DISALLOWED_PATTERNS` list. Out of scope here; #345 will rebase on top if it lands later.