### PR TITLE
chore(ci): enforce subject-style rules in pr-lint validator

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -10,15 +10,20 @@ name: PR Lint
 #   1. PR title uses one of the Palantir-style prefixes
 #      (feature | improvement | fix | break | deprecation | migration |
 #      chore), with optional `(scope)`.
-#   2. The PR body contains exactly one well-formed `==COMMIT_MSG==`
+#   2. PR title obeys the prose-style rules from CONTRIBUTING.md
+#      § "Writing release-worthy commits" → "Subject (PR title)":
+#      72-char hard cap, no trailing period, no past-tense opener
+#      (the closed list of `Added` / `Fixed` / `Updated` / etc.).
+#   3. The PR body contains exactly one well-formed `==COMMIT_MSG==`
 #      block (line wrap, no markdown, BREAKING CHANGE positioning,
-#      trailer parsing).
+#      trailer parsing, leading non-blank, no first-line subject
+#      duplication, kernel-style `Fixes: <sha> ("subject")` shape).
 #
-# A separate `validator-self-test` job exercises the validator against
-# the fixtures under `.github/workflows/tests/pr-lint-fixtures/` on
-# every run, so a regression in the validator (e.g. one that exits 0
-# on every input) immediately fails CI rather than silently approving
-# every PR.
+# Separate self-test jobs (`validator-self-test`,
+# `pr-title-self-test`, `pr-body-title-aware-self-test`) exercise the
+# validators against fixtures and inline cases on every run, so a
+# regression in either validator (e.g. one that exits 0 on every
+# input) immediately fails CI rather than silently approving every PR.
 #
 # This workflow runs on `pull_request_target` so the validator
 # operates on the *base ref's* copy of the script — a fork can't
@@ -66,6 +71,32 @@ jobs:
           # keep-sorted end
           requireScope: false
 
+  pr-title-style:
+    name: PR title (subject style)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Pin to the base ref so a fork PR cannot weaken the
+          # validator in the same PR (see workflow-level comment).
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Validate PR title prose style
+        env:
+          # Read the title via env var instead of inlining
+          # ${{ github.event.pull_request.title }} into the run-block —
+          # the env-var path keeps shell expansion off the title and
+          # mirrors the injection-safety pattern of pr-body-commit-msg.
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          python3 scripts/validate-pr-title.py "${TITLE:-}"
+
   pr-body-commit-msg:
     name: PR body (==COMMIT_MSG== block)
     runs-on: ubuntu-latest
@@ -84,13 +115,19 @@ jobs:
       - name: Validate ==COMMIT_MSG== block
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          # Pass the PR title through to the validator so the
+          # subject-dup body rule (CONTRIBUTING.md → "Writing
+          # release-worthy commits") can run. Same env-var pattern as
+          # the body itself for shell-injection safety.
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
           tmp="$(mktemp)"
           # Write the PR body to disk via env var; piping through the
           # shell would let backticks / $(...) in the PR body execute.
           printf '%s' "${PR_BODY:-}" > "${tmp}"
-          python3 scripts/validate-commit-msg-block.py "${tmp}"
+          python3 scripts/validate-commit-msg-block.py "${tmp}" \
+            --title "${PR_TITLE:-}"
 
   validator-self-test:
     name: Validator self-test
@@ -142,3 +179,41 @@ jobs:
           if [[ ${fail} -ne 0 ]]; then
             exit 1
           fi
+
+  pr-title-self-test:
+    name: PR title validator self-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Same base-ref pin as the live job: the self-test exercises
+          # the validator the live job will run against.
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Run inline self-test
+        run: |
+          set -euo pipefail
+          python3 scripts/validate-pr-title.py --self-test
+
+  pr-body-title-aware-self-test:
+    name: PR body title-aware validator self-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Run inline title-aware self-test
+        run: |
+          set -euo pipefail
+          python3 scripts/validate-commit-msg-block.py --self-test

--- a/.github/workflows/tests/pr-lint-fixtures/README.md
+++ b/.github/workflows/tests/pr-lint-fixtures/README.md
@@ -15,3 +15,21 @@ A new failure mode goes here as `invalid-<slug>.md` alongside the
 extra check it exercises in the validator. The self-test job iterates
 the directory and asserts the expected outcome, so adding a fixture
 is enough to cover the new branch.
+
+## Title-aware and PR-title rules
+
+A few rules need inputs the file-loop cannot supply (the PR title, or
+a (body, title) pair for the subject-dup check). Those rules live in
+inline self-test cases inside the validator scripts and run via
+separate self-test jobs in `pr-lint.yml`:
+
+- `python3 scripts/validate-pr-title.py --self-test` — title-only
+  rules (`pr-title-self-test` job).
+- `python3 scripts/validate-commit-msg-block.py --self-test` —
+  body rules that need a paired title (`pr-body-title-aware-self-test`
+  job).
+
+When you add a new title-only or title-aware rule, extend the
+corresponding `_SELF_TEST_CASES` / `_TITLE_AWARE_SELF_TEST_CASES`
+tuple in the script. File-based fixtures stay reserved for body-only
+rules.

--- a/.github/workflows/tests/pr-lint-fixtures/invalid-fixes-trailer-shape.md
+++ b/.github/workflows/tests/pr-lint-fixtures/invalid-fixes-trailer-shape.md
@@ -1,0 +1,9 @@
+==COMMIT_MSG==
+Use constant-time HMAC comparison in parse_token.
+
+The previous implementation used `==`, exposing a timing oracle.
+
+Fixes: 9c4f1 (broken comparison)
+Closes #2
+Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
+==COMMIT_MSG==

--- a/.github/workflows/tests/pr-lint-fixtures/invalid-leading-blank.md
+++ b/.github/workflows/tests/pr-lint-fixtures/invalid-leading-blank.md
@@ -1,0 +1,10 @@
+==COMMIT_MSG==
+
+Add a thing.
+
+The leading blank line above the subject would render as an empty
+line in `git log`.
+
+Closes #1
+Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
+==COMMIT_MSG==

--- a/.github/workflows/tests/pr-lint-fixtures/valid-fixes-sha-trailer.md
+++ b/.github/workflows/tests/pr-lint-fixtures/valid-fixes-sha-trailer.md
@@ -1,0 +1,10 @@
+==COMMIT_MSG==
+Use constant-time HMAC comparison in parse_token.
+
+Switch to `hmac.compare_digest` so the comparison takes the same
+number of cycles regardless of which byte differs.
+
+Fixes: 9c4f1a2b3d5e ("improvement(tokens): inline parse_token hot path")
+Closes #3
+Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
+==COMMIT_MSG==

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -642,10 +642,13 @@ audiences**:
 
 The split is enforced by [`.github/workflows/pr-lint.yml`](.github/workflows/pr-lint.yml):
 the `pr-title` job validates the PR-title prefix, the
+`pr-title-style` job enforces the prose-style rules on the title
+(length cap, no trailing period, no past-tense opener), the
 `pr-body-commit-msg` job validates the `==COMMIT_MSG==` block, and
-the `validator-self-test` job exercises the validator against
-fixtures so a regression in the validator can never silently approve
-PRs.
+the `validator-self-test` / `pr-title-self-test` /
+`pr-body-title-aware-self-test` jobs exercise both validators against
+fixtures and inline cases so a regression in either validator can
+never silently approve PRs.
 
 #### Writing release-worthy commits
 
@@ -663,6 +666,30 @@ The rules sit alongside
 [ADR 0037](design/decisions/0037-palantir-commit-prefixes-and-commit-msg-block.md)
 rather than superseding it: ADR 0037 defines the prefix allowlist and
 the block structure, this section defines the prose inside.
+
+A subset of the rules below is **CI-enforced**; the rest are
+**convention only** (caught at human review). The split is:
+
+| Rule                                                                             | Enforced by                                                                                                                       |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Title prefix in the Palantir allowlist                                           | CI (`pr-title` job, `amannn/action-semantic-pull-request`)                                                                        |
+| Title ≤ 72 chars                                                                 | CI (`pr-title-style` job, `scripts/validate-pr-title.py`)                                                                         |
+| Title has no trailing period                                                     | CI (`pr-title-style` job)                                                                                                         |
+| Title does not open with a past-tense / participle verb in the closed list       | CI (`pr-title-style` job — list: `Added` / `Fixed` / `Updated` / `Changed` / `Removed` / `Refactored` / `Implemented` / `Bumped`) |
+| Title summary ≤ 50 chars (soft target on the post-prefix summary)                | Convention only                                                                                                                   |
+| Title summary capitalisation (project lowercases post-prefix)                    | Convention only                                                                                                                   |
+| Imperative mood beyond the past-tense closed list                                | Convention only (no clean regex without false positives)                                                                          |
+| Body wraps at ≤ 72 chars                                                         | CI (`pr-body-commit-msg` job, `scripts/validate-commit-msg-block.py`)                                                             |
+| Body has no markdown headings / bullet lists / numbered lists / task checkboxes  | CI (`pr-body-commit-msg` job)                                                                                                     |
+| Body opens non-blank (after PR-template scaffolding)                             | CI (`pr-body-commit-msg` job)                                                                                                     |
+| Body's first line does not duplicate the PR title                                | CI (`pr-body-commit-msg` job, with the title passed in via env var)                                                               |
+| `Fixes: <sha> ("subject")` follows the kernel-style shape when SHA-style is used | CI (`pr-body-commit-msg` job)                                                                                                     |
+| Trailers parse as `Token: value` and use a recognised token                      | CI (`pr-body-commit-msg` job)                                                                                                     |
+| `BREAKING CHANGE:` is the last non-`Signed-off-by:` line                         | CI (`pr-body-commit-msg` job)                                                                                                     |
+| At least one `Signed-off-by:` trailer is present                                 | CI (`pr-body-commit-msg` job; also enforced post-merge by `dco.yml`)                                                              |
+| One logical change per PR                                                        | Convention only (undecidable mechanically)                                                                                        |
+| Body leads with *why*, not *how*                                                 | Convention only (undecidable mechanically)                                                                                        |
+| `fix:` PRs include observable symptoms                                           | Convention only                                                                                                                   |
 
 ##### Subject (PR title)
 

--- a/scripts/validate-commit-msg-block.py
+++ b/scripts/validate-commit-msg-block.py
@@ -24,6 +24,29 @@
 #      `main` without DCO and the post-merge `dco` workflow goes red.
 #      The DCO workflow checks per-PR-commit trailers; this rule
 #      covers the *body* the bot will paste.
+#   7. The first content line of the block (after stripping HTML
+#      comments) is non-blank — git commits open with the subject,
+#      not a leading blank line.
+#   8. When a `Fixes:` trailer carries a SHA-style value (i.e. it is
+#      not the `Fixes #N` GitHub-keyword form), it follows the
+#      kernel-style `Fixes: <sha> ("subject")` shape: a hex SHA of
+#      at least 7 characters followed by a parenthesised
+#      double-quoted subject.
+#
+# The PR title (subject) has its own prose-style rules — length cap,
+# trailing period, past-tense imperative — enforced by the sibling
+# `scripts/validate-pr-title.py` script in the `pr-title-style` job
+# of `.github/workflows/pr-lint.yml`. The two scripts split because
+# the title and the body have different inputs (string vs. file) and
+# different runtime audiences (the action consumes the title via env
+# var; the body validator works against a file on disk).
+#
+# These rules sit alongside the prose conventions documented in
+# CONTRIBUTING.md → "Writing release-worthy commits" (#337); the
+# "Convention only / not CI-enforced" subset there (one-logical-change,
+# why-not-how, ≤50-char summary soft target, capitalisation,
+# imperative mood beyond the past-tense blacklist) is deliberately
+# left to human review.
 #
 # Exits 0 on success, 1 with a human-readable error on failure. Reads
 # the PR body from a file path given as argv[1].
@@ -339,8 +362,140 @@ def check_signoff_present(lines: list[str]) -> None:
     )
 
 
-def validate(body: str) -> None:
+# Kernel-style `Fixes: <sha> ("subject")` shape. The SHA must be at
+# least 7 hex chars (git's default short-SHA width) and the subject
+# must be parenthesised double-quoted text. The trailing-only `\.?`
+# accommodates the historical `Fixes: ... .` shape some contributors
+# use; otherwise the structure is rigid by design.
+FIXES_SHA_TRAILER_RE = re.compile(r'^[0-9a-fA-F]{7,}\s+\("[^"]+"\)\.?$')
+
+# Issue-ref shapes accepted as alternatives to the kernel-style SHA
+# form: `#123` and `owner/repo#123`.
+GITHUB_ISSUE_REF_RE = re.compile(r"^(?:#\d+|[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#\d+)\.?$")
+
+
+def _is_github_issue_ref(value: str) -> bool:
+    return GITHUB_ISSUE_REF_RE.match(value) is not None
+
+
+def check_first_line_non_blank(block: str) -> None:
+    """Reject a leading blank line at the top of the block.
+
+    The git-commit shape is "subject on the first line, blank line,
+    body" — a leading blank line in the *authored* block means the
+    bot pastes a body whose first line is empty, which renders
+    without a subject in `git log`.
+
+    Template scaffolding is the recognised exception: when the first
+    non-blank line is an HTML comment (`<!-- ... -->`) the contributor
+    is using the PR template's instructional comments and the leading
+    blanks are just visual padding around them. In that case we
+    delegate to ``check_non_empty`` to confirm there is *some* content
+    once the comments are stripped.
+    """
+    raw_lines = block.splitlines()
+    if not raw_lines:
+        return
+    # Find the first non-blank line in the raw (un-stripped) block.
+    first_idx = next(
+        (i for i, line in enumerate(raw_lines) if line.strip()),
+        None,
+    )
+    if first_idx is None:
+        # All-blank block — ``check_non_empty`` owns that error path.
+        return
+    # An HTML comment opener at the first non-blank position means the
+    # contributor is using the PR template's scaffolding; preceding
+    # blank lines are intentional padding around it.
+    if raw_lines[first_idx].lstrip().startswith("<!--"):
+        return
+    if first_idx > 0:
+        raise ValidationError(
+            f"`{MARKER}` block opens with {first_idx} blank line(s) "
+            "before the subject. The first content line must be the "
+            "commit subject so the bot's pasted body renders correctly "
+            "in `git log` — drop the leading blank line(s)."
+        )
+
+
+def check_first_line_not_subject_dup(lines: list[str], title: str | None) -> None:
+    """Reject a body whose first line duplicates the PR title.
+
+    The merge bot pastes the PR title as the squash-merge subject and
+    pastes the block as the body. If the contributor copies the title
+    into the first line of the block, the resulting commit has the
+    subject repeated as the first body line — visually noisy in
+    `git log`, and a sign the contributor didn't realise the title
+    *is* the subject.
+
+    `title` is the PR title (passed via `--title` / env var); a
+    ``None`` value means the validator was not given a title (e.g.
+    when invoked from the `validator-self-test` fixture loop), in
+    which case the check is a no-op.
+    """
+    if title is None or not lines:
+        return
+    title_summary = _strip_title_prefix(title).strip().rstrip(".")
+    first_line = lines[0].strip().rstrip(".")
+    if not title_summary or not first_line:
+        return
+    if first_line.lower() == title_summary.lower():
+        raise ValidationError(
+            f"`{MARKER}` block's first line duplicates the PR title "
+            f"({first_line!r}). The PR title becomes the squash-merge "
+            "subject; drop the duplicate from the body and lead with "
+            "the rationale."
+        )
+
+
+PR_TITLE_PREFIX_RE = re.compile(r"^[A-Za-z]+(?:\([^)]+\))?:\s+")
+
+
+def _strip_title_prefix(title: str) -> str:
+    """Return the post-prefix summary of a PR title for comparison."""
+    match = PR_TITLE_PREFIX_RE.match(title)
+    if match is None:
+        return title
+    return title[match.end() :]
+
+
+def check_fixes_trailer_shape(lines: list[str]) -> None:
+    """Validate `Fixes: <sha> ("subject")` shape when SHA-style is used.
+
+    `Fixes #N` and `Fixes owner/repo#N` (the GitHub-keyword form) are
+    accepted as-is — they're handled by the closing-keyword path in
+    ``parse_trailer_block`` and have nothing to validate beyond the
+    issue ref. The kernel-style `Fixes: <sha> ("subject")` form is
+    structurally distinct and easy to get wrong; the regex insists on
+    a ≥ 7-char hex SHA and a parenthesised double-quoted subject so
+    typos like `Fixes: 9c4f1` (too short) or `Fixes: 9c4f1a2 broken`
+    (no quoted subject) fail loudly.
+    """
+    trailers = parse_trailer_block(lines)
+    for idx, token, value in trailers:
+        if token.lower() != "fixes":
+            continue
+        # Skip the GitHub-keyword form (`Fixes #N` /
+        # `Fixes owner/repo#N`); both the no-colon form (matched by
+        # GITHUB_KEYWORD_RE in parse_trailer_block) and the
+        # `Fixes: #N` colon variant produce a value starting with `#`
+        # or containing `<owner>/<repo>#`. parse_trailer_block already
+        # validated those shapes.
+        if _is_github_issue_ref(value):
+            continue
+        if FIXES_SHA_TRAILER_RE.match(value) is None:
+            raise ValidationError(
+                f"Trailer on line {idx} (`Fixes: {value}`) does not "
+                'match the kernel-style `Fixes: <sha> ("subject")` '
+                "shape. Use a 7+ hex-char SHA followed by a "
+                "parenthesised double-quoted subject, e.g. "
+                '`Fixes: 9c4f1a2b3d5e ("subject of the broken commit")`.'
+            )
+
+
+def validate(body: str, title: str | None = None) -> None:
     block = extract_commit_msg_block(body)
+    check_first_line_non_blank(block)
     lines = block_lines(block)
     check_non_empty(lines)
     check_line_width(lines)
@@ -348,6 +503,68 @@ def validate(body: str) -> None:
     check_breaking_change_position(lines)
     check_trailers(lines)
     check_signoff_present(lines)
+    check_first_line_not_subject_dup(lines, title)
+    check_fixes_trailer_shape(lines)
+
+
+# Inline self-test cases for title-aware checks (currently only
+# subject-dup). Each tuple is (body, title, expect_pass, label).
+# A separate self-test entry point — rather than fixture files — is
+# used because these checks need both a body and a title and the
+# fixture-loop runs title-less.
+_TITLE_AWARE_SELF_TEST_CASES: tuple[tuple[str, str, bool, str], ...] = (
+    (
+        # Failing case: body's first line duplicates the PR title's
+        # post-prefix summary. Bot would paste a commit whose subject
+        # is followed by the same line as the first body line.
+        "==COMMIT_MSG==\n"
+        "Wire the foo into the bar.\n\n"
+        "More rationale.\n\n"
+        "Closes #1\n"
+        "Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>\n"
+        "==COMMIT_MSG==\n",
+        "feature(foo): wire the foo into the bar",
+        False,
+        "failing-first-line-dup",
+    ),
+    (
+        # Passing case: same body, but the title's summary is genuinely
+        # different from the first body line.
+        "==COMMIT_MSG==\n"
+        "Wire the foo into the bar.\n\n"
+        "More rationale.\n\n"
+        "Closes #1\n"
+        "Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>\n"
+        "==COMMIT_MSG==\n",
+        "chore(foo): refactor the foo helper",
+        True,
+        "passing-no-dup",
+    ),
+)
+
+
+def _run_title_aware_self_test() -> int:
+    fail = 0
+    for body, title, expect_pass, label in _TITLE_AWARE_SELF_TEST_CASES:
+        try:
+            validate(body, title=title)
+        except ValidationError as err:
+            if expect_pass:
+                print(f"FAIL: {label}: expected pass, got {err}", file=sys.stderr)
+                fail += 1
+            else:
+                print(f"ok: {label}: {err}")
+        else:
+            if expect_pass:
+                print(f"ok: {label}")
+            else:
+                print(f"FAIL: {label}: expected fail, got pass", file=sys.stderr)
+                fail += 1
+    if fail:
+        print(f"{fail} self-test case(s) failed", file=sys.stderr)
+        return 1
+    print(f"all {len(_TITLE_AWARE_SELF_TEST_CASES)} self-test cases passed")
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -360,12 +577,38 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "body_path",
         type=Path,
+        nargs="?",
+        default=None,
         help="Path to a file containing the PR body markdown.",
     )
+    parser.add_argument(
+        "--title",
+        default=None,
+        help=(
+            "PR title (the squash-merge subject). When provided, the "
+            "first body line is also checked for duplication of the "
+            "title. Omit to skip that check (used by the fixture "
+            "self-test loop, which has no PR title to compare against)."
+        ),
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help=(
+            "Run the inline title-aware self-test cases instead of "
+            "validating a body file. Covers the rules whose input "
+            "needs both a body and a title (subject-dup) so the "
+            "fixture-loop's title-less invocation does not have to."
+        ),
+    )
     args = parser.parse_args(argv)
+    if args.self_test:
+        return _run_title_aware_self_test()
+    if args.body_path is None:
+        parser.error("body_path is required unless --self-test is given")
     body = args.body_path.read_text(encoding="utf-8")
     try:
-        validate(body)
+        validate(body, title=args.title)
     except ValidationError as err:
         print(f"pr-lint: {err}", file=sys.stderr)
         return 1

--- a/scripts/validate-pr-title.py
+++ b/scripts/validate-pr-title.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+#
+# Validate the PR title (and therefore the squash-merge commit subject)
+# against the prose-style rules documented in `CONTRIBUTING.md` →
+# "Writing release-worthy commits" → "Subject (PR title)".
+#
+# The Palantir-style prefix allowlist (`feature` / `improvement` /
+# `fix` / `chore` / `deprecation` / `migration` / `break`) is enforced
+# separately by `amannn/action-semantic-pull-request` in the `pr-title`
+# job of `.github/workflows/pr-lint.yml`. This validator picks up the
+# *prose* rules that action does not cover:
+#
+#   1. Length: 72-char hard cap on the full subject (prefix + summary).
+#      The 50-char soft target on the post-prefix summary documented in
+#      CONTRIBUTING.md is *not* enforced (false-positive risk on long
+#      scopes); only the hard cap is mechanical.
+#   2. No trailing period: the subject is a fragment, not a sentence.
+#   3. Imperative mood: reject subjects whose summary opens with a
+#      narrow, closed list of past-tense / participle / gerund verbs
+#      that are unambiguous false-imperatives in this project's style.
+#      The list is intentionally tiny (`Added`, `Fixed`, `Updated`,
+#      `Changed`, `Removed`, `Refactored`, `Implemented`, `Bumped`)
+#      to avoid false positives. Other mood violations (`Wires`,
+#      `Wiring`) are left to human review — there is no clean regex
+#      that catches them without flagging legitimate present-tense
+#      imperatives ending in `s` (`Address`, `Express`).
+#
+# The validator runs in the `pr-title-style` job of
+# `.github/workflows/pr-lint.yml`; the title is read via the env var
+# `TITLE` to keep `${{ github.event.pull_request.title }}` out of the
+# shell-expansion path (same injection-safety pattern as
+# `pr-body-commit-msg`).
+#
+# Exits 0 on success, 1 with a one-line error and remediation hint on
+# failure.
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+MAX_TITLE_WIDTH = 72
+
+# Palantir-style prefix shape: `prefix:` or `prefix(scope):`. The
+# prefix-allowlist check itself runs in the `pr-title` job
+# (`amannn/action-semantic-pull-request`); this regex only locates the
+# prefix boundary so the past-tense / mood check operates on the
+# *summary*, not the prefix.
+PREFIX_RE = re.compile(r"^[A-Za-z]+(?:\([^)]+\))?:\s+")
+
+# Closed-list past-tense / participle openings rejected as false
+# imperatives. Anchored to the start of the summary (after the prefix)
+# and matched case-sensitively at the canonical capitalised form, since
+# the project convention lowercases the post-prefix summary anyway —
+# `Fixed` at the start of a summary is already two style violations
+# (capitalised + past-tense). A lowercase `fixed` is matched too: the
+# past-tense rule still applies even when the contributor obeys the
+# capitalisation convention.
+PAST_TENSE_VERBS = (
+    "Added",
+    "Fixed",
+    "Updated",
+    "Changed",
+    "Removed",
+    "Refactored",
+    "Implemented",
+    "Bumped",
+)
+PAST_TENSE_RE = re.compile(
+    r"^(?:" + "|".join(PAST_TENSE_VERBS) + r")\b",
+    re.IGNORECASE,
+)
+
+
+class TitleValidationError(Exception):
+    """Raised when the PR title fails the subject-style lint."""
+
+
+def _strip_prefix(title: str) -> str:
+    """Return the post-prefix summary, or the whole title if no prefix.
+
+    The prefix-allowlist check is owned by
+    `amannn/action-semantic-pull-request`, so this validator
+    deliberately tolerates a missing / malformed prefix: the
+    past-tense check then runs over the entire title, which still
+    catches `Fixed gpg-bridge timeout` regardless of whether the
+    contributor remembered the prefix.
+    """
+    match = PREFIX_RE.match(title)
+    if match is None:
+        return title
+    return title[match.end() :]
+
+
+def check_length(title: str) -> None:
+    if len(title) > MAX_TITLE_WIDTH:
+        raise TitleValidationError(
+            f"subject is {len(title)} chars (limit {MAX_TITLE_WIDTH}) — "
+            "shorten the summary or drop the scope."
+        )
+
+
+def check_no_trailing_period(title: str) -> None:
+    if title.rstrip().endswith("."):
+        raise TitleValidationError(
+            f"subject ends with '.' — drop the trailing period. " f"Title was: {title!r}."
+        )
+
+
+def check_imperative_mood(title: str) -> None:
+    summary = _strip_prefix(title)
+    match = PAST_TENSE_RE.match(summary)
+    if match is None:
+        return
+    verb = match.group(0)
+    raise TitleValidationError(
+        f"subject {title!r} uses past tense — start with an "
+        f"imperative verb (e.g. {_imperative_for(verb)!r}) instead of "
+        f"{verb!r}."
+    )
+
+
+# Hint mapping past-tense -> imperative for the error message. Kept
+# small and explicit — the validator's job is to point a contributor
+# at the obvious fix, not to be a thesaurus.
+_IMPERATIVE_HINTS = {
+    "added": "Add",
+    "fixed": "Fix",
+    "updated": "Update",
+    "changed": "Change",
+    "removed": "Remove",
+    "refactored": "Refactor",
+    "implemented": "Implement",
+    "bumped": "Bump",
+}
+
+
+def _imperative_for(verb: str) -> str:
+    return _IMPERATIVE_HINTS.get(verb.lower(), verb)
+
+
+def validate(title: str) -> None:
+    if not title.strip():
+        raise TitleValidationError(
+            "subject is empty — author a PR title with the "
+            "Palantir-style `prefix: summary` shape."
+        )
+    check_length(title)
+    check_no_trailing_period(title)
+    check_imperative_mood(title)
+
+
+# Inline self-test cases. The PR-title input is a single string from
+# `${{ github.event.pull_request.title }}`, so file-based fixtures
+# (the body validator's pattern) buy nothing here. Each tuple is
+# (title, expect_pass, label) — `label` shows up in the self-test
+# log so a regression points at the failing case immediately.
+_SELF_TEST_CASES: tuple[tuple[str, bool, str], ...] = (
+    # Passing cases: representative titles drawn from recent merged
+    # PRs and the worked examples in CONTRIBUTING.md.
+    (
+        "chore(ci): enforce subject-style rules in pr-lint validator",
+        True,
+        "passing-chore",
+    ),
+    (
+        "feature(ci): add release-build dry-run and post-publish asset smoke",
+        True,
+        "passing-feature",
+    ),
+    (
+        "fix(tokens): use constant-time HMAC comparison",
+        True,
+        "passing-fix",
+    ),
+    (
+        "improvement: tighten numbered-list regex",
+        True,
+        "passing-no-scope",
+    ),
+    # Failing cases: one per rule.
+    (
+        "fix: drop the trailing period.",
+        False,
+        "failing-trailing-period",
+    ),
+    (
+        "improvement: Fixed gpg-bridge timeout",
+        False,
+        "failing-past-tense-fixed",
+    ),
+    (
+        "feature: Added a thing",
+        False,
+        "failing-past-tense-added",
+    ),
+    (
+        # 84 chars — the example from the issue body.
+        "fix(very-long-scope): a summary that runs on and on past the seventy two char cap easy",
+        False,
+        "failing-too-long",
+    ),
+    (
+        "",
+        False,
+        "failing-empty",
+    ),
+)
+
+
+def _run_self_test() -> int:
+    fail = 0
+    for title, expect_pass, label in _SELF_TEST_CASES:
+        try:
+            validate(title)
+        except TitleValidationError as err:
+            if expect_pass:
+                print(f"FAIL: {label}: expected pass, got {err}", file=sys.stderr)
+                fail += 1
+            else:
+                print(f"ok: {label}: {err}")
+        else:
+            if expect_pass:
+                print(f"ok: {label}")
+            else:
+                print(f"FAIL: {label}: expected fail, got pass", file=sys.stderr)
+                fail += 1
+    if fail:
+        print(f"{fail} self-test case(s) failed", file=sys.stderr)
+        return 1
+    print(f"all {len(_SELF_TEST_CASES)} self-test cases passed")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate the PR title (squash-merge commit subject) against "
+            "CONTRIBUTING.md → 'Writing release-worthy commits' → "
+            "'Subject (PR title)' prose rules."
+        )
+    )
+    parser.add_argument(
+        "title",
+        nargs="?",
+        default=None,
+        help="The PR title to validate (the full subject including prefix).",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help=(
+            "Run the inline self-test cases instead of validating a title. "
+            "Used by the `pr-title-self-test` job in pr-lint.yml so a "
+            "regression in the validator surfaces immediately."
+        ),
+    )
+    args = parser.parse_args(argv)
+    if args.self_test:
+        return _run_self_test()
+    if args.title is None:
+        parser.error("title is required unless --self-test is given")
+    try:
+        validate(args.title)
+    except TitleValidationError as err:
+        print(f"pr-title: {err}", file=sys.stderr)
+        return 1
+    print("pr-title: subject OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
==COMMIT_MSG==
Add a new pr-title-style job and three additional body-side checks to
pr-lint.yml so the cbea.ms / Linux-kernel commit-message conventions
documented in #337 stop drifting from CI. The new mechanical rules:
72-char title cap, no trailing period, no past-tense opener (closed
list), body-opens-non-blank, no first-line subject duplication, and
the kernel-style `Fixes: <sha> ("subject")` shape. Other conventions
(one-logical-change, why-not-how, le-50-char summary, capitalisation,
imperative mood beyond the closed list) stay convention-only because
they have no false-positive-free regex.

The PR-title rules live in a new scripts/validate-pr-title.py — split
from the body validator because the inputs (string vs. file) and
runtime audiences (env-var consumer vs. file-on-disk consumer)
differ. The body validator gains a --title flag the workflow now
passes through so the subject-dup body rule has the title to compare
against.

Coverage: file-based fixtures cover every body-only rule; an inline
self-test loop covers the title-only rules and the title-aware body
rule (subject-dup) because those need inputs the fixture loop
cannot supply. Three new self-test jobs in pr-lint.yml run the
fixtures and the inline cases on every PR.

Rollout: pr-lint.yml uses pull_request_target with types: [opened,
edited, reopened, synchronize], so existing open PRs surface the
new failures the next time their title or body is touched. That is
intentional — the new rules are catch-up enforcement of conventions
that were already documented.

CONTRIBUTING.md gains a CI-enforced vs. convention-only table next
to the prose rules so a contributor reading the docs knows which
rules will fail their CI.

Closes #338
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==
==NO_CHANGELOG==

## Review notes

### Implementation choice

Split the title rules into a new `scripts/validate-pr-title.py` rather than extending `validate-commit-msg-block.py`. The two scripts have genuinely different inputs (a single string from `${{ ... .title }}` vs. a file on disk for the body) and different runtime audiences; keeping them separate makes the workflow YAML easy to read and avoids a single argparse interface that has to reject incompatible argument combinations. The body validator gains a `--title` flag so the title-aware subject-dup rule has the title available; the file-loop self-test calls the body validator with no `--title` and the rule is a no-op there.

### Rollout note

`pr-lint.yml` runs on `pull_request_target` with `types: [opened, edited, reopened, synchronize]`, so existing open PRs surface the new failures the next time their title or body is touched. That is intentional but reviewers should expect a brief wave of stale-PR lints when this lands.

### Test plan

- [ ] `python3 scripts/validate-commit-msg-block.py .github/workflows/tests/pr-lint-fixtures/<each fixture>` — every `valid-*.md` exits 0; every `invalid-*.md` (including the new `invalid-leading-blank.md`, `invalid-fixes-trailer-shape.md`) exits 1 with a targeted error.
- [ ] `python3 scripts/validate-commit-msg-block.py --self-test` — title-aware self-test passes.
- [ ] `python3 scripts/validate-pr-title.py --self-test` — inline title self-test passes.
- [ ] `python3 scripts/validate-pr-title.py "Fixed gpg-bridge timeout"` — exits 1 with the past-tense hint.
- [ ] `python3 scripts/validate-pr-title.py "fix: drop the trailing period."` — exits 1 with the trailing-period hint.
- [ ] `pr-title-style`, `validator-self-test`, `pr-title-self-test`, `pr-body-title-aware-self-test` jobs all run on this PR and stay green.
- [ ] `pr-body-commit-msg` runs on this PR with `--title` and stays green (this PR's body is the smoke test for the live wiring).