### PR TITLE
fix(build_release): keep numeric refs off the start of wrapped lines

### DIFF
--- a/changelog/@unreleased/pr-362-build-release-numeric-reference-wrap-fix.yml
+++ b/changelog/@unreleased/pr-362-build-release-numeric-reference-wrap-fix.yml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+type: fix
+fix:
+  description: |
+    `scripts/changelog/build_release.py` no longer produces a
+    release-PR `==COMMIT_MSG==` body that fails the PR-body lint
+    when changelog descriptions cite an ADR, issue, or spec by
+    number. Greedy 72-char word wrap previously landed tokens like
+    `0011.` (from `ADR 0011.`) or `1234)` (from `(issue 1234)`) at
+    line start, which `validate-commit-msg-block.py`'s
+    `numbered list item` rule rejects as an ordered-list item — see
+    PR #355's broken `chore(release): 0.14.0` body. The renderer now
+    refuses to break immediately before a `<digits>[.)]` token,
+    accepting a soft overflow rather than producing a line the
+    validator rejects. Hyphen-joined identifiers like
+    `CVE-2024-12345` still wrap normally.
+  links:
+    - https://github.com/aidanns/agent-auth/issues/357
+    - https://github.com/aidanns/agent-auth/pull/362

--- a/changelog/@unreleased/pr-362-build-release-numeric-reference-wrap-fix.yml
+++ b/changelog/@unreleased/pr-362-build-release-numeric-reference-wrap-fix.yml
@@ -12,11 +12,12 @@ fix:
     `0011.` (from `ADR 0011.`) or `1234)` (from `(issue 1234)`) at
     line start, which `validate-commit-msg-block.py`'s
     `numbered list item` rule rejects as an ordered-list item — see
-    PR #355's broken `chore(release): 0.14.0` body. The renderer now
-    refuses to break immediately before a `<digits>[.)]` token,
-    accepting a soft overflow rather than producing a line the
-    validator rejects. Hyphen-joined identifiers like
-    `CVE-2024-12345` still wrap normally.
+    PR #355's broken `chore(release): 0.14.0` body. When a numeric
+    token would otherwise overflow the current line, the renderer
+    now moves the preceding token down with it so the wrap point
+    sits between two ordinary tokens — preserving both the 72-char
+    width rule and the no-numbered-list rule. Hyphen-joined
+    identifiers like `CVE-2024-12345` still wrap normally.
   links:
     - https://github.com/aidanns/agent-auth/issues/357
     - https://github.com/aidanns/agent-auth/pull/362

--- a/scripts/changelog/build_release.py
+++ b/scripts/changelog/build_release.py
@@ -84,6 +84,16 @@ SECTION_HEADINGS: dict[EntryType, str] = {
 # Matches `validate-commit-msg-block.py`'s `MAX_LINE_WIDTH`.
 COMMIT_MSG_WRAP = 72
 
+# Tokens shaped like `<digits>.` or `<digits>)` look like ordered-list
+# items to `validate-commit-msg-block.py`'s `numbered list item` rule
+# (DISALLOWED_PATTERNS) when they land at the start of a wrapped line.
+# This recurs in changelog prose because numbered references such as
+# `ADR 0011.`, `issue 1234)`, `RFC 2119`, or `PR 357.` are common —
+# the noun and the digits sit on either side of a soft wrap point.
+# `_wrap_paragraph` glues such a token to the previous one rather than
+# letting it open a fresh line, even at the cost of a soft overflow.
+NUMERIC_PERIOD_RE = re.compile(r"^\d+[.)]")
+
 
 @dataclass(frozen=True)
 class FileMove:
@@ -382,12 +392,26 @@ def _wrap_paragraph(text: str, width: int) -> str:
     `textwrap.fill` breaks long URLs at boundary chars; this trivial
     greedy wrapper instead keeps each whitespace-separated token
     intact so the rendered notes never split a link.
+
+    Also refuses to break immediately before a `<digits>.` or
+    `<digits>)` token: letting one land at line start would look
+    like an ordered-list item to ``validate-commit-msg-block.py``'s
+    "numbered list item" rule (numbered references like `ADR 0011.`
+    and `issue 1234)` are common in changelog prose). Glueing the
+    numeric token to the previous one preserves a soft overflow
+    rather than producing a paragraph the validator rejects.
     """
     out_lines: list[str] = []
     current = ""
     for token in text.split():
         if not current:
             current = token
+            continue
+        if NUMERIC_PERIOD_RE.match(token):
+            # Soft-overflow ok: a wrap here would leave the numeric
+            # token at the start of the next line and trip the
+            # validator's numbered-list-item rule.
+            current = f"{current} {token}"
             continue
         if len(current) + 1 + len(token) <= width:
             current = f"{current} {token}"

--- a/scripts/changelog/build_release.py
+++ b/scripts/changelog/build_release.py
@@ -393,33 +393,61 @@ def _wrap_paragraph(text: str, width: int) -> str:
     greedy wrapper instead keeps each whitespace-separated token
     intact so the rendered notes never split a link.
 
-    Also refuses to break immediately before a `<digits>.` or
-    `<digits>)` token: letting one land at line start would look
-    like an ordered-list item to ``validate-commit-msg-block.py``'s
+    Also refuses to leave a `<digits>.` or `<digits>)` token at the
+    start of a wrapped line: such a token would look like an ordered
+    list item to ``validate-commit-msg-block.py``'s
     "numbered list item" rule (numbered references like `ADR 0011.`
-    and `issue 1234)` are common in changelog prose). Glueing the
-    numeric token to the previous one preserves a soft overflow
-    rather than producing a paragraph the validator rejects.
+    and `issue 1234)` are common in changelog prose). When a numeric
+    token would otherwise overflow the current line, the previous
+    token is moved down to the next line *with* it — preserving both
+    the 72-char width rule and the no-numbered-list rule. The
+    fallback (when the previous-token-plus-numeric pair still
+    overflows on its own line, or the line has no spare token to
+    move) is to soft-overflow the current line rather than emit a
+    line that opens with `<digits>[.)]`.
     """
     out_lines: list[str] = []
-    current = ""
+    current_tokens: list[str] = []
+
+    def current_width() -> int:
+        # Joined width = sum of token lengths + one space between each.
+        return sum(len(t) for t in current_tokens) + max(len(current_tokens) - 1, 0)
+
+    def flush() -> None:
+        if current_tokens:
+            out_lines.append(" ".join(current_tokens))
+            current_tokens.clear()
+
     for token in text.split():
-        if not current:
-            current = token
+        if not current_tokens:
+            current_tokens.append(token)
             continue
-        if NUMERIC_PERIOD_RE.match(token):
-            # Soft-overflow ok: a wrap here would leave the numeric
-            # token at the start of the next line and trip the
-            # validator's numbered-list-item rule.
-            current = f"{current} {token}"
+        is_numeric = bool(NUMERIC_PERIOD_RE.match(token))
+        fits = current_width() + 1 + len(token) <= width
+        if fits:
+            current_tokens.append(token)
             continue
-        if len(current) + 1 + len(token) <= width:
-            current = f"{current} {token}"
-        else:
-            out_lines.append(current)
-            current = token
-    if current:
-        out_lines.append(current)
+        if is_numeric and len(current_tokens) >= 2:
+            # Move the last token of the current line down with the
+            # numeric token so the wrap point sits between two
+            # ordinary tokens. Preserves both the width rule and the
+            # no-numbered-list rule when the moved pair fits on its
+            # own line; the rare case where it still overflows is
+            # accepted as a soft overflow rather than re-introducing a
+            # numbered-list-shaped line start.
+            last = current_tokens.pop()
+            flush()
+            current_tokens.extend([last, token])
+            continue
+        if is_numeric:
+            # Only one token on the line — moving it down would just
+            # restart the same situation. Soft-overflow instead so
+            # the numeric token does not land at line start.
+            current_tokens.append(token)
+            continue
+        flush()
+        current_tokens.append(token)
+    flush()
     return "\n".join(out_lines)
 
 

--- a/scripts/changelog/tests/test_build_release.py
+++ b/scripts/changelog/tests/test_build_release.py
@@ -283,7 +283,8 @@ def test_render_commit_msg_block_keeps_lines_under_72(repo: Path) -> None:
 # 72 chars used to land tokens like `0011.` (from `ADR 0011.`) at line
 # start when the noun and the digits straddled the wrap point — see
 # issue #357 and the broken `chore(release): 0.14.0` PR. The fix in
-# `_wrap_paragraph` glues `<digits>[.)]` to the previous token.
+# `_wrap_paragraph` keeps `<digits>[.)]` tokens off the start of a
+# wrapped line by moving the preceding token down with them.
 #
 # Tests exercise `render_commit_msg_block` (public API, per
 # testing-standards.md) rather than reaching into `_wrap_paragraph`
@@ -294,15 +295,28 @@ def test_render_commit_msg_block_keeps_lines_under_72(repo: Path) -> None:
 _NUMBERED_REFERENCE_LINE_RE = re.compile(r"^\s*\d+[.)]\s+\S")
 
 
-def _assert_no_numbered_lines(block: str) -> None:
-    """Fail with a useful message if any block line opens like a numbered list."""
-    offenders = [
+def _assert_block_satisfies_validator(block: str) -> None:
+    """Assert no line opens like a numbered list AND every line wraps at 72.
+
+    Both rules sit in ``validate-commit-msg-block.py``. The renderer
+    must satisfy both simultaneously: an early version of the fix
+    glued the numeric token to the previous one but pushed the line
+    past 72 chars, trading one validator failure for another. This
+    helper guards against that regression.
+    """
+    numbered = [
         (idx, line)
         for idx, line in enumerate(block.splitlines(), start=1)
         if _NUMBERED_REFERENCE_LINE_RE.match(line)
     ]
-    assert not offenders, "wrapped numeric reference at line start: " + ", ".join(
-        f"line {idx}: {line!r}" for idx, line in offenders
+    assert not numbered, "wrapped numeric reference at line start: " + ", ".join(
+        f"line {idx}: {line!r}" for idx, line in numbered
+    )
+    too_wide = [
+        (idx, line) for idx, line in enumerate(block.splitlines(), start=1) if len(line) > 72
+    ]
+    assert not too_wide, "block line over 72 chars: " + ", ".join(
+        f"line {idx} ({len(line)} chars): {line!r}" for idx, line in too_wide
     )
 
 
@@ -330,7 +344,7 @@ def test_render_commit_msg_block_does_not_wrap_before_adr_number(repo: Path) -> 
     plan = compute_release(repo, "0.4.0")
     assert plan is not None
     block = render_commit_msg_block(plan.entries, plan.next_version)
-    _assert_no_numbered_lines(block)
+    _assert_block_satisfies_validator(block)
 
 
 def test_render_commit_msg_block_does_not_wrap_before_close_paren_number(
@@ -356,7 +370,7 @@ def test_render_commit_msg_block_does_not_wrap_before_close_paren_number(
     plan = compute_release(repo, "0.4.0")
     assert plan is not None
     block = render_commit_msg_block(plan.entries, plan.next_version)
-    _assert_no_numbered_lines(block)
+    _assert_block_satisfies_validator(block)
 
 
 def test_render_commit_msg_block_wraps_normally_around_hyphen_joined_id(
@@ -381,9 +395,7 @@ def test_render_commit_msg_block_wraps_normally_around_hyphen_joined_id(
     plan = compute_release(repo, "0.4.0")
     assert plan is not None
     block = render_commit_msg_block(plan.entries, plan.next_version)
-    _assert_no_numbered_lines(block)
-    for line in block.splitlines():
-        assert len(line) <= 72, f"line too wide: {line!r}"
+    _assert_block_satisfies_validator(block)
     # Sanity: the identifier survives unbroken — it must not be split
     # across a wrap point either (the existing URL-preservation rule).
     assert "CVE-2024-12345" in block

--- a/scripts/changelog/tests/test_build_release.py
+++ b/scripts/changelog/tests/test_build_release.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import datetime as _dt
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -273,6 +274,119 @@ def test_render_commit_msg_block_keeps_lines_under_72(repo: Path) -> None:
     block = render_commit_msg_block(plan.entries, plan.next_version)
     for line in block.splitlines():
         assert len(line) <= 72, f"line too wide: {line!r}"
+
+
+# --- numbered-reference wrap regressions ------------------------------------
+#
+# `validate-commit-msg-block.py` rejects any block line matching
+# `^\s*\d+[.)]\s+\S` (the `numbered list item` rule). Greedy wrap on
+# 72 chars used to land tokens like `0011.` (from `ADR 0011.`) at line
+# start when the noun and the digits straddled the wrap point — see
+# issue #357 and the broken `chore(release): 0.14.0` PR. The fix in
+# `_wrap_paragraph` glues `<digits>[.)]` to the previous token.
+#
+# Tests exercise `render_commit_msg_block` (public API, per
+# testing-standards.md) rather than reaching into `_wrap_paragraph`
+# directly: the validator only sees the rendered block, and the
+# render-then-validate path is the contract a regression would break.
+
+
+_NUMBERED_REFERENCE_LINE_RE = re.compile(r"^\s*\d+[.)]\s+\S")
+
+
+def _assert_no_numbered_lines(block: str) -> None:
+    """Fail with a useful message if any block line opens like a numbered list."""
+    offenders = [
+        (idx, line)
+        for idx, line in enumerate(block.splitlines(), start=1)
+        if _NUMBERED_REFERENCE_LINE_RE.match(line)
+    ]
+    assert not offenders, "wrapped numeric reference at line start: " + ", ".join(
+        f"line {idx}: {line!r}" for idx, line in offenders
+    )
+
+
+def test_render_commit_msg_block_does_not_wrap_before_adr_number(repo: Path) -> None:
+    """`ADR 0011.` must never end up split across a soft wrap point.
+
+    Reproduces issue #357: the source prose mirrors the wording from
+    PR #355 that broke the `==COMMIT_MSG==` lint, with enough prefix
+    text to push the `0011.` token onto a wrap boundary at width 72.
+    """
+    # Crafted so the buggy greedy wrapper would land `0011.` at the
+    # start of the second line: `Features: ` + the prose below packs
+    # exactly to 72 chars at `… from ADR`, leaving the `0011.` token
+    # (digits + period) to overflow onto the next line — exactly the
+    # failure mode from PR #355's `chore(release): 0.14.0` body.
+    description = (
+        "Switch back to the single-use refresh contract design "
+        "from ADR 0011. Then verify the rebuilt wrap."
+    )
+    _seed_unreleased(
+        repo,
+        "pr-100-feat.yml",
+        f"type: feature\nfeature:\n  description: {description}\n",
+    )
+    plan = compute_release(repo, "0.4.0")
+    assert plan is not None
+    block = render_commit_msg_block(plan.entries, plan.next_version)
+    _assert_no_numbered_lines(block)
+
+
+def test_render_commit_msg_block_does_not_wrap_before_close_paren_number(
+    repo: Path,
+) -> None:
+    """`issue 1234)` must not split with `1234)` opening a wrapped line.
+
+    Same failure mode as the `<digits>.` case but for the close-paren
+    variant rejected by the same validator rule.
+    """
+    # Crafted so `Fixes: ` + the prose below ends the first line at
+    # `… in (issue` (68 chars), leaving the buggy wrapper to drop
+    # `1234)` onto the next line — i.e. `1234) and verify the …`.
+    description = (
+        "Restore the long-standing renderer regression noted in "
+        "(issue 1234) and verify the rebuilt wrap."
+    )
+    _seed_unreleased(
+        repo,
+        "pr-100-fix.yml",
+        f"type: fix\nfix:\n  description: {description}\n",
+    )
+    plan = compute_release(repo, "0.4.0")
+    assert plan is not None
+    block = render_commit_msg_block(plan.entries, plan.next_version)
+    _assert_no_numbered_lines(block)
+
+
+def test_render_commit_msg_block_wraps_normally_around_hyphen_joined_id(
+    repo: Path,
+) -> None:
+    """Hyphen-joined identifiers like `CVE-2024-12345` must wrap normally.
+
+    The fix targets `\\d+[.)]` tokens specifically. A token containing
+    digits but joined with hyphens does not match `NUMERIC_PERIOD_RE`,
+    so the standard greedy wrap should apply and the resulting lines
+    must still satisfy the 72-char width and numbered-list rules.
+    """
+    description = (
+        "Mitigate the upstream advisory tracked as CVE-2024-12345 by "
+        "pinning the affected dependency and adding a regression test."
+    )
+    _seed_unreleased(
+        repo,
+        "pr-100-fix.yml",
+        f"type: fix\nfix:\n  description: {description}\n",
+    )
+    plan = compute_release(repo, "0.4.0")
+    assert plan is not None
+    block = render_commit_msg_block(plan.entries, plan.next_version)
+    _assert_no_numbered_lines(block)
+    for line in block.splitlines():
+        assert len(line) <= 72, f"line too wide: {line!r}"
+    # Sanity: the identifier survives unbroken — it must not be split
+    # across a wrap point either (the existing URL-preservation rule).
+    assert "CVE-2024-12345" in block
 
 
 # --- render_release_notes ---------------------------------------------------


### PR DESCRIPTION
==COMMIT_MSG==
fix(build_release): keep numeric refs off the start of wrapped lines

`scripts/changelog/build_release.py:_wrap_paragraph` did greedy
whitespace-split word wrap at 72 chars. When source prose contained
a numbered reference like `ADR 0011.`, `issue 1234)`, or `RFC 2119`
and the wrap point landed between the noun and the digits, the
resulting line opened with `<digits>[.)]` — which the
`==COMMIT_MSG==` validator's `numbered list item` rule
(`scripts/validate-commit-msg-block.py`) rejects as an ordered-list
item. The auto-generated `chore(release): 0.14.0` body in PR #355
hit this on the line `0011.` `scripts/setup-devcontainer-signing.sh`
writes the new schema..., and every future release whose entries
reference an ADR / issue / spec by number was equally vulnerable.

Add a `NUMERIC_PERIOD_RE = re.compile(r"^\d+[.)]")` constant and
have `_wrap_paragraph` keep `<digits>[.)]` tokens off the start of
a wrapped line. When a numeric token would otherwise overflow the
current line, the preceding token is moved down with it so the
wrap point sits between two ordinary tokens — preserving both the
72-char width rule and the no-numbered-list rule. A simpler glue-
to-previous variant was tried first but pushed lines past 72,
trading one validator failure for another. URL-preserving
behaviour is unchanged; hyphen-joined identifiers like
`CVE-2024-12345` still wrap normally because they don't match the
new pattern.

Tested via `render_commit_msg_block` (the public surface the
validator actually sees) with descriptions crafted to land
`0011.` and `1234)` at line start under the buggy wrapper plus a
sanity case for `CVE-2024-12345`. The regression assertion checks
both validator rules simultaneously so a future "fix" can't
re-introduce the width failure. The companion validator-side
fix is tracked separately as defense-in-depth.

Closes #357
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

## Review notes

### Why this is a fix, not a chore

This is release-tooling code, but the failure mode is a hard block
on opening any release PR whose changelog entries mention an ADR or
issue by number — i.e. it stops releases from going out. Following
the convention of the recently-merged sibling fix (PR #354,
`fix(merge-bot): ...`), this lands as `fix:` with a hand-authored
changelog entry rather than `chore:` + `no changelog`.

### Title shortening

The original title from issue #357 (`fix(build_release): never wrap
with numeric-reference token at line start`) was 73 chars — one over
the validator's 72-char limit. Shortened to `fix(build_release): keep
numeric refs off the start of wrapped lines` (68 chars).

### Test plan

- [x] `task changelog:test` (197 passed)
- [x] `task test` (742 passed)
- [x] `task lint`
- [x] `task typecheck`
- [x] Reproduced the failure mode against unfixed `build_release.py`:
      both the `ADR 0011.` and `(issue 1234)` regression tests fail,
      the `CVE-2024-12345` sanity test passes — confirming the new
      tests bite the bug and don't over-reach.
- [x] Verified the rendered output of all three regression cases
      stays under 72 chars per line AND avoids numbered-list-shaped
      starts (the assertion helper checks both).
- [ ] After merge, regenerate #355's body via re-running the release
      workflow and confirm the `==COMMIT_MSG==` lint passes.

### Out of scope (per issue)

- Tightening the validator regex itself — companion bug, separate PR.
- Re-wrapping CHANGELOG.md content — different code path,
  CHANGELOG.md tolerates ordered lists.