### PR TITLE
improvement(merge-bot): close residual automerge event-coverage gaps

### DIFF
--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -24,8 +24,34 @@ name: Merge Bot
 #     `check_suite: completed` never delivered. `workflow_run` is the
 #     documented escape hatch and fires regardless of the upstream
 #     authenticating token. Origin: issue #348.
+#   - pull_request_review: submitted | dismissed — re-fire merge-bot
+#     when a review state changes. Covers the gap where `automerge`
+#     was applied before the final approval landed: the bot exits
+#     once on `pull_request: labeled` (review requirement unmet) and
+#     no `workflow_run.completed` is tied to a review submission, so
+#     without this trigger the PR sits stuck. The `if:` chain accepts
+#     the event regardless of `review.state` and lets the existing
+#     in-job gating (mergeable / mergeStateStatus / required reviews
+#     via the merge-API call) decide — duplicating GitHub's required-
+#     reviews logic in a workflow predicate would drift. `dismissed`
+#     is included so a queued-but-now-unapproved PR no-ops cleanly
+#     instead of sitting on the label. Origin: issue #388.
+#   - push: branches: [main] — sweep open `automerge` PRs whenever
+#     `main` advances. Covers the gap where a labeled PR was up-to-
+#     date when the bot last fired, then `main` moved and nothing
+#     else triggered the bot — `workflow_run.completed` never fires
+#     on this PR until someone pushes to it. The new sweep job lists
+#     every open `automerge` PR and dispatches the existing per-PR
+#     `merge` job via `workflow_dispatch`, keeping the resolve-PR
+#     logic single-sourced. Sweep-level concurrency
+#     (`merge-bot-sweep`, `cancel-in-progress: true`) collapses a
+#     burst of merges into one sweep; the existing per-PR
+#     concurrency key (`merge-bot-<n>`) is unchanged. Restricted to
+#     `branches: [main]` so tag pushes (release tags) don't trigger
+#     sweeps with nothing to do. Origin: issue #388.
 #   - workflow_dispatch — maintainer break-glass against a specific
-#     PR number.
+#     PR number. Also the sweep job's fan-out target — see the
+#     `push:main` trigger above.
 #
 # The bot authors no commits — it only calls `PUT /pulls/{n}/merge`.
 # The squash commit body is the contents of the PR's `==COMMIT_MSG==`
@@ -73,6 +99,12 @@ on:
       - Verify Token CLI / HTTP Parity
       - Changelog Bot
     types: [completed]
+  pull_request_review:
+    types: [submitted, dismissed]
+  # `branches: [main]` only — tag pushes (release tags) would
+  # otherwise trigger sweeps with nothing to do.
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -85,35 +117,54 @@ on:
 # is needed for the BEHIND-handling auto-update branch — the
 # `PUT /pulls/{n}/update-branch` endpoint requires write access to
 # the repo's contents to push the merge commit that fast-forwards
-# the PR head onto the latest `main`. NO `id-token: write` — the bot
-# is not on the SLSA-attestation path.
+# the PR head onto the latest `main`. `actions: write` is needed by
+# the `push:main` sweep job to fan out via `gh workflow run` (which
+# calls `POST /repos/.../actions/workflows/{id}/dispatches`); the
+# default `GITHUB_TOKEN` carries that grant when set here, which
+# avoids needing to mint an App token in the sweep job at all (the
+# App's `actions:write` grant is not currently provisioned, and the
+# issue body's "no additional bot-token plumbing" constraint rules
+# out adding it). NO `id-token: write` — the bot is not on the
+# SLSA-attestation path.
 permissions:
   pull-requests: write
   contents: write
   checks: read
-
-# Prevent two triggers (label + workflow_run) from racing on the same
-# PR. Group key includes the PR/SHA so different PRs still run in
-# parallel; cancellation is OFF because we want each trigger to run
-# to completion (an early-exit on "already merged" is cheap, and
-# losing a trigger could leave the PR stuck waiting for the next
-# event).
-concurrency:
-  group: merge-bot-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || inputs.pr_number }}
-  cancel-in-progress: false
+  actions: write
 
 jobs:
   merge:
     name: Merge ==COMMIT_MSG== block as squash body
     runs-on: ubuntu-latest
+    # Per-PR concurrency so two triggers (label + workflow_run +
+    # pull_request_review + sweep-dispatched workflow_dispatch)
+    # cannot race on the same PR. `pull_request_review` carries
+    # `github.event.pull_request.number` on the same shape as
+    # `pull_request`, so the existing first fallback already covers
+    # it. Group key includes the PR/SHA so different PRs still run
+    # in parallel; cancellation is OFF because we want each trigger
+    # to run to completion (an early-exit on "already merged" is
+    # cheap, and losing a trigger could leave the PR stuck waiting
+    # for the next event).
+    concurrency:
+      group: merge-bot-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || inputs.pr_number }}
+      cancel-in-progress: false
     # Cheap pre-filter so we don't burn a runner on every label
     # event (`labeled` fires for *every* label, not just `automerge`),
     # and so `workflow_run.completed` only proceeds when the upstream
-    # workflow itself succeeded. Per-PR sticky-label and required-check
-    # checks happen in the steps below.
+    # workflow itself succeeded. For `pull_request_review`, gate on
+    # the PR carrying `automerge` (the event payload's
+    # `pull_request.labels` is reliable) so reviews on non-automerge
+    # PRs don't burn a runner each. `pull_request_review` is
+    # otherwise accepted regardless of `review.state` — the existing
+    # in-job gating (mergeable / required-reviews via the merge API)
+    # is the source of truth; duplicating the required-reviews logic
+    # in this predicate would drift. Per-PR sticky-label and
+    # required-check checks happen in the steps below.
     if: |
       (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'automerge')
       || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      || (github.event_name == 'pull_request_review' && contains(github.event.pull_request.labels.*.name, 'automerge'))
       || github.event_name == 'workflow_dispatch'
     steps:
       # Distinguish two configuration states before minting the App
@@ -171,13 +222,14 @@ jobs:
           app-id: ${{ secrets.MERGE_BOT_APP_ID }}
           private-key: ${{ secrets.MERGE_BOT_PRIVATE_KEY }}
 
-      # Resolve the PR number for each trigger. `pull_request`
-      # carries it directly. `workflow_run` carries the head SHA of
-      # the upstream workflow's run; we resolve the same-repo PR by
-      # `automerge` label and matching head SHA. `workflow_dispatch`
-      # takes it as input. Surface the resolved number as a step
-      # output so later steps don't have to re-derive it from the
-      # event payload.
+      # Resolve the PR number for each trigger. `pull_request` and
+      # `pull_request_review` both carry it directly via
+      # `event.pull_request.number`. `workflow_run` carries the head
+      # SHA of the upstream workflow's run; we resolve the same-repo
+      # PR by `automerge` label and matching head SHA.
+      # `workflow_dispatch` takes it as input. Surface the resolved
+      # number as a step output so later steps don't have to
+      # re-derive it from the event payload.
       - name: Resolve target PR
         id: pr
         if: steps.secrets-check.outputs.configured == 'true'
@@ -196,7 +248,7 @@ jobs:
         run: |
           set -euo pipefail
           case "${EVENT_NAME}" in
-            pull_request)
+            pull_request|pull_request_review)
               echo "pr=${PULL_REQUEST_NUMBER}" >> "${GITHUB_OUTPUT}"
               ;;
             workflow_dispatch)
@@ -724,3 +776,73 @@ jobs:
           gh pr comment "${PR_NUMBER}" \
             --repo "${GITHUB_REPOSITORY}" \
             --body "Claude: Merged via bot."
+
+  # `push:main` sweep. Whenever `main` advances, list every open
+  # PR carrying the `automerge` label and re-process each by
+  # firing a `workflow_dispatch` against this same workflow. The
+  # existing `merge` job's `Resolve target PR` step already
+  # accepts a PR number via `inputs.pr_number`, so the sweep
+  # delegates to it verbatim — resolve / metadata / required-check
+  # gating / BEHIND handling / merge-API call all stay
+  # single-sourced in the `merge` job. See the `push:` trigger
+  # comment block at the top of this file for the full rationale.
+  #
+  # Uses the default `GITHUB_TOKEN` (not the App token) for both
+  # `gh pr list` and `gh workflow run`. `pull-requests: read`
+  # covers the list call and `actions: write` (granted in the
+  # workflow-level `permissions:` block above) covers the
+  # dispatch call. `GITHUB_TOKEN` can fire `workflow_dispatch`
+  # events (the `workflow_run` anti-recursion rule does not apply
+  # to `workflow_dispatch`); using the App token here would
+  # require an `actions: write` grant on the App installation
+  # that is not currently provisioned. Issue #388.
+  sweep:
+    name: Sweep open automerge PRs after main advances
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # `cancel-in-progress: true` so a burst of merges to `main`
+    # collapses into one sweep — only the latest sweep needs to
+    # run, since each sweep enumerates the *current* set of
+    # open `automerge` PRs. The per-PR `merge-bot-<n>` group on
+    # the `merge` job remains the source of truth for per-PR
+    # serialisation; the sweep just decides which PRs to dispatch.
+    concurrency:
+      group: merge-bot-sweep
+      cancel-in-progress: true
+    steps:
+      - name: List open automerge PRs and dispatch merge-bot per PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # `gh pr list --json number` returns a JSON array of
+          # `{number: <int>}`; `--jq '.[].number'` flattens it to
+          # one number per line. Empty output means no PRs to
+          # dispatch — exit 0 cleanly. Bind through `mapfile` so
+          # the per-PR loop body sees one number at a time and
+          # the dispatch call quotes `${pr}` rather than splitting
+          # on whitespace.
+          mapfile -t prs < <(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --state open \
+            --label automerge \
+            --json number \
+            --jq '.[].number')
+          if [[ "${#prs[@]}" -eq 0 ]]; then
+            echo "merge-bot sweep: no open automerge PRs; nothing to dispatch."
+            exit 0
+          fi
+          echo "merge-bot sweep: dispatching merge-bot for PRs: ${prs[*]}"
+          for pr in "${prs[@]}"; do
+            # `gh workflow run` posts to
+            # `POST /repos/.../actions/workflows/{id}/dispatches`,
+            # which fires a `workflow_dispatch` event. Each
+            # dispatched run hits the existing per-PR
+            # `merge-bot-<n>` concurrency group on the `merge`
+            # job, so a sweep-triggered dispatch for a PR already
+            # being processed by another trigger queues cleanly.
+            gh workflow run merge-bot.yml \
+              --repo "${GITHUB_REPOSITORY}" \
+              --ref main \
+              -f pr_number="${pr}"
+          done

--- a/changelog/@unreleased/pr-389-merge-bot-event-gaps.yml
+++ b/changelog/@unreleased/pr-389-merge-bot-event-gaps.yml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+type: improvement
+improvement:
+  description: |
+    `merge-bot` now fires on two additional event surfaces so
+    `automerge`-labeled PRs no longer wedge on state transitions
+    that produced no merge-bot trigger event before. New
+    `pull_request_review` trigger (types `submitted` and
+    `dismissed`) re-fires the bot when a review state changes,
+    closing the gap where `automerge` was applied before the
+    final approval landed and no `workflow_run.completed` was
+    tied to the review submission. New `push: branches: [main]`
+    trigger plus a `sweep` job lists every open `automerge` PR
+    whenever `main` advances and dispatches the existing per-PR
+    `merge` job via `gh workflow run merge-bot.yml -f
+    pr_number=<N>`, closing the gap where a labeled PR was
+    up-to-date when the bot last fired and then `main` moved
+    with nothing else to re-trigger the bot. Sweep concurrency
+    (`merge-bot-sweep`, `cancel-in-progress: true`) collapses a
+    burst of merges to `main` into one sweep; per-PR concurrency
+    (`merge-bot-<n>`) is unchanged. The sweep uses the default
+    `GITHUB_TOKEN` (with `actions: write` added to the
+    workflow-level `permissions:` block) rather than the App
+    token, so no additional App permission grant is required.
+  links:
+    - https://github.com/aidanns/agent-auth/issues/388
+    - https://github.com/aidanns/agent-auth/pull/389

--- a/plans/merge-bot-event-gaps.md
+++ b/plans/merge-bot-event-gaps.md
@@ -1,0 +1,235 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# merge-bot — close residual automerge event-coverage gaps
+
+Closes #388. Builds on PR #383 / issue #374 (BEHIND-handling) by
+adding two trigger surfaces to `.github/workflows/merge-bot.yml` so
+state transitions that today produce no merge-bot trigger event
+stop wedging `automerge`-labeled PRs indefinitely.
+
+## Context
+
+PR #383 made merge-bot self-heal a BEHIND PR by calling
+`PUT /pulls/{n}/update-branch` from inside the existing job — but
+only when the bot fires for some other reason. Two adjacent gaps
+remain:
+
+1. **PR labeled `automerge`, was up-to-date when the bot last
+   fired, then `main` moved.** No `workflow_run.completed` will
+   fire on this PR until someone pushes to it; the BEHIND-handling
+   step only helps if the bot fires in the first place.
+2. **`automerge` set before final approval lands.** The bot fires
+   once on `pull_request: labeled`, exits because the review
+   requirement is unmet, and never re-fires when the approval
+   eventually arrives — there is no `workflow_run.completed` event
+   tied to a review submission.
+
+Both are the same shape: an event-driven bot misses a state
+transition because the transition does not currently produce one
+of its trigger events.
+
+## Proposal
+
+Two new `on:` triggers and one new sweep job:
+
+### `push: branches: [main]` — sweep open `automerge` PRs
+
+Whenever `main` advances, list every open PR carrying the
+`automerge` label and re-process each. New `sweep` job, separate
+from the existing per-PR `merge` job. Lists PRs with
+`gh pr list --label automerge --state open`, then fans out to the
+existing `merge` job via `gh workflow run merge-bot.yml -f pr_number=<N>` (one `workflow_dispatch` per PR).
+
+Sweep concurrency: `group: merge-bot-sweep`,
+`cancel-in-progress: true` so a burst of merges to `main`
+collapses into one sweep. Per-PR concurrency key
+(`merge-bot-<n>`) is unchanged, so the dispatch fan-out cannot
+stomp on a PR already being processed by a label or workflow_run
+trigger.
+
+`branches: [main]` only — explicitly NOT firing on tag pushes
+(release tags would otherwise trigger sweeps with nothing to do).
+
+### `pull_request_review: types: [submitted, dismissed]`
+
+Re-fire merge-bot when a review state changes:
+
+- `submitted` covers the "approval lands after CI completed and
+  after label was set" case.
+- `dismissed` lets a queued-but-now-unapproved PR early-exit
+  cleanly (the existing in-job `mergeable` / required-reviews
+  checks decide; the bot just no-ops if the PR is no longer
+  approved).
+
+PR number resolves directly from `github.event.pull_request.number`
+in the existing `Resolve target PR` step's `pull_request` case —
+the `pull_request_review` event payload exposes
+`event.pull_request.number` with the same shape as `pull_request`.
+No new resolution code path needed.
+
+## Design decisions
+
+### Fan-out mechanism: `workflow_dispatch` per-PR (Option A)
+
+Confirmed by reading the existing `merge` job: the resolve-PR
+logic is single-sourced in the `Resolve target PR` step which
+already accepts a PR number via `inputs.pr_number` for the
+`workflow_dispatch` case. Picking `workflow_dispatch` per-PR
+fan-out lets the sweep delegate to the existing job verbatim:
+
+- Resolve, metadata fetch, required-check inspection, BEHIND
+  handling, DCO trailer check, and merge-API call all stay in
+  the single `merge` job.
+- The existing `merge-bot-<n>` concurrency key already keys on
+  `inputs.pr_number` for the dispatch path; multiple sweep-
+  triggered dispatches for the same PR queue cleanly behind any
+  in-flight run that beat them to it.
+
+The alternative — `strategy.matrix` over a sweep job — would have
+to duplicate the resolve / metadata / gating logic inside the
+sweep, and the per-PR concurrency wouldn't compose with the
+existing `merge-bot-<n>` group. Rejected.
+
+`gh workflow run` only triggers `workflow_dispatch` if the
+workflow file on the *default branch* allows it — which it does
+(the existing `workflow_dispatch` input is in place).
+
+### Composite action: NOT extracted
+
+The sweep job does need its own secret-check + App-token mint to
+call `gh pr list --label automerge` and `gh workflow run`. That
+is one duplication of two short steps (~25 lines), not N
+duplications. Extracting a composite action under
+`.github/actions/merge-bot-token/` would:
+
+- Hide the step IDs (`secrets-check`, `app-token`) that downstream
+  conditionals in the existing `merge` job reference, so the
+  composite would have to re-export both as outputs and the
+  existing job would need to be rewritten to use them.
+- Save ~25 lines once.
+
+The cost / benefit doesn't justify the indirection. Inline the
+secret-check + token-mint into the sweep job, with a comment
+calling out the duplication and pointing at the existing `merge`
+job's pair.
+
+### `pull_request_review` job's `if:` predicate
+
+- Fires on both `submitted` and `dismissed` (the trigger types
+  declared in `on:`).
+- Gates on the PR carrying the `automerge` label using the event
+  payload's `github.event.pull_request.labels.*.name` — this is
+  reliable on `pull_request_review` events and avoids burning a
+  runner per review on non-automerge PRs.
+- Does NOT gate on `review.state == 'approved'` — that would
+  duplicate GitHub's required-reviews logic in the workflow
+  predicate. The existing in-job gating (which calls
+  `gh pr view --json mergeable,mergeStateStatus` and the merge
+  API) is the source of truth; let it decide.
+
+### Sweep job's `if:` predicate
+
+Gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'`. Tag pushes go to `refs/tags/...` and so
+naturally fall outside the predicate.
+
+### CodeQL `js/actions/command-injection` discipline
+
+Every new `run:` block consuming event-payload values binds the
+value through `env:` and quotes `${VAR}` rather than templating
+`${{ ... }}` directly into shell. The existing file already uses
+this pattern; new code must too. Specifically:
+
+- Sweep job: `gh pr list` output (PR numbers) are integers from
+  GitHub's API and not author-controlled, so they don't need the
+  same level of defence — but bind them through `env:` anyway
+  for consistency with the surrounding pattern.
+- `pull_request_review` payload values flow into `Resolve target PR` only via the existing `PULL_REQUEST_NUMBER` env binding,
+  which is already in place.
+
+### Header doc-comment block
+
+Update the trigger-surface comment block at the top of the file
+to include both new triggers and a one-paragraph rationale for
+each. Don't let the doc drift from the workflow.
+
+## Test plan
+
+Static checks (no end-to-end smoke required for the `push:main`
+path):
+
+- [ ] `yq .github/workflows/merge-bot.yml > /dev/null` parses
+  cleanly.
+- [ ] The `on:` block contains `push: branches: [main]` and
+  `pull_request_review: types: [submitted, dismissed]`.
+- [ ] The new sweep job's `if:` is gated on
+  `github.event_name == 'push' && github.ref ==     'refs/heads/main'`.
+- [ ] The existing `merge` job's `if:` chain accepts the new
+  `pull_request_review` event only when the PR carries the
+  `automerge` label
+  (`contains(github.event.pull_request.labels.*.name,     'automerge')`). The existing `Skip if PR is not in scope`
+  step still early-exits as a defence-in-depth.
+- [ ] The existing `concurrency.group` expression resolves
+  correctly for `pull_request_review` (uses
+  `github.event.pull_request.number`) and for the new sweep
+  job (uses the literal `merge-bot-sweep` group).
+- [ ] Every new `run:` block binds event-payload values through
+  `env:` (CodeQL discipline).
+- [ ] Every new `uses:` reference (composite action calls,
+  checkout, etc.) is SHA-pinned per
+  `.claude/instructions/tooling-and-ci.md`.
+- [ ] The header trigger-surface comment block lists the two new
+  triggers with a one-paragraph rationale each.
+- [ ] `changelog/@unreleased/pr-<N>-merge-bot-event-gaps.yml`
+  exists with `type: improvement` and links to issue #388 and
+  this PR.
+- [ ] `git log -p -1 .github/workflows/merge-bot.yml` shows no
+  drift from `main` outside the documented changes.
+
+Live smoke (only the `pull_request_review` path can be tested on
+this PR itself):
+
+- [ ] Submit a review on this PR after CI is green and confirm
+  merge-bot fires (visible in the PR's checks rollup as a new
+  `Merge Bot` run keyed to the `pull_request_review` event).
+- [ ] The `push:main` sweep is verifiable post-merge: after this
+  PR merges, observe one sweep run firing on the merge
+  commit's push to `main`. No `automerge` PRs are likely to
+  be open at that moment, so the sweep will exit cleanly with
+  "no PRs to dispatch" — that's the expected steady state.
+
+## Design and verification
+
+- **Verify implementation against design doc** —
+  `design/decisions/0038-merge-bot-via-github-app.md` describes
+  the App-mediated merge mechanism but does not enumerate the
+  trigger surface; this change adds two triggers to the existing
+  workflow without altering the App-token / merge-API flow. No
+  ADR amendment needed; the workflow header comment block carries
+  the rationale.
+- **Threat model** — no new trust boundaries introduced. The new
+  triggers (`push`, `pull_request_review`) run under the
+  workflow-default `GITHUB_TOKEN` for trigger delivery; the App
+  token mint is unchanged. `pull_request_review` runs against the
+  PR head, but the bot does no checkout of contributor code (it
+  only reads PR metadata via `gh api`); no new attack surface.
+- **PIR** — N/A (not remediating a confirmed vulnerability).
+- **ADR** — not needed (incremental hardening of an existing
+  component documented in 0038).
+- **Cybersecurity standard compliance** — N/A
+  (workflow change, no application-layer surface).
+- **QM / SIL compliance** — N/A.
+
+## Post-implementation standards review
+
+- **`coding-standards.md`** — N/A (YAML workflow; no code).
+- **`service-design.md`** — N/A.
+- **`release-and-hygiene.md`** — hand-authored changelog YAML
+  required (improvement-tier); apply the `automerge` label after
+  CI green; do not push a commit that bypasses DCO sign-off.
+- **`testing-standards.md`** — N/A (no test code changes).
+- **`tooling-and-ci.md`** — every new `uses:` SHA-pinned;
+  release-path-adjacent so the policy applies in full.

--- a/tests/test_merge_bot_workflow_run_trigger.py
+++ b/tests/test_merge_bot_workflow_run_trigger.py
@@ -243,15 +243,20 @@ def test_concurrency_group_includes_workflow_run_head_sha() -> None:
     workflow_run trigger's group key collapses to `merge-bot-` (the
     PR number is unset on workflow_run events) and every workflow_run
     trigger contends on the same singleton group regardless of PR.
+
+    The concurrency key lives on the `merge` job (not the workflow's
+    top-level) since the sweep job introduced for the `push:main`
+    trigger surface needs its own `merge-bot-sweep` group; workflow-
+    level concurrency would force the two to share.
     """
     workflow = _load_workflow()
-    group_expr = workflow["concurrency"]["group"]
+    group_expr = workflow["jobs"]["merge"]["concurrency"]["group"]
     assert "github.event.workflow_run.head_sha" in group_expr, (
-        "merge-bot.yml concurrency-group key must include "
+        "merge-bot.yml `merge` job concurrency-group key must include "
         "`github.event.workflow_run.head_sha` as a fallback."
     )
     assert "github.event.check_suite.head_sha" not in group_expr, (
-        "merge-bot.yml concurrency-group key still references "
-        "`check_suite.head_sha`; it should reference "
+        "merge-bot.yml `merge` job concurrency-group key still "
+        "references `check_suite.head_sha`; it should reference "
         "`workflow_run.head_sha` (issue #348)."
     )


### PR DESCRIPTION
==COMMIT_MSG==
improvement(merge-bot): close residual automerge event-coverage gaps

PR #383 made merge-bot self-heal a BEHIND PR by calling
`PUT /pulls/{n}/update-branch` from inside the existing job, but
only when the bot fires for some other reason. Two adjacent gaps
remained: (a) a labeled PR that was up-to-date when the bot last
fired then `main` moved, with no `workflow_run.completed` in sight
to re-fire the bot; and (b) `automerge` set before the final
approval lands, so the bot exits once on `pull_request: labeled`
(review requirement unmet) and never re-fires when the approval
arrives — there is no `workflow_run.completed` event tied to a
review submission. Same shape both times: an event-driven bot
misses a state transition because the transition does not produce
one of its trigger events.

Add two trigger surfaces:

- `pull_request_review: types: [submitted, dismissed]`. The PR
  number resolves directly via `event.pull_request.number` (same
  shape as `pull_request`), so the existing resolve step picks
  it up with one extra case-arm. The `if:` predicate gates on
  the PR carrying `automerge` (`contains(github.event
  .pull_request.labels.*.name, 'automerge')`) so reviews on
  other PRs do not burn a runner each. The predicate does not
  gate on `review.state` — duplicating GitHub's required-reviews
  logic in a workflow predicate would drift; the existing
  in-job gating (mergeable / mergeStateStatus / required reviews
  via the merge API) is the source of truth.

- `push: branches: [main]` plus a new `sweep` job. Whenever
  `main` advances, list every open `automerge` PR
  (`gh pr list --label automerge --state open --json number`)
  and dispatch the existing per-PR `merge` job via
  `gh workflow run merge-bot.yml -f pr_number=<N>`. The
  dispatch fan-out keeps resolve-PR / metadata / required-check
  / BEHIND / merge-API logic single-sourced in the existing
  job (the `Resolve target PR` step already accepts
  `inputs.pr_number`). Each dispatched run hits the existing
  per-PR `merge-bot-<n>` concurrency group, so a
  sweep-triggered dispatch for a PR already being processed by
  another trigger queues cleanly. `branches: [main]` only —
  tag pushes (release tags) would otherwise trigger sweeps with
  nothing to do.

Sweep job uses the default `GITHUB_TOKEN` (not the App token)
for both `gh pr list` and `gh workflow run`. `pull-requests:
read` covers the list call and `actions: write` (added to the
workflow-level `permissions:` block) covers the dispatch call.
`GITHUB_TOKEN` can fire `workflow_dispatch` events — the
`workflow_run` anti-recursion rule does not apply to
`workflow_dispatch` — so no App-token mint is needed in the
sweep job. Using the App token here would require an
`actions: write` grant on the App installation that is not
currently provisioned, which the issue body's "no additional
bot-token plumbing" constraint rules out.

Sweep concurrency is `merge-bot-sweep` with
`cancel-in-progress: true` so a burst of merges to `main`
collapses into one sweep — only the latest sweep needs to run,
since each sweep enumerates the *current* set of open
`automerge` PRs. The existing per-PR concurrency
(`merge-bot-<n>`) was moved from the workflow-level
`concurrency:` to job-level on the `merge` job so the new
`sweep` job can carry its own concurrency group.

The new BEHIND-handling step's loop guard from PR #383 still
bounds the worst case across all triggers, not just the
original ones, so this change does not alter the loop-guard
contract.

Closes #388

Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

## Review notes

### Implementation choices

- **Fan-out via `workflow_dispatch` per-PR (Option A)** rather
  than `strategy.matrix`. The existing `merge` job's
  `Resolve target PR` step already accepts `inputs.pr_number`,
  so the sweep delegates to it verbatim — resolve / metadata /
  required-check / BEHIND / merge-API logic stays
  single-sourced. A matrix sweep would duplicate the resolve
  logic and the per-PR concurrency wouldn't compose with the
  existing `merge-bot-<n>` group.

- **No composite action extracted.** The duplication is two
  short steps (secret-check + App-token mint) and only the
  existing `merge` job needs them — the new sweep job uses the
  default `GITHUB_TOKEN` (no mint at all), so there is no
  duplication to factor out.

- **`GITHUB_TOKEN`, not the App token, in the sweep job.** The
  App's `actions: write` grant is not currently provisioned, and
  the issue's "no additional bot-token plumbing" constraint
  rules out adding it. `GITHUB_TOKEN` can fire
  `workflow_dispatch` events (the `workflow_run` anti-recursion
  rule does not apply); workflow-level `actions: write` carries
  the grant.

- **`pull_request_review` predicate gates on the `automerge`
  label** via `contains(github.event.pull_request.labels.*.name,
  'automerge')` so reviews on other PRs do not burn a runner.
  Predicate does not gate on `review.state` — the existing
  in-job gating (mergeable / required-reviews via the merge
  API) is the source of truth.

- **Top-level `concurrency:` moved to job-level.** The existing
  `merge-bot-<n>` group now lives on the `merge` job; the new
  `sweep` job carries its own `merge-bot-sweep` group.
  Functionally identical for existing trigger paths.

### Self-review only

The general-purpose subagent (`Task` / `Agent` tool) was
unavailable in this environment, so this PR was self-reviewed
against the project conventions checklist rather than reviewed
by a separate subagent.

Self-review checklist outcome:

- `push: branches: [main]` only — tag pushes excluded by
  branch filter, and the sweep job's `if:` re-asserts
  `github.ref == 'refs/heads/main'` as defence-in-depth.
- `pull_request_review` `if:` does not fire on every review —
  gated on `contains(...labels.*.name, 'automerge')`.
- Per-PR concurrency unchanged — `merge-bot-<n>` group moved
  from workflow-level to job-level on `merge`, with the
  identical group-key expression.
- Every new `run:` block binds event-payload values through
  `env:` (CodeQL discipline). The sweep step's only env-binding
  is `GH_TOKEN` from `github.token`; the `gh pr list` output
  flows through `mapfile` and quoted `${pr}` expansions only.
- No new `uses:` references added — sweep job calls `gh` from a
  `run:` block. SHA-pinning policy already satisfied by the
  unchanged `actions/create-github-app-token`,
  `actions/checkout`, `actions/setup-python` references.
- Header comment block updated with one-paragraph rationale per
  new trigger.
- Plan committed at `plans/merge-bot-event-gaps.md`.

### Test plan

- [ ] Static: `yq .github/workflows/merge-bot.yml > /dev/null`
      parses cleanly.
- [ ] Static: the `on:` block contains
      `pull_request_review: types: [submitted, dismissed]` and
      `push: branches: [main]`.
- [ ] Static: the new `sweep` job's `if:` is
      `github.event_name == 'push' && github.ref ==
      'refs/heads/main'`.
- [ ] Static: the existing `merge` job's `if:` chain accepts
      `pull_request_review` only when the PR carries
      `automerge`.
- [ ] Static: workflow-level `permissions:` includes
      `actions: write`.
- [ ] Static: the `merge` job's `concurrency.group` resolves to
      `merge-bot-<pr_number>` for `pull_request_review` events
      via the existing `github.event.pull_request.number`
      fallback.
- [ ] Static: `shellcheck` on the sweep step's `run:` body parses
      cleanly (verified locally).
- [ ] Live: submitting a review on this PR after CI is green
      fires merge-bot via the new `pull_request_review` trigger
      (visible as a new `Merge Bot` workflow run keyed to the
      review event in the PR's checks rollup).
- [ ] Post-merge: confirm a `push:main` event on the merge
      commit triggers exactly one `sweep` run; with no other
      `automerge` PRs open, it exits cleanly with "no PRs to
      dispatch".