### PR TITLE
improvement(release-pr): auto-apply automerge, drop review gate

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -234,14 +234,23 @@ jobs:
           set -euo pipefail
           body="$(jq -r '.pr_body' /tmp/release-plan.json)"
           existing="$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')"
+          # Apply `automerge` and `no changelog` on both create and update
+          # paths so the merge-bot lands the release once required checks
+          # pass. The release PR body is auto-rendered prose and carries
+          # no hand-authored changelog YAML, so `no changelog` keeps
+          # changelog-lint happy. Both labels are idempotent on re-run.
+          # See ADR 0041 § Consequences ("Fully automated releases") and
+          # issue #359.
           if [[ -n "${existing}" ]]; then
             echo "release-pr: updating existing PR #${existing}"
-            gh pr edit "${existing}" --title "${TITLE}" --body "${body}"
+            gh pr edit "${existing}" --title "${TITLE}" --body "${body}" \
+              --add-label automerge,'no changelog'
           else
             echo "release-pr: opening new PR for ${BRANCH}"
             gh pr create \
               --base main \
               --head "${BRANCH}" \
               --title "${TITLE}" \
-              --body "${body}"
+              --body "${body}" \
+              --label automerge,'no changelog'
           fi

--- a/design/decisions/0041-yaml-driven-release-workflow.md
+++ b/design/decisions/0041-yaml-driven-release-workflow.md
@@ -148,10 +148,16 @@ workflow that handles tag + GitHub-Release creation lives in
   the canonical record; the CHANGELOG, the GitHub Release, and the
   release PR are all renderings of the same data. Edits to release
   notes go through the YAML, not three parallel surfaces.
-- **Maintainer review gate.** A release ships only after the
-  release PR merges. Trivial today (auto-merge possible); load-
-  bearing later when the project graduates to 1.0 and downstream
-  consumers care about each release.
+- **Fully automated releases.** A release ships once the release
+  PR's CI passes; the merge bot lands the squash without maintainer
+  involvement. Trust rests on YAML lint and the original feature
+  PR's review at YAML-commit time, plus deterministic rendering by
+  `version_logic` and `build_release`. The maintainer-review gate
+  originally proposed in this ADR was removed in #359 because pre-
+  1.0 the cost of an incorrect bump (recoverable on the next
+  release) does not justify the per-release human checkpoint. Re-
+  evaluate at the 1.0 transition (see *Re-evaluation trigger*
+  below).
 - **Simpler dependency footprint.** The repo loses
   `package.json`, `package-lock.json`, `.releaserc.mjs`, the
   `@semantic-release/*` toolchain, and the npm Dependabot ecosystem.
@@ -163,11 +169,11 @@ workflow that handles tag + GitHub-Release creation lives in
 
 ### Negative / accepted trade-offs
 
-- **Two-step release.** Cutting a release now requires a maintainer
-  to merge the release PR. On a solo project this is overhead the
-  previous flow avoided. Mitigated by `task release` (manual
-  workflow dispatch) and by GitHub auto-merge if the maintainer
-  trusts the auto-rendered notes.
+- **Two-step release.** A release now lands as two commits on
+  `main` (the feature merge then the release PR's squash) rather
+  than one direct `chore(release):` commit. With the merge bot
+  auto-landing the release PR (#359), this costs only the second
+  CI run, not maintainer time.
 - **Workflow complexity.** Two new workflow files + a Python module
   vs. semantic-release's single workflow. The Python module is
   unit-tested (mirroring `version_logic.py`); the workflow YAML
@@ -215,3 +221,13 @@ workflow that handles tag + GitHub-Release creation lives in
   approve pull requests* was off, not the ruleset). `release-pr.yml`
   now mints an App token and uses it for both the release-branch
   push and the `gh pr` calls.
+
+### Re-evaluation trigger
+
+Revisit the auto-merge decision on any of:
+
+- The project crossing 1.0.0.
+- Two consecutive incorrect-bump releases shipping where corrections
+  are disruptive.
+- Downstream consumers reporting reliance on a maintainer review
+  gate.


### PR DESCRIPTION
==COMMIT_MSG==
improvement(release-pr): auto-apply automerge, drop review gate

The release PR's `Open or update release PR` step now applies the
`automerge` and `no changelog` labels on both the create and update
paths, so the merge bot lands the squash without maintainer
involvement once required checks pass. ADR 0041 § Consequences is
amended to reflect the new "Fully automated releases" posture, and
§ Follow-ups gains a Re-evaluation trigger that fires on the 1.0
transition, two consecutive incorrect-bump releases, or a
downstream consumer asking for a maintainer review gate.

Trust now rests on the chain that already exists at PR-merge time:
the YAML changelog lint plus the original feature PR's review when
the YAML lands; deterministic version inference in
`scripts/changelog/version_logic.py`; deterministic CHANGELOG and
PR-body rendering in `scripts/changelog/build_release.py`; and the
merge bot's required-checks gate (no auto-merge until CI is
green). A wrong-tagged YAML still ships a release with the wrong
bump, but pre-1.0 that is recoverable on the next release without
disruption — the cost does not justify a per-release human
checkpoint. ADR 0041 originally deferred the gate's load-bearing
role to "post-1.0"; this honours that deferral and revisits at the
1.0 transition.

The "Two-step release" trade-off bullet is rewritten in the same
edit because the prior wording explicitly required a maintainer to
merge the release PR — a direct contradiction with the new
"Fully automated releases" bullet sitting two bullets above it.

Both `gh pr create --label` and `gh pr edit --add-label` accept
the labels and are idempotent on re-runs, so the workflow stays
safe to re-execute on every push.

Closes #359
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==
==NO_CHANGELOG==
Release-process automation only — no agent-auth, things-bridge,
gpg-bridge, or downstream-CLI surface changes. ADR text is
internal documentation. The auto-merge label is operator
configuration, not a user-facing capability. The release PR
opened by `release-pr.yml` is itself a `chore(release):`
candidate that hand-authored changelog YAML would not describe
better than the rendered release notes do.
==NO_CHANGELOG==

## Review notes

### Test plan

- `yq . .github/workflows/release-pr.yml > /dev/null` — workflow YAML parses.
- `task check` — repo-wide lint + format + workspace dep gates pass.
- `mdformat --check design/decisions/0041-yaml-driven-release-workflow.md` — ADR stays formatted (one wording tweak made to keep `version_logic` and `build_release` off the start of a wrapped line so mdformat does not reflow the bullet into a sublist).
- End-to-end exercise of the labels deferred to the next real `release-pr.yml` run on `main` after this lands; the labels are advisory inputs to merge-bot and changelog-lint, not state the workflow itself reads back.

### Sequencing

Land order from issue #359: #356 + #357 first (so release PR CI can go green), then this. Both prerequisites have already merged (PR #360 for #356, PR #361/#362 for #358/#357), so this is safe to land.

### Out of scope

- Per-package release trains (#275).
- Any further validator / renderer fixes to CHANGELOG.md formatting.