### PR TITLE
improvement(ci): assert exact per-package release-asset counts

### DIFF
--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -84,6 +84,10 @@ jobs:
         run: |
           set -euo pipefail
           expected=$(find packages -mindepth 2 -maxdepth 2 -name pyproject.toml | wc -l)
+          if [[ "${expected}" -lt 1 ]]; then
+            echo "::error::no workspace members found under packages/* — dryrun count derivation is broken"
+            exit 1
+          fi
           # `nullglob` makes an unmatched glob expand to nothing
           # rather than the literal pattern, so the array stays empty
           # when the build step (above) failed and produced no dist/.

--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -72,21 +72,18 @@ jobs:
         continue-on-error: true
         run: scripts/build-release-artifacts.sh --out dist
 
-      # Today the workspace-root `uv build` produces one wheel + one
-      # sdist (when it works); after #324 the per-package loop
-      # produces one pair per `packages/<svc>/`. The assertion is
-      # "the build produced at least one wheel + one sdist", which
-      # is the weakest meaningful contract that still catches the
-      # workspace-split regression (build error → zero artefacts)
-      # and stays valid through the #324 transition without needing
-      # an update. Tighten this to per-package enumeration once #324
-      # lands (issue tracks the move from informational to required
-      # status check).
+      # Per-package release-asset layout (ADR 0044): one wheel + one
+      # sdist per workspace member. The expected count is derived from
+      # `packages/<svc>/pyproject.toml` so adding a new workspace
+      # member tightens the gate automatically with no edit here. A
+      # regression that drops one package's pair will fail the assert
+      # — the looser "at least one" gate this replaces could not.
       - name: Assert expected artefact set
         continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
+          expected=$(find packages -mindepth 2 -maxdepth 2 -name pyproject.toml | wc -l)
           # `nullglob` makes an unmatched glob expand to nothing
           # rather than the literal pattern, so the array stays empty
           # when the build step (above) failed and produced no dist/.
@@ -99,12 +96,16 @@ jobs:
           else
             echo "No dist/ directory — build step failed before producing any artefacts."
           fi
-          if [[ "${#wheels[@]}" -eq 0 ]]; then
-            echo "::error::no .whl artefacts produced in dist/"
-            exit 1
+          fail=0
+          if [[ "${#wheels[@]}" -ne "${expected}" ]]; then
+            echo "::error::expected ${expected} .whl artefacts (one per workspace member), got ${#wheels[@]}"
+            fail=1
           fi
-          if [[ "${#sdists[@]}" -eq 0 ]]; then
-            echo "::error::no .tar.gz sdist artefacts produced in dist/"
-            exit 1
+          if [[ "${#sdists[@]}" -ne "${expected}" ]]; then
+            echo "::error::expected ${expected} .tar.gz sdist artefacts (one per workspace member), got ${#sdists[@]}"
+            fail=1
           fi
-          echo "OK: ${#wheels[@]} wheel(s), ${#sdists[@]} sdist(s)."
+          if [[ "${fail}" -eq 0 ]]; then
+            echo "OK: ${#wheels[@]} wheel(s), ${#sdists[@]} sdist(s) for ${expected} workspace member(s)."
+          fi
+          exit "${fail}"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -186,17 +186,23 @@ jobs:
   # SLSA `multiple.intoto.jsonl` lives in `provenance`, so this job
   # gates on both.
   #
-  # Today the expected set is one entry per category (one wheel + one
-  # sdist + their SBOMs + a cosign bundle for each signed file + one
-  # SLSA provenance file). Issue #324 multiplies the wheel/sdist/SBOM/
-  # cosign categories per workspace member; when that lands, tighten
-  # the asserts below to enumerate per-package names.
+  # Per-package release-asset layout (ADR 0044): one wheel + one sdist
+  # per workspace member, one SBOM per artefact (so 2N SBOMs), one
+  # cosign bundle per signed file (each artefact + each SBOM, so 4N
+  # bundles), and one SLSA provenance file per release. The expected
+  # member count is derived from `packages/<svc>/pyproject.toml` so a
+  # new workspace member tightens the gate automatically.
   verify-assets:
     needs: [publish, provenance]
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Only need `packages/` to count workspace members; a shallow
+          # clone is enough.
+          fetch-depth: 1
       - name: Verify expected release assets are uploaded
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -204,6 +210,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          # Workspace member count (matches `[tool.uv.workspace].members
+          # = ["packages/*"]` in the root pyproject.toml). Drives every
+          # per-package count below.
+          members=$(find packages -mindepth 2 -maxdepth 2 -name pyproject.toml | wc -l)
+          if [[ "${members}" -lt 1 ]]; then
+            echo "::error::no workspace members found under packages/* — release-asset count derivation is broken"
+            exit 1
+          fi
 
           # `gh release view --json assets` returns one record per
           # uploaded asset. The publish + provenance jobs upload in
@@ -223,6 +238,11 @@ jobs:
 
           wheels="$(count 'endswith(".whl")')"
           sdists="$(count 'endswith(".tar.gz")')"
+          # `.sha256` sidecars are uploaded for every wheel + sdist
+          # (the install scripts read them for tamper-evident
+          # verification). `endswith(".sha256")` matches both
+          # `<wheel>.sha256` and `<sdist>.sha256`.
+          sha256_sidecars="$(count 'endswith(".sha256")')"
           # SBOM files end in `.spdx.json`; cosign bundles end in
           # `.sig.bundle` and may sign either an artefact or its SBOM.
           sboms="$(count 'endswith(".spdx.json")')"
@@ -231,27 +251,28 @@ jobs:
           # single `multiple.intoto.jsonl` file (one per release).
           slsa="$(count 'endswith(".intoto.jsonl")')"
 
-          echo "Release ${TAG} assets:"
-          echo "  wheels=${wheels} sdists=${sdists} sboms=${sboms}"
-          echo "  cosign_bundles=${cosign_bundles} slsa=${slsa}"
+          expected_wheels="${members}"
+          expected_sdists="${members}"
+          expected_sha256_sidecars=$((members * 2))
+          expected_sboms=$((members * 2))
+          expected_cosign_bundles=$((members * 4))
+
+          echo "Release ${TAG} assets (workspace members=${members}):"
+          echo "  wheels=${wheels} (expected ${expected_wheels})"
+          echo "  sdists=${sdists} (expected ${expected_sdists})"
+          echo "  sha256_sidecars=${sha256_sidecars} (expected ${expected_sha256_sidecars})"
+          echo "  sboms=${sboms} (expected ${expected_sboms})"
+          echo "  cosign_bundles=${cosign_bundles} (expected ${expected_cosign_bundles})"
+          echo "  slsa=${slsa} (expected 1)"
           echo "Asset list:"
           jq -r '.[]' <<<"${assets}" | sed 's/^/  /'
 
           fail=0
-          # Today (workspace-root build): 1 wheel + 1 sdist = 2 source
-          # artefacts; one SBOM each = 2; cosign signs all 4 of those
-          # = 4 bundles; SLSA = 1 file. The thresholds use `-ge` rather
-          # than `-eq` because issue #324's per-package build will
-          # multiply every count by the workspace-member count once it
-          # lands; tightening to `-eq` here would make this gate fail
-          # the moment that PR merges. The trade-off is that the gate
-          # won't catch a future regression that *over*-uploads (e.g.
-          # a flag change duplicates an asset). Revisit and tighten
-          # once #324 settles and the per-package count is stable.
-          [[ "${wheels}" -ge 1 ]] || { echo "::error::no .whl asset on release ${TAG}"; fail=1; }
-          [[ "${sdists}" -ge 1 ]] || { echo "::error::no .tar.gz sdist asset on release ${TAG}"; fail=1; }
-          [[ "${sboms}" -ge 2 ]] || { echo "::error::expected at least 2 .spdx.json SBOMs (sdist + wheel), got ${sboms}"; fail=1; }
-          [[ "${cosign_bundles}" -ge 4 ]] || { echo "::error::expected at least 4 .sig.bundle cosign signatures (sdist + wheel + 2 SBOMs), got ${cosign_bundles}"; fail=1; }
-          [[ "${slsa}" -ge 1 ]] || { echo "::error::missing SLSA provenance (multiple.intoto.jsonl) on release ${TAG}"; fail=1; }
+          [[ "${wheels}" -eq "${expected_wheels}" ]] || { echo "::error::expected ${expected_wheels} .whl assets (one per workspace member), got ${wheels}"; fail=1; }
+          [[ "${sdists}" -eq "${expected_sdists}" ]] || { echo "::error::expected ${expected_sdists} .tar.gz sdist assets (one per workspace member), got ${sdists}"; fail=1; }
+          [[ "${sha256_sidecars}" -eq "${expected_sha256_sidecars}" ]] || { echo "::error::expected ${expected_sha256_sidecars} .sha256 sidecars (one per wheel + one per sdist), got ${sha256_sidecars}"; fail=1; }
+          [[ "${sboms}" -eq "${expected_sboms}" ]] || { echo "::error::expected ${expected_sboms} .spdx.json SBOMs (one per wheel + one per sdist), got ${sboms}"; fail=1; }
+          [[ "${cosign_bundles}" -eq "${expected_cosign_bundles}" ]] || { echo "::error::expected ${expected_cosign_bundles} .sig.bundle cosign signatures (one per artefact + one per SBOM), got ${cosign_bundles}"; fail=1; }
+          [[ "${slsa}" -eq 1 ]] || { echo "::error::expected exactly 1 SLSA provenance file (multiple.intoto.jsonl) on release ${TAG}, got ${slsa}"; fail=1; }
 
           exit "${fail}"

--- a/changelog/@unreleased/pr-393-release-asset-count-asserts.yml
+++ b/changelog/@unreleased/pr-393-release-asset-count-asserts.yml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+type: improvement
+improvement:
+  description: |
+    The `release-publish.yml` `verify-assets` post-publish gate and
+    the `release-dryrun.yml` PR-time gate now assert exact per-package
+    counts derived from the workspace member count, instead of the
+    pre-#324 "at least one" thresholds. With N workspace members the
+    gates expect N wheels, N sdists, 2N `.sha256` sidecars, 2N SBOMs
+    (one per artefact), and 4N cosign signature bundles (one per
+    artefact + one per SBOM). A regression that drops one package's
+    asset set (e.g. a `gh release upload` glob change that misses
+    `*.spdx.json.sig.bundle`, or a `uv build --all-packages` skip)
+    will now fail the gate; the previous `-ge 1` thresholds would
+    silently pass. Adds `.sha256` sidecar enumeration, which the
+    earlier check did not cover at all, and a `actions/checkout`
+    step on `verify-assets` so the workspace member count is read
+    from `packages/*/pyproject.toml` rather than hard-coded.
+  links:
+    - https://github.com/aidanns/agent-auth/issues/382


### PR DESCRIPTION
==COMMIT_MSG==
improvement(ci): assert exact per-package release-asset counts

The post-publish `verify-assets` gate and the PR-time
`release-dryrun` gate both used `-ge 1` thresholds because the
workspace-root build that pre-dated #324 only produced one wheel
+ one sdist; tightening would have failed once the per-package
build (#324, ADR 0044) landed. With #324 now on `main` the soft
thresholds let a regression that drops one package's full asset
set pass silently.

Both gates now derive the workspace member count from
`packages/<svc>/pyproject.toml` (seven today, automatic on add)
and assert exact per-category counts — N wheels, N sdists, 2N
.sha256 sidecars, 2N SBOMs, 4N cosign bundles, 1 SLSA provenance
file. .sha256 sidecar enumeration is new; the previous gate did
not count them at all even though they have been uploaded since
#324. Adds an `actions/checkout` step to `verify-assets` so the
member count is read from the repo rather than hard-coded.

Closes #382

Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

## Review notes

Origin: deferred from the independent review of #378 (https://github.com/aidanns/agent-auth/pull/378#issuecomment-4322199803). Issue #382 captured the deferred work; this PR addresses it.

Verification:
- `find packages -mindepth 2 -maxdepth 2 -name pyproject.toml | wc -l` → `7` on main today, matches `SECURITY.md` § Supply-chain artifacts ("seven packages today").
- The expected counts match the actual upload globs in `release-publish.yml`:
  - `*.whl` `*.whl.sha256` `*.whl.sig.bundle` → N + N + N
  - `*.tar.gz` `*.tar.gz.sha256` `*.tar.gz.sig.bundle` → N + N + N
  - `*.spdx.json` `*.spdx.json.sig.bundle` → 2N + 2N
  - SLSA generator → 1 `multiple.intoto.jsonl`
- Total: N wheels, N sdists, 2N `.sha256`, 2N SBOMs, 4N cosign bundles, 1 SLSA file. ✅
- `endswith` filters are mutually exclusive — `<wheel>.spdx.json.sig.bundle` ends with `.sig.bundle`, not `.spdx.json` or `.whl`, so no double-counting.

Choices made (no explicit issue guidance):

- Member count derivation by `find packages/*/pyproject.toml` rather than parsing the workspace glob from `pyproject.toml` — `pyproject.toml`'s `members = ["packages/*"]` is hard-coded today, and a future change to that glob would also need a corresponding find-pattern change here. Documenting the link in the workflow comment is enough.
- Added `actions/checkout` to `verify-assets` (new step). The job previously did no checkout because it only needed the GitHub release API. The shallow clone (`fetch-depth: 1`) is fine — only `packages/*/pyproject.toml` is read.
- Kept the `continue-on-error: true` on the dryrun assert step. The header comment explicitly calls removing it the trigger for moving the gate from informational to required, and that's a separate config-only follow-up tracked in the dryrun comment.