### PR TITLE
chore(docs): consolidate three-bot deployment checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -734,7 +734,11 @@ label or hand-editing the block before the merge.
 
 Maintainer setup of the merge-bot GitHub App is documented in
 [`docs/release/merge-bot-setup.md`](docs/release/merge-bot-setup.md).
-The interim maintainer-paste mechanics that pre-dated the bot are
+The cross-cutting bring-up checklist for all three release-automation
+bots (changelog, merge, release) and the bypass-actor policy that
+applies to the `main` ruleset are documented in
+[`docs/release/bots-overview.md`](docs/release/bots-overview.md). The
+interim maintainer-paste mechanics that pre-dated the merge bot are
 preserved in
 [`docs/release/rollout-pr-template.md`](docs/release/rollout-pr-template.md)
 for historical reference.

--- a/docs/release/bots-overview.md
+++ b/docs/release/bots-overview.md
@@ -1,0 +1,179 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# Release-automation bots — overview and bring-up checklist
+
+Three GitHub Apps back the release-automation workflows on this
+repo. Each App has its own setup doc covering permissions, secret
+rotation, and decommissioning. This doc is the cross-cutting
+checklist: what the three Apps are at a glance, the order in which a
+maintainer brings them online from a clean state, and the
+bypass-actor policy that applies to all three together. Per-App
+docs remain authoritative for App-specific detail; this doc links
+out rather than duplicating.
+
+## The three Apps at a glance
+
+| App slug / actor login          | Workflow file(s)                                                                                                         | Permissions                                                                                       | Required secrets                                                           | Main-ruleset bypass? |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------------------- |
+| `agent-auth-changelog-bot[bot]` | [`changelog-bot.yml`](../../.github/workflows/changelog-bot.yml)                                                         | See [changelog-bot-setup.md](changelog-bot-setup.md#one-time-registration)                        | `CHANGELOG_BOT_APP_ID`, `CHANGELOG_BOT_PRIVATE_KEY`, `CHANGELOG_BOT_EMAIL` | No                   |
+| `agent-auth-merge-bot[bot]`     | [`merge-bot.yml`](../../.github/workflows/merge-bot.yml)                                                                 | See [merge-bot-setup.md](merge-bot-setup.md#step-1--register-the-agent-auth-merge-bot-github-app) | `MERGE_BOT_APP_ID`, `MERGE_BOT_PRIVATE_KEY`                                | **Yes**              |
+| `agent-auth-release-bot[bot]`   | [`release-pr.yml`](../../.github/workflows/release-pr.yml), [`release-tag.yml`](../../.github/workflows/release-tag.yml) | See [Release App setup](../../CONTRIBUTING.md#release-app-setup)                                  | `RELEASE_BOT_APP_ID`, `RELEASE_BOT_PRIVATE_KEY`                            | No                   |
+
+A dedicated `docs/release/release-bot-setup.md` is pending
+(companion follow-up to PR #342). Until it lands, the
+[`CONTRIBUTING.md` § "Release App setup"](../../CONTRIBUTING.md#release-app-setup)
+entry is the source of truth for release-bot setup.
+
+The canonical secret-name shape is `<BOT>_BOT_APP_ID` /
+`<BOT>_BOT_PRIVATE_KEY` where `<BOT>` is the short bot name
+(`CHANGELOG`, `MERGE`, or `RELEASE`). The changelog-bot also needs
+`CHANGELOG_BOT_EMAIL` because its workflow commits to PR branches
+and needs a deterministic `git author.email`. Seven secrets total.
+
+## Bring-up checklist
+
+Order matters: install before secrets so the App's installation ID
+is resolvable when the bypass-actor step looks it up.
+
+1. **Register all three GitHub Apps.** Follow the per-App setup
+   doc for permissions and webhook settings:
+   - `agent-auth-changelog-bot` — see
+     [changelog-bot-setup.md](changelog-bot-setup.md).
+   - `agent-auth-merge-bot` — see
+     [merge-bot-setup.md](merge-bot-setup.md).
+   - `agent-auth-release-bot` — see
+     [`CONTRIBUTING.md` § "Release App setup"](../../CONTRIBUTING.md#release-app-setup).
+2. **Install all three Apps on `aidanns/agent-auth` only.** Not
+   *All repositories*. Each App's installation token is scoped to
+   the repo it is installed on; widening the install scope would
+   broaden the blast radius of a compromised key with no upside.
+3. **Add the seven secrets to the repo's Actions secrets**, using
+   the canonical names from the table above. Set them in
+   [Settings → Secrets and variables → Actions](https://github.com/aidanns/agent-auth/settings/secrets/actions).
+   The workflows consume the names verbatim — a typo
+   (`MERGE_APP_ID` instead of `MERGE_BOT_APP_ID`, say) silently
+   breaks the affected bot at the first run.
+4. **Add `agent-auth-merge-bot` — and only `agent-auth-merge-bot` —
+   as a bypass actor on the `main` ruleset.** Use *Always*
+   bypass-mode. Do **not** add `agent-auth-changelog-bot` or
+   `agent-auth-release-bot`: changelog-bot pushes to PR feature
+   branches (governed by PR-branch rules, not the `main` ruleset),
+   and release-bot pushes to `release/*` branches and tags (also
+   not governed by the `main` ruleset). Adding either to the
+   bypass list would widen the trust boundary without need. See
+   the [bypass-actor policy](#bypass-actor-policy) section below
+   for the full reasoning.
+5. **Verify each bot end-to-end** using the per-App acceptance
+   test:
+   - Changelog-bot:
+     [Verifying the install](changelog-bot-setup.md#verifying-the-install).
+   - Merge-bot:
+     [Verifying the bot end-to-end](merge-bot-setup.md#verifying-the-bot-end-to-end).
+   - Release-bot: open and merge a PR with a release-bumping
+     prefix (`feature:` / `improvement:` / `fix:` / etc.) and
+     confirm `release-pr.yml` opens the `release/X.Y.Z` PR and
+     `release-tag.yml` pushes the tag on its merge.
+
+## Bypass-actor policy
+
+Why merge-bot needs main-ruleset bypass and the other two do not.
+This is the cross-cutting rationale — `merge-bot-setup.md` covers
+the merge-bot-specific UI / API mechanics for adding the bypass
+entry.
+
+- The `main` ruleset enforces `required_status_checks` with
+  `strict_required_status_checks_policy: true` ("Require branches
+  to be up to date before merging"). The default `GITHUB_TOKEN`
+  cannot bypass `required_status_checks` administration; a GitHub
+  App installation can.
+- **Bots wait for checks; they do not bypass the checks
+  themselves.** Merge-bot only fires once every required check on
+  the PR's head SHA is green — see
+  [`merge-bot.yml`](../../.github/workflows/merge-bot.yml) and the
+  `Verifies every required check is green` step in
+  [merge-bot-setup.md](merge-bot-setup.md#what-the-bot-does).
+- The bypass exists so the bot's own gating
+  (checks-green-on-head-SHA) replaces the ruleset's stricter
+  gating (checks-green **and** branch-up-to-date). The bot inspects
+  `statusCheckRollup` for the actual head SHA; the ruleset's
+  strict-policy check additionally requires a fresh rebase against
+  `main`, which would force every bot-merge to be preceded by a
+  human rebase round-trip.
+- **Tradeoff.** With bypass, the bot can squash-merge a
+  slightly-stale-but-green PR (head SHA is green, but a newer
+  commit has landed on `main` since the PR last rebased). Without
+  bypass, every PR needs rebasing right before bot-merge — that
+  re-runs CI on the rebased head, which often takes longer than
+  the staleness-induced semantic risk warrants. The
+  semantic-risk bound is "what changed on `main` between the PR's
+  base and the current `main`"; review at PR time covers it for
+  the kinds of changes this repo lands.
+
+The other two Apps push to branches the `main` ruleset does not
+govern, so their pushes are subject only to PR-branch / release-
+branch rules (signed-commits, status checks at PR merge time)
+and bypass-actor configuration is unnecessary.
+
+## Decommissioning the old `bypass_actors` entry
+
+The `main` ruleset's current `bypass_actors` list still carries an
+entry from PR #321:
+
+```
+actor_id: 3465211
+actor_type: Integration
+```
+
+This is the now-decommissioned `semantic-release-agent-auth` App
+(the previous release-automation App, superseded by
+`agent-auth-release-bot` per
+[ADR 0026](../../design/decisions/0026-semantic-release-autorelease.md)
+and the workspace-release model in
+[ADR 0035](../../design/decisions/0035-workspace-release-model.md)).
+The semantic-release App was removed when the workspace release
+model landed; the `bypass_actors` entry was not cleaned up at the
+time.
+
+Remove the stale entry once `agent-auth-merge-bot` has been added
+as a bypass actor (step 4 above). Either via the UI
+(*Settings → Rules → Rulesets → `main` → Bypass list*) or via the
+API:
+
+```bash
+# Read the current ruleset, drop the stale Integration entry,
+# write the trimmed list back. Keep agent-auth-merge-bot's
+# Integration entry intact.
+gh api 'repos/aidanns/agent-auth/rulesets/<RULESET_ID>' \
+  --jq '.bypass_actors | map(select(.actor_id != 3465211))'
+# … then PATCH the ruleset with the trimmed list (see
+# merge-bot-setup.md for the PATCH payload shape).
+```
+
+Confirm the entry is gone:
+
+```bash
+gh api 'repos/aidanns/agent-auth/rulesets/<RULESET_ID>' \
+  --jq '.bypass_actors[] | select(.actor_id == 3465211)'
+# (no output expected)
+```
+
+## Per-App docs are authoritative
+
+This doc is the deployment checklist + cross-cutting policy
+explainer. For anything App-specific — App permissions, key
+rotation, decommissioning, the operational mechanics of adding the
+merge-bot bypass-actor entry — the per-App docs are the source of
+truth:
+
+- [changelog-bot-setup.md](changelog-bot-setup.md)
+- [merge-bot-setup.md](merge-bot-setup.md)
+- [`CONTRIBUTING.md` § "Release App setup"](../../CONTRIBUTING.md#release-app-setup)
+  (interim, until a dedicated `release-bot-setup.md` lands)
+
+If a per-App detail conflicts with this doc, the per-App doc
+wins; please open an issue so this overview can be brought back
+into agreement.

--- a/docs/release/changelog-bot-setup.md
+++ b/docs/release/changelog-bot-setup.md
@@ -16,7 +16,10 @@ This App is **separate** from
 [`agent-auth-release-bot`](../../CONTRIBUTING.md#release-app-setup)
 (release path) and from #291's merge bot App. Each App is scoped to
 the narrowest set of permissions it needs so revoking one does not
-disrupt the other.
+disrupt the other. For the cross-cutting bring-up checklist that
+covers all three release-automation Apps together (and the
+bypass-actor policy that distinguishes them), see
+[`bots-overview.md`](bots-overview.md).
 
 ## Why a dedicated GitHub App?
 

--- a/docs/release/merge-bot-setup.md
+++ b/docs/release/merge-bot-setup.md
@@ -93,11 +93,19 @@ useful as soon as the next workflow run mints a fresh token.
 
 ## Step 3 — Add the App as a bypass actor on the `main` ruleset
 
-The `main` branch ruleset enforces required status checks. The
+The `main` branch ruleset enforces required status checks; the
 default `GITHUB_TOKEN` cannot bypass `required_status_checks`
-administration; a GitHub App installation can. Add the
-`agent-auth-merge-bot` App installation to the ruleset's bypass-actor
-list:
+administration but a GitHub App installation can. The cross-cutting
+rationale — why merge-bot specifically needs this bypass and the
+other two release-automation bots do not, and the
+fresh-rebase-vs-stale-but-green tradeoff the bypass implies — lives
+in [`bots-overview.md` § "Bypass-actor
+policy"](bots-overview.md#bypass-actor-policy). The mechanics for
+adding the bypass entry (and removing the stale
+`semantic-release-agent-auth` entry from PR #321) are below.
+
+Add the `agent-auth-merge-bot` App installation to the ruleset's
+bypass-actor list:
 
 Via the UI:
 


### PR DESCRIPTION
==COMMIT_MSG==
chore(docs): consolidate three-bot deployment checklist

Add docs/release/bots-overview.md as the single deployment checklist
for the three release-automation Apps (changelog-bot, merge-bot,
release-bot). It centralises the canonical secret-name table, the
end-to-end bring-up sequence, the bypass-actor policy that explains
why only merge-bot needs main-ruleset bypass, and the cleanup of
the stale semantic-release-agent-auth bypass entry from PR #321.

Per-App docs remain authoritative for App-specific detail; this doc
is checklist + cross-cutting policy only. merge-bot-setup.md's
Step 3 is condensed to keep its merge-bot-specific UI / API
mechanics in place but link out to the new doc for the
cross-cutting rationale, satisfying the "documented exactly once"
acceptance criterion. CONTRIBUTING.md and changelog-bot-setup.md
gain one-line cross-references.

Closes #353

Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

### Test plan

- [ ] Static: doc renders cleanly in GitHub preview.
- [ ] All intra-doc links resolve (verified locally with grep over
      file paths and heading anchors before push).
- [ ] `scripts/format.sh` clean on the changed files (verified
      locally; pre-commit lefthook re-ran treefmt with 0 changes).
- [ ] Per-App docs no longer duplicate the bypass-actor policy
      explainer — merge-bot-setup.md Step 3 was condensed to a
      one-paragraph link out, with merge-bot-specific UI / API
      mechanics retained in place.

### Design notes

- The release-bot row links to `CONTRIBUTING.md` § "Release App
  setup" as the interim source of truth, with a note that a
  dedicated `release-bot-setup.md` is pending (issue's "Out of
  scope" anticipates this — companion follow-up to PR #342). Chose
  the inline-paragraph form rather than a `[^1]` footnote because
  mdformat-gfm doesn't support footnotes and was escaping the
  syntax to `\[^1\]:` on format.
- merge-bot-setup.md Step 3 retains its full UI / API instructions
  (the operational mechanics) and adds a one-paragraph link out
  for the cross-cutting policy. The 60-line block flagged in the
  issue body was a mix of cross-cutting policy and operational
  detail; ripping it wholesale would have lost the merge-bot-
  specific PATCH payload shape that maintainers need at bring-up.
- Manual changelog entry omitted (chore: PR). The `no changelog`
  label will be applied via `gh pr edit` after the PR opens; the
  `==NO_CHANGELOG==` marker in the body is the bot's signal.

### Self-review only

No `Task` / general-purpose subagent tool was available in this
environment, so this PR was self-reviewed against the same
checklist instead of being reviewed by a separate agent. Confirmed:

- All five sections from issue #353 are present in
  `bots-overview.md` (table, bring-up checklist, bypass-actor
  policy, decommissioning the stale `actor_id: 3465211` entry,
  per-App-authoritative pointer).
- Secret names in the table match the workflow files verbatim
  (cross-checked via `grep -E 'secrets\.[A-Z_]+_(APP_ID|PRIVATE_KEY|EMAIL)' .github/workflows/{changelog-bot,merge-bot,release-pr,release-tag}.yml`).
- `actor_id: 3465211` is attributed to the decommissioned
  `semantic-release-agent-auth` App (the only repo reference to
  that name is in ADR 0026, which the doc cites).
- `CONTRIBUTING.md` § "Writing PRs" links to the new doc; the
  per-App docs link back to it; the bypass-actor policy lives
  exactly once (in `bots-overview.md`).
- All intra-doc link targets exist on disk; heading anchors match
  the linked-to headings.
- Pre-commit lefthook (treefmt) ran clean — 0 changes after
  format on all four touched files.
