### PR TITLE
chore(ci): adapt Dependabot PRs to the project's PR conventions

### DIFF
--- a/.github/workflows/changelog-lint.yml
+++ b/.github/workflows/changelog-lint.yml
@@ -14,7 +14,11 @@ name: Changelog Lint
 # update the ruleset itself).
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # `labeled` / `unlabeled` are included so the `no changelog`
+    # bypass label takes effect immediately. Without them, applying
+    # the label after the initial run (e.g. by the dependabot-adapter
+    # workflow) leaves the lint stuck red until the next push.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read

--- a/.github/workflows/dependabot-adapter.yml
+++ b/.github/workflows/dependabot-adapter.yml
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+name: Dependabot Adapter
+
+# Adapt Dependabot PRs to the project's PR conventions so they pass
+# the required `pr-lint` and `changelog-lint` checks without manual
+# intervention. Dependabot only writes a PR title plus an upstream
+# release-notes body — neither the curated `==COMMIT_MSG==` block
+# (ADR 0037, .github/workflows/pr-lint.yml) nor the changelog-entry
+# requirement (.github/workflows/changelog-lint.yml) is satisfied
+# out of the box.
+#
+# What this does on every `dependabot[bot]` PR:
+#
+#   1. Prepends a synthesized `==COMMIT_MSG==` block (with a
+#      Dependabot `Signed-off-by:` trailer that mirrors the trailer
+#      Dependabot already puts on its own commits, so the squash-
+#      merge body lands on `main` with valid DCO).
+#   2. Applies the `no changelog` label — Dependabot upgrades are
+#      `chore(deps)` and don't warrant a CHANGELOG entry, and
+#      `scripts/changelog/lint.py` already supports the label as a
+#      bypass.
+#   3. Applies the `automerge` label — hands the PR to merge-bot
+#      (.github/workflows/merge-bot.yml, ADR 0038) once every
+#      required check is green.
+#
+# Both edits go through the `agent-auth-changelog-bot` App token
+# (not `secrets.GITHUB_TOKEN`) because GitHub does not fire
+# downstream workflows for events caused by `GITHUB_TOKEN` — the
+# label-add must trigger merge-bot's `pull_request: labeled` and the
+# body-edit must trigger pr-lint's `pull_request_target: edited`.
+# App-token-driven events do trigger downstream workflows.
+#
+# Runs on `pull_request` (NOT `pull_request_target`) so a fork PR
+# can never reach this workflow's elevated token. The `if:` gate
+# narrows execution to PRs whose `user.login` is `dependabot[bot]`,
+# which GitHub assigns to PRs opened by the Dependabot App and
+# cannot be spoofed by a contributor.
+#
+# Idempotent: re-running on the same PR is a no-op (the body edit
+# is skipped when a `==COMMIT_MSG==` marker is already present; `gh
+# pr edit --add-label` is a no-op for labels already applied).
+
+on:
+  pull_request:
+    # `synchronize` is included so the adapter picks up Dependabot
+    # PRs that were opened before the workflow shipped (their next
+    # rebase / `@dependabot recreate` push fires `synchronize`).
+    # Idempotency is enforced by the body-block check below — if a
+    # `==COMMIT_MSG==` marker is already in the body, the whole step
+    # is a no-op, which means a maintainer who removes the
+    # `automerge` label mid-flight is not fought by the adapter.
+    types: [opened, reopened, synchronize]
+
+permissions:
+  # Workflow-level perms stay minimal — the App token mints its own
+  # `pull-requests: write` for the body edit and label adds. See
+  # changelog-bot.yml for the same pattern.
+  contents: read
+  pull-requests: read
+
+jobs:
+  adapt:
+    name: dependabot-adapter
+    runs-on: ubuntu-latest
+    # `dependabot[bot]` is the GitHub-assigned login for the
+    # Dependabot App; a fork PR's `user.login` is always the fork
+    # owner, never the bot login, so this gate cannot be spoofed.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      # Bail out cleanly when the bot's secrets haven't been
+      # provisioned yet (e.g. on the PR that adds this workflow, or
+      # in a fork that hasn't installed the App). Mirrors the
+      # changelog-bot pattern so a not-yet-configured environment
+      # doesn't fail the PR.
+      - name: Check secrets are configured
+        id: secrets-check
+        env:
+          APP_ID: ${{ secrets.CHANGELOG_BOT_APP_ID }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APP_ID:-}" ]]; then
+            echo "::notice::CHANGELOG_BOT_APP_ID secret is not set; skipping adapter run."
+            echo "::notice::See docs/release/changelog-bot-setup.md for setup instructions."
+            echo "configured=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "configured=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Create GitHub App token
+        if: steps.secrets-check.outputs.configured == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ secrets.CHANGELOG_BOT_APP_ID }}
+          private-key: ${{ secrets.CHANGELOG_BOT_PRIVATE_KEY }}
+
+      - name: Inject ==COMMIT_MSG== block and apply labels
+        if: steps.secrets-check.outputs.configured == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          existing_body=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" \
+            --json body --jq .body)
+
+          if printf '%s' "${existing_body}" | grep -Fq '==COMMIT_MSG=='; then
+            echo "::notice::PR #${PR_NUMBER} already has a ==COMMIT_MSG== block; adapter is a no-op."
+            exit 0
+          fi
+
+          # Build the new body with printf rather than a heredoc:
+          # the validator (scripts/validate-commit-msg-block.py)
+          # matches the `==COMMIT_MSG==` markers as a full line
+          # after stripping, so leading whitespace on the marker
+          # line would defeat extract_block. printf keeps every
+          # line flush-left regardless of YAML script indentation.
+          tmp=$(mktemp)
+          printf '%s\n' \
+            '==COMMIT_MSG==' \
+            'Routine dependency upgrade authored by Dependabot.' \
+            '' \
+            'See the PR description for upstream release notes.' \
+            '' \
+            'Signed-off-by: dependabot[bot] <support@github.com>' \
+            '==COMMIT_MSG==' \
+            '' \
+            > "${tmp}"
+          printf '%s' "${existing_body}" >> "${tmp}"
+          gh pr edit "${PR_NUMBER}" --repo "${REPO}" --body-file "${tmp}"
+          echo "::notice::Prepended ==COMMIT_MSG== block to PR #${PR_NUMBER} body."
+
+          gh pr edit "${PR_NUMBER}" --repo "${REPO}" \
+            --add-label "no changelog" \
+            --add-label "automerge"
+          echo "::notice::Applied 'no changelog' and 'automerge' labels to PR #${PR_NUMBER}."

--- a/.github/workflows/tests/pr-lint-fixtures/valid-dependabot-adapter.md
+++ b/.github/workflows/tests/pr-lint-fixtures/valid-dependabot-adapter.md
@@ -1,0 +1,23 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+<!--
+The body the dependabot-adapter workflow synthesizes for Dependabot
+PRs (.github/workflows/dependabot-adapter.yml). The block content is
+literal — keep this fixture in sync with the printf invocation in
+that workflow so a regression in either side fails the self-test.
+-->
+
+==COMMIT_MSG==
+Routine dependency upgrade authored by Dependabot.
+
+See the PR description for upstream release notes.
+
+Signed-off-by: dependabot[bot] <support@github.com>
+==COMMIT_MSG==
+
+Bumps [actions/setup-python](https://github.com/actions/setup-python) from 5.6.0 to 6.2.0.
+- Upstream release notes elided in this fixture.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -723,6 +723,15 @@ doesn't have to. Add the trailer manually if you're hand-editing
 the block; if you ran `git commit -s` on the PR commits, copy the
 same `Signed-off-by:` line into the block.
 
+Dependabot PRs are adapted to this flow automatically by
+[`.github/workflows/dependabot-adapter.yml`](.github/workflows/dependabot-adapter.yml):
+on every `dependabot[bot]` PR the adapter prepends a synthesized
+`==COMMIT_MSG==` block (with a Dependabot `Signed-off-by:` trailer)
+and applies the `no changelog` and `automerge` labels, so routine
+`chore(deps):` upgrades flow through pr-lint, changelog-lint, and
+merge-bot without manual intervention. Override by removing either
+label or hand-editing the block before the merge.
+
 Maintainer setup of the merge-bot GitHub App is documented in
 [`docs/release/merge-bot-setup.md`](docs/release/merge-bot-setup.md).
 The interim maintainer-paste mechanics that pre-dated the bot are


### PR DESCRIPTION
<!-- The ==COMMIT_MSG== block below is the squash-merge body. -->

==COMMIT_MSG==
Dependabot PRs are blocked by two required checks the bot cannot
satisfy on its own: pr-lint requires a curated `==COMMIT_MSG==`
block and changelog-lint requires either an `@unreleased/*.yml`
entry or the `no changelog` label. Routine dep bumps stall
indefinitely until a maintainer hand-rolls both.

Add `.github/workflows/dependabot-adapter.yml`: on every
`dependabot[bot]` PR (opened, reopened, or synchronize) the
adapter mints a token from the existing
`agent-auth-changelog-bot` App, prepends a synthesized
`==COMMIT_MSG==` block with a Dependabot `Signed-off-by:`
trailer, and applies the `no changelog` + `automerge` labels. The
work goes through an App token so the downstream `pr-lint`,
`changelog-lint`, and `merge-bot` workflows actually re-fire on
the body / label changes — events caused by
`secrets.GITHUB_TOKEN` do not. The body-block check makes the
whole step idempotent: a maintainer who removes `automerge` to
pause a merge is not fought by the adapter.

Add `labeled` / `unlabeled` to changelog-lint's trigger types so
the `no changelog` bypass takes effect immediately when the
adapter applies it. Without this the lint stays red until the
next push.

Add a pr-lint validator fixture (valid-dependabot-adapter.md)
that mirrors the synthesized body, so a regression in either
side fails the existing self-test.

Existing PR #340 will be picked up by the adapter on its next
`@dependabot rebase` (which fires `pull_request: synchronize`).

Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

### Test plan

- [x] `python3 scripts/validate-commit-msg-block.py` passes against the new fixture and against a synthesized body prepended to PR #340's actual body.
- [x] All existing pr-lint fixtures still pass (`for f in .github/workflows/tests/pr-lint-fixtures/*.md ...`).
- [x] `treefmt --no-cache --fail-on-change` clean; `keep-sorted --mode=lint` clean; `ripsecrets --strict-ignore` clean.
- [x] `scripts/verify-standards.sh` clean.
- [ ] Post-merge: comment `@dependabot rebase` on #340 to fire `pull_request: synchronize`; confirm the adapter prepends the block, applies both labels, downstream checks go green, and merge-bot squashes.

### Design notes

- Sign-off identity is `dependabot[bot] <support@github.com>` — the same trailer Dependabot already puts on its own commits (DCO accepts it on every prior Dependabot PR), and short enough to fit pr-lint's 72-char per-line limit. Using the bot-rid form (`49699333+dependabot[bot]@users.noreply.github.com`) overflows.
- Reuses the existing `agent-auth-changelog-bot` App rather than introducing a new App: same scopes (PR write, contents read), same secret pair already configured, and a maintainer who hasn't installed it sees a no-op notice instead of a red workflow.
- `pull_request` (not `pull_request_target`); the `if:` gate is keyed on `github.event.pull_request.user.login == 'dependabot[bot]'`, which GitHub assigns and contributors cannot spoof from a fork.