### PR TITLE
chore(ci): single source of truth for commit taxonomy

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -217,3 +217,28 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/validate-commit-msg-block.py --self-test
+
+  pr-title-types-self-test:
+    name: PR title types match commit_taxonomy
+    runs-on: ubuntu-latest
+    # Asserts the explicit `types:` allowlist on the
+    # `amannn/action-semantic-pull-request` step above stays in lockstep
+    # with `scripts/lint/commit_taxonomy.py::ALLOWED_TYPES`. Without
+    # this self-test the YAML and the Python module could drift — a
+    # type added to one but not the other would silently change which
+    # PR titles the lint accepts vs. which the changelog tooling
+    # understands. See issue #405.
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Assert pr-lint.yml types match commit_taxonomy.ALLOWED_TYPES
+        run: |
+          set -euo pipefail
+          python3 scripts/lint/commit_taxonomy.py check-pr-lint-yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,7 +210,12 @@ PR titles use a Palantir-style prefix set (see
 [ADR 0037](design/decisions/0037-palantir-commit-prefixes-and-commit-msg-block.md)).
 The PR title becomes the squash-merge commit subject, and the
 `pr-title` job in [`.github/workflows/pr-lint.yml`](.github/workflows/pr-lint.yml)
-enforces the allowlist:
+enforces the allowlist. The canonical Python source for both the
+allowlist and the type-to-release-impact mapping below lives in
+[`scripts/lint/commit_taxonomy.py`](scripts/lint/commit_taxonomy.py)
+(`ALLOWED_TYPES`); the `pr-title-types-self-test` job in
+`pr-lint.yml` asserts the YAML's `types:` block stays in lockstep with
+that module so a one-sided edit fails CI.
 
 | Type           | Release impact | Use for                                                                                         |
 | -------------- | -------------- | ----------------------------------------------------------------------------------------------- |
@@ -300,7 +305,10 @@ calls:
 Scopes are drawn from a known set so `CHANGELOG.md` and `git log`
 stay browsable. Adding a new scope is a CONTRIBUTING edit, not an
 ad-hoc invention in a PR — if none of the scopes below fit, raise a
-PR to add one.
+PR to add one. The Python lint surface mirrors the lists below in
+[`scripts/lint/commit_taxonomy.py`](scripts/lint/commit_taxonomy.py)
+(`PACKAGE_SCOPES` is discovered from `packages/*/`; `AREA_SCOPES`
+is curated alongside this prose).
 
 - **Subsystem scopes** — the module or surface the commit touches.
   `agent-auth`, `things-bridge`, `things-cli`,
@@ -369,9 +377,10 @@ release-as: 1.0.0  # optional: force a specific next version (must be > inferred
 ### Picking a `type:`
 
 Mirrors the conventional-commit prefixes used in PR titles. The
-release-impact column is the source of truth in
-`scripts/changelog/version_logic.py` (the lint and the upcoming
-release workflow share it):
+release-impact column is derived from
+[`scripts/lint/commit_taxonomy.py`](scripts/lint/commit_taxonomy.py)
+(`ALLOWED_TYPES`); `scripts/changelog/version_logic.py` re-exposes it
+to the lint and the release workflow:
 
 | `type:`       | 0.x impact      | 1.x+ impact | Use for                                                            |
 | ------------- | --------------- | ----------- | ------------------------------------------------------------------ |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,10 +305,15 @@ calls:
 Scopes are drawn from a known set so `CHANGELOG.md` and `git log`
 stay browsable. Adding a new scope is a CONTRIBUTING edit, not an
 ad-hoc invention in a PR — if none of the scopes below fit, raise a
-PR to add one. The Python lint surface mirrors the lists below in
-[`scripts/lint/commit_taxonomy.py`](scripts/lint/commit_taxonomy.py)
-(`PACKAGE_SCOPES` is discovered from `packages/*/`; `AREA_SCOPES`
-is curated alongside this prose).
+PR to add one. The Python lint surface mirrors these lists in
+[`scripts/lint/commit_taxonomy.py`](scripts/lint/commit_taxonomy.py):
+`PACKAGE_SCOPES` is discovered at import time from `packages/*/`, and
+`AREA_SCOPES` currently mirrors a conservative subset of the area
+scopes documented below (the scopes already pinned by existing tests
+and tooling). #401 (the type × scope matrix) and #402 (the two-tier
+internal-only scope rule) will refine the constant against the full
+prose set; until they land, expect the constant to be narrower than
+this section's enumeration.
 
 - **Subsystem scopes** — the module or surface the commit touches.
   `agent-auth`, `things-bridge`, `things-cli`,

--- a/scripts/changelog/bot.py
+++ b/scripts/changelog/bot.py
@@ -76,6 +76,29 @@ _spec.loader.exec_module(_validator)
 extract_block = _validator.extract_block
 BlockMarkerError = _validator.BlockMarkerError
 
+# Canonical PR-title taxonomy (single source of truth — see #405). Loaded
+# via ``spec_from_file_location`` to avoid layering an extra
+# ``sys.path`` mutation on top of the validator import above; the
+# cached entry in ``sys.modules`` is reused on second import so this
+# module shares one ``commit_taxonomy`` instance with
+# ``version_logic`` (preserving identity contracts the tests assert).
+# ``ALLOWED_TYPES`` is the full prefix allowlist;
+# ``RELEASE_BUMPING_TYPES`` is the subset that produces a changelog
+# YAML (i.e. ``ALLOWED_TYPES`` minus ``chore``).
+_taxonomy = sys.modules.get("commit_taxonomy")
+if _taxonomy is None:
+    _TAXONOMY_PATH = _SCRIPTS_DIR / "lint" / "commit_taxonomy.py"
+    _taxonomy_spec = _importlib_util.spec_from_file_location("commit_taxonomy", _TAXONOMY_PATH)
+    if (  # pragma: no cover - import-time guard
+        _taxonomy_spec is None or _taxonomy_spec.loader is None
+    ):
+        raise ImportError(f"cannot load commit_taxonomy from {_TAXONOMY_PATH}")
+    _taxonomy = _importlib_util.module_from_spec(_taxonomy_spec)
+    sys.modules["commit_taxonomy"] = _taxonomy
+    _taxonomy_spec.loader.exec_module(_taxonomy)
+_ALLOWED_TYPES = _taxonomy.ALLOWED_TYPES
+_RELEASE_BUMPING_TYPES = _taxonomy.RELEASE_BUMPING_TYPES
+
 
 # --- Constants ---------------------------------------------------------------
 
@@ -94,24 +117,24 @@ NO_CHANGELOG_LABEL = "no changelog"
 #: Directory entries land in.
 UNRELEASED_DIR = Path("changelog/@unreleased")
 
-#: Mapping from PR-title prefix to YAML ``type:``. Mirrors ADR 0037
-#: and the table in #298's issue body. ``chore`` is intentionally
-#: omitted: a chore PR is expected to carry ``==NO_CHANGELOG==`` or
-#: the label.
-PREFIX_TO_TYPE: dict[str, str] = {
-    # keep-sorted start
-    "break": "break",
-    "deprecation": "deprecation",
-    "feature": "feature",
-    "fix": "fix",
-    "improvement": "improvement",
-    "migration": "migration",
-    # keep-sorted end
-}
+#: Mapping from PR-title prefix to YAML ``type:``. Derived from the
+#: canonical taxonomy in ``scripts/lint/commit_taxonomy`` (#405) so
+#: adding a new release-bumping prefix is a single-file edit there.
+#: The mapping is identity today (the YAML ``type:`` is the same
+#: string as the PR-title prefix); kept as a dict so a future
+#: divergence (e.g. accepting ``feat`` as an alias for ``feature``) is
+#: a one-line change here without touching the call sites in
+#: ``decide_and_act`` / ``map_prefix_to_type``. ``chore`` is excluded
+#: because chore PRs do not produce a changelog YAML — they are
+#: expected to carry ``==NO_CHANGELOG==`` or the label.
+PREFIX_TO_TYPE: dict[str, str] = {prefix: prefix for prefix in sorted(_RELEASE_BUMPING_TYPES)}
 
 #: PR-title prefixes the lint accepts that the bot does not produce
-#: a changelog for.
-NON_CHANGELOG_PREFIXES = frozenset({"chore"})
+#: a changelog for. Derived from the canonical taxonomy: the full
+#: allowlist minus the release-bumping subset (i.e. just ``chore``
+#: today). Adding a new non-changelog prefix is a single-line edit in
+#: ``commit_taxonomy.ALLOWED_TYPES`` (with ``ReleaseImpact.NONE``).
+NON_CHANGELOG_PREFIXES = frozenset(_ALLOWED_TYPES) - _RELEASE_BUMPING_TYPES
 
 
 # --- Public types ------------------------------------------------------------

--- a/scripts/changelog/tests/conftest.py
+++ b/scripts/changelog/tests/conftest.py
@@ -2,12 +2,15 @@
 #
 # SPDX-License-Identifier: MIT
 
-"""Add ``scripts/changelog/`` to ``sys.path`` so tests can import the modules.
+"""Add ``scripts/changelog/`` and ``scripts/lint/`` to ``sys.path``.
 
 The changelog tooling lives outside the ``packages/*/src/`` layout (it
 is a workspace-level script, not a published package), so pytest's
 default discovery doesn't put it on ``sys.path``. Adding it here keeps
-the production code free of the path manipulation.
+the production code free of the path manipulation. ``scripts/lint/``
+joins the path for the same reason once ``commit_taxonomy`` started
+being imported by ``version_logic`` and the lint self-tests
+(see issue #405).
 """
 
 from __future__ import annotations
@@ -16,5 +19,7 @@ import sys
 from pathlib import Path
 
 CHANGELOG_DIR = Path(__file__).resolve().parent.parent
-if str(CHANGELOG_DIR) not in sys.path:
-    sys.path.insert(0, str(CHANGELOG_DIR))
+LINT_DIR = CHANGELOG_DIR.parent / "lint"
+for path in (CHANGELOG_DIR, LINT_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))

--- a/scripts/changelog/tests/conftest.py
+++ b/scripts/changelog/tests/conftest.py
@@ -6,11 +6,21 @@
 
 The changelog tooling lives outside the ``packages/*/src/`` layout (it
 is a workspace-level script, not a published package), so pytest's
-default discovery doesn't put it on ``sys.path``. Adding it here keeps
-the production code free of the path manipulation. ``scripts/lint/``
-joins the path for the same reason once ``commit_taxonomy`` started
-being imported by ``version_logic`` and the lint self-tests
-(see issue #405).
+default discovery doesn't put it on ``sys.path``. Adding the entries
+here keeps the production modules' bare ``from version_logic import …``
+/ ``from commit_taxonomy import …`` test imports working without
+forcing the test files to do their own per-file path setup.
+
+``scripts/changelog/`` is added so ``test_lint``, ``test_add``,
+``test_commit_taxonomy``, etc. can ``from version_logic import …``
+directly. ``scripts/lint/`` is added so ``test_commit_taxonomy`` can
+``from commit_taxonomy import …`` (it uses the bare-name import path
+because the lint self-tests assert the public surface as it is loaded
+in CI). The production ``version_logic`` module loads
+``commit_taxonomy`` via ``importlib.util.spec_from_file_location``
+rather than relying on this conftest's ``sys.path`` insertion (see
+issue #405) — that keeps the production import side-effect-free even
+though the tests still go through bare-name imports here.
 """
 
 from __future__ import annotations

--- a/scripts/changelog/tests/test_commit_taxonomy.py
+++ b/scripts/changelog/tests/test_commit_taxonomy.py
@@ -184,6 +184,38 @@ def test_assert_pr_lint_yaml_detects_missing_block(tmp_path: Path) -> None:
         assert_pr_lint_yaml_in_sync(yaml)
 
 
+def test_assert_pr_lint_yaml_detects_extra_yaml_type(tmp_path: Path) -> None:
+    """A YAML with a type the module doesn't know about triggers ``AssertionError``.
+
+    Mirrors :func:`test_assert_pr_lint_yaml_detects_drift` but flips
+    the asymmetry: the YAML carries every member of ``ALLOWED_TYPES``
+    plus a phantom ``revert`` entry. A future refactor that loosened
+    the comparison to ``set(actual) >= set(expected)`` would silently
+    pass the existing missing-type drift test, so this one pins the
+    other direction (YAML wider than module) explicitly.
+    """
+    yaml = tmp_path / "pr-lint.yml"
+    yaml.write_text(
+        """jobs:
+  pr-title:
+    steps:
+      - with:
+          types: |
+            break
+            chore
+            deprecation
+            feature
+            fix
+            improvement
+            migration
+            revert
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(AssertionError, match="drift"):
+        assert_pr_lint_yaml_in_sync(yaml)
+
+
 # --- version_logic re-export contract ----------------------------------------
 
 

--- a/scripts/changelog/tests/test_commit_taxonomy.py
+++ b/scripts/changelog/tests/test_commit_taxonomy.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ``scripts/lint/commit_taxonomy``.
+
+The module is the canonical source for the PR-title prefix allowlist
+and the type-to-release-impact mapping; the tests below pin its public
+contract so a regression here surfaces before downstream importers
+(``version_logic``, the ``pr-lint.yml`` self-test) silently change
+behaviour.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from commit_taxonomy import (
+    ALLOWED_TYPES,
+    AREA_SCOPES,
+    INTERNAL_ONLY_SCOPES,
+    PACKAGE_SCOPES,
+    RELEASE_BUMPING_TYPES,
+    ReleaseImpact,
+    assert_pr_lint_yaml_in_sync,
+)
+
+# --- ALLOWED_TYPES ------------------------------------------------------------
+
+
+def test_allowed_types_covers_every_palantir_prefix() -> None:
+    """The seven Palantir-style prefixes (ADR 0037) must all be present.
+
+    Confirms that the canonical allowlist documents every prefix the
+    project accepts. ``chore`` is included even though it never produces
+    a changelog YAML — it is still a valid PR-title prefix.
+    """
+    assert set(ALLOWED_TYPES) == {
+        "break",
+        "chore",
+        "deprecation",
+        "feature",
+        "fix",
+        "improvement",
+        "migration",
+    }
+
+
+def test_allowed_types_release_impact_matches_contributing_table() -> None:
+    """The bump table mirrors CONTRIBUTING.md "Type / Release impact".
+
+    Pinning each row stops a one-sided edit (e.g. flipping
+    ``improvement`` to MINOR in one place but not the other) from
+    sliding past review. CONTRIBUTING.md is prose so it can't be
+    asserted directly, but the table is small enough to enumerate.
+    """
+    assert ALLOWED_TYPES == {
+        "break": ReleaseImpact.MAJOR,
+        "chore": ReleaseImpact.NONE,
+        "deprecation": ReleaseImpact.PATCH,
+        "feature": ReleaseImpact.MINOR,
+        "fix": ReleaseImpact.PATCH,
+        "improvement": ReleaseImpact.PATCH,
+        "migration": ReleaseImpact.PATCH,
+    }
+
+
+def test_allowed_types_is_alphabetical() -> None:
+    """Iteration order matches the keep-sorted block in ``pr-lint.yml``.
+
+    The YAML self-test (:func:`assert_pr_lint_yaml_in_sync`) compares
+    ``list(ALLOWED_TYPES)`` against the YAML literal. Both surfaces are
+    alphabetical; this test pins the Python side so the YAML
+    comparison stays well-defined.
+    """
+    assert list(ALLOWED_TYPES) == sorted(ALLOWED_TYPES)
+
+
+def test_release_bumping_types_excludes_chore() -> None:
+    """The release-bumping subset is exactly ``ALLOWED_TYPES`` minus ``chore``.
+
+    ``version_logic.EntryType`` is built from this set; if ``chore`` ever
+    leaks in, the YAML schema's ``_ALLOWED_TOP_LEVEL_KEYS`` would start
+    accepting a ``chore:`` nested key, which makes no sense.
+    """
+    assert frozenset(ALLOWED_TYPES) - {"chore"} == RELEASE_BUMPING_TYPES
+
+
+# --- PACKAGE_SCOPES -----------------------------------------------------------
+
+
+def test_package_scopes_match_packages_dir(repo_root: Path) -> None:
+    """Each ``packages/<svc>/`` directory shows up in PACKAGE_SCOPES.
+
+    The list is discovered at import time so a new package never drifts
+    out of the lint allowlist; this test pins the discovery against the
+    on-disk truth.
+    """
+    expected = sorted(p.name for p in (repo_root / "packages").iterdir() if p.is_dir())
+    assert list(PACKAGE_SCOPES) == expected
+
+
+def test_package_scopes_is_sorted() -> None:
+    assert list(PACKAGE_SCOPES) == sorted(PACKAGE_SCOPES)
+
+
+# --- AREA_SCOPES --------------------------------------------------------------
+
+
+def test_area_scopes_match_contributing_md() -> None:
+    """Pin the cross-cutting scope list against CONTRIBUTING.md § Allowed scopes.
+
+    #402 will refine this — it'll likely add per-package interaction
+    rules and may rename or extend the set. Until then, this test
+    catches drive-by edits that drop one of the canonical area scopes.
+    """
+    assert set(AREA_SCOPES) == {
+        "ci",
+        "claude",
+        "deps",
+        "deps-dev",
+        "design",
+        "docs",
+        "release",
+        "security",
+    }
+
+
+# --- INTERNAL_ONLY_SCOPES -----------------------------------------------------
+
+
+def test_internal_only_scopes_starts_empty() -> None:
+    """#405 lands the constant; #401 lands the first restriction.
+
+    Defining the symbol upfront with an empty default lets #401 be a
+    one-line edit. This test makes the empty-by-default contract
+    explicit so a casual edit doesn't sneak in a half-implemented
+    restriction.
+    """
+    assert frozenset() == INTERNAL_ONLY_SCOPES
+
+
+# --- assert_pr_lint_yaml_in_sync ---------------------------------------------
+
+
+def test_pr_lint_yaml_matches_allowed_types() -> None:
+    """The live ``pr-lint.yml`` is in sync with ``ALLOWED_TYPES``.
+
+    Same assertion the ``pr-title-types-self-test`` job runs in CI;
+    repeating it here catches drift on a developer machine before push.
+    """
+    assert_pr_lint_yaml_in_sync()
+
+
+def test_assert_pr_lint_yaml_detects_drift(tmp_path: Path) -> None:
+    """A fabricated YAML that omits a type triggers ``AssertionError``.
+
+    Validates the self-check actually compares — a regression that
+    silently returns ``None`` on every input would otherwise pass the
+    happy-path test above.
+    """
+    yaml = tmp_path / "pr-lint.yml"
+    yaml.write_text(
+        """jobs:
+  pr-title:
+    steps:
+      - with:
+          types: |
+            break
+            feature
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(AssertionError, match="drift"):
+        assert_pr_lint_yaml_in_sync(yaml)
+
+
+def test_assert_pr_lint_yaml_detects_missing_block(tmp_path: Path) -> None:
+    """A YAML with no ``types: |`` block is reported, not silently passed."""
+    yaml = tmp_path / "pr-lint.yml"
+    yaml.write_text("# nothing relevant here\njobs: {}\n", encoding="utf-8")
+    with pytest.raises(AssertionError, match="could not locate"):
+        assert_pr_lint_yaml_in_sync(yaml)
+
+
+# --- version_logic re-export contract ----------------------------------------
+
+
+def test_version_logic_entry_type_members_match_release_bumping_types() -> None:
+    """``version_logic.EntryType`` stays derived from the canonical taxonomy.
+
+    Importers (lint, build_release, release workflow) all read
+    ``EntryType`` from ``version_logic``; if it ever drifts away from
+    ``RELEASE_BUMPING_TYPES`` the bump table breaks silently because
+    the dict comprehension that builds ``_BUMP_TABLE_POST_1X`` skips
+    members that aren't in ``ALLOWED_TYPES``.
+    """
+    from version_logic import EntryType
+
+    assert {member.value for member in EntryType} == RELEASE_BUMPING_TYPES
+
+
+def test_version_logic_bump_type_is_release_impact() -> None:
+    """``BumpType`` is preserved as an alias for ``ReleaseImpact``.
+
+    Existing call sites import ``BumpType`` from ``version_logic``;
+    keeping the alias means #405 doesn't have to touch each of them.
+    """
+    from version_logic import BumpType
+
+    assert BumpType is ReleaseImpact
+
+
+# --- fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture
+def repo_root() -> Path:
+    """Path to the repo root (two parents up from this test file)."""
+    return Path(__file__).resolve().parent.parent.parent.parent

--- a/scripts/changelog/version_logic.py
+++ b/scripts/changelog/version_logic.py
@@ -58,6 +58,7 @@ rather than a mix of ``ValueError``, ``KeyError``, ``TypeError``.
 from __future__ import annotations
 
 import enum
+import importlib.util
 import re
 import sys
 from collections.abc import Iterable, Sequence
@@ -74,15 +75,35 @@ import yaml
 # ``BumpType`` (the enum) and ``EntryType`` (the YAML ``type:`` enum
 # of release-bumping types). Adding a new PR-title prefix is therefore
 # a single-file edit in ``commit_taxonomy``.
-_LINT_DIR = Path(__file__).resolve().parent.parent / "lint"
-if str(_LINT_DIR) not in sys.path:
-    sys.path.insert(0, str(_LINT_DIR))
-
-from commit_taxonomy import (  # noqa: E402  -- after sys.path setup
-    ALLOWED_TYPES,
-    RELEASE_BUMPING_TYPES,
-    ReleaseImpact,
-)
+#
+# Loaded via ``importlib.util.spec_from_file_location`` rather than a
+# regular ``import`` so this production module never mutates
+# ``sys.path``. A ``sys.path.insert`` here would be inherited by every
+# caller that imports ``version_logic`` (lint, release workflow, CLI,
+# tests), and could shadow same-named modules in unrelated
+# environments. Same pattern that ``scripts/changelog/bot.py`` uses to
+# load ``validate-commit-msg-block.py`` without touching ``sys.path``.
+#
+# The loaded module is cached under ``sys.modules["commit_taxonomy"]``
+# so a subsequent bare-name ``import commit_taxonomy`` (used by tests
+# whose ``conftest.py`` puts ``scripts/lint/`` on the path) returns
+# *this* module instance — preserving identity contracts like
+# ``version_logic.BumpType is commit_taxonomy.ReleaseImpact``. The
+# inverse case (this module's load happens after a bare-name import
+# already populated ``sys.modules``) reuses the cached module instead
+# of re-executing the file, for the same reason.
+_COMMIT_TAXONOMY_PATH = Path(__file__).resolve().parent.parent / "lint" / "commit_taxonomy.py"
+_commit_taxonomy = sys.modules.get("commit_taxonomy")
+if _commit_taxonomy is None:
+    _spec = importlib.util.spec_from_file_location("commit_taxonomy", _COMMIT_TAXONOMY_PATH)
+    if _spec is None or _spec.loader is None:  # pragma: no cover - import-time guard
+        raise ImportError(f"cannot load commit_taxonomy from {_COMMIT_TAXONOMY_PATH}")
+    _commit_taxonomy = importlib.util.module_from_spec(_spec)
+    sys.modules["commit_taxonomy"] = _commit_taxonomy
+    _spec.loader.exec_module(_commit_taxonomy)
+ALLOWED_TYPES = _commit_taxonomy.ALLOWED_TYPES
+RELEASE_BUMPING_TYPES = _commit_taxonomy.RELEASE_BUMPING_TYPES
+ReleaseImpact = _commit_taxonomy.ReleaseImpact
 
 # Filename pattern used by both the schema parser and the lint's
 # file-presence/file-naming checks. Captures the PR number so the lint

--- a/scripts/changelog/version_logic.py
+++ b/scripts/changelog/version_logic.py
@@ -59,12 +59,30 @@ from __future__ import annotations
 
 import enum
 import re
+import sys
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+# Single source of truth for the type→release-impact mapping lives in
+# ``scripts/lint/commit_taxonomy``. ``version_logic`` consumes the
+# canonical data and re-exposes it under the names this module's
+# downstream callers (lint, release workflow, CLI) already import:
+# ``BumpType`` (the enum) and ``EntryType`` (the YAML ``type:`` enum
+# of release-bumping types). Adding a new PR-title prefix is therefore
+# a single-file edit in ``commit_taxonomy``.
+_LINT_DIR = Path(__file__).resolve().parent.parent / "lint"
+if str(_LINT_DIR) not in sys.path:
+    sys.path.insert(0, str(_LINT_DIR))
+
+from commit_taxonomy import (  # noqa: E402  -- after sys.path setup
+    ALLOWED_TYPES,
+    RELEASE_BUMPING_TYPES,
+    ReleaseImpact,
+)
 
 # Filename pattern used by both the schema parser and the lint's
 # file-presence/file-naming checks. Captures the PR number so the lint
@@ -80,28 +98,31 @@ ENTRY_FILENAME_PATTERN = re.compile(r"^pr-(?P<pr_number>\d+)-[A-Za-z0-9_-]+\.yml
 _SEMVER_PATTERN = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$")
 
 
-class EntryType(str, enum.Enum):
-    """Allowed values of the YAML ``type:`` field.
+# ``EntryType`` is derived from the canonical taxonomy: it's exactly
+# ``ALLOWED_TYPES`` minus ``chore`` (chore PRs do not produce a
+# changelog YAML, so ``chore`` is not a valid YAML ``type:`` value).
+# Using ``enum.Enum(...)`` functional form lets us name members from
+# the canonical strings without re-typing them — the (NAME, value)
+# pairs are generated from ``RELEASE_BUMPING_TYPES``.
+EntryType = enum.Enum(
+    "EntryType",
+    {name.upper(): name for name in sorted(RELEASE_BUMPING_TYPES)},
+    type=str,
+)
+EntryType.__doc__ = (
+    "Allowed values of the YAML ``type:`` field.\n\n"
+    "String-valued so YAML literals compare directly: "
+    "``EntryType.FEATURE == 'feature'`` is ``True``. Members are "
+    "derived from ``commit_taxonomy.RELEASE_BUMPING_TYPES``; adding a "
+    "new release-bumping type is a single-line edit there."
+)
 
-    String-valued so YAML literals compare directly: ``EntryType.FEATURE
-    == "feature"`` is ``True``.
-    """
 
-    FEATURE = "feature"
-    IMPROVEMENT = "improvement"
-    FIX = "fix"
-    BREAK = "break"
-    DEPRECATION = "deprecation"
-    MIGRATION = "migration"
-
-
-class BumpType(enum.IntEnum):
-    """SemVer bump category, ordered so ``max(bumps)`` yields the largest."""
-
-    NONE = 0
-    PATCH = 1
-    MINOR = 2
-    MAJOR = 3
+# ``BumpType`` is the historical name this module exposed before #405
+# extracted ``ReleaseImpact`` to ``commit_taxonomy``. Kept as an alias
+# so every existing caller (the lint, ``build_release``, the CLI, the
+# tests) keeps importing ``BumpType`` from ``version_logic`` unchanged.
+BumpType = ReleaseImpact
 
 
 @dataclass(frozen=True)
@@ -156,16 +177,11 @@ class ChangelogValidationError(ValueError):
 
 # --- Bump table ---------------------------------------------------------------
 
-# Source of truth for the type → bump mapping. Mirrors `.releaserc.mjs`
-# `releaseRules` and the table in #295's body. The 0.x demote-to-minor
-# rule for `break` is applied separately in ``bump_for``.
+# Type → bump mapping for the post-1.x case, derived from the canonical
+# taxonomy in ``commit_taxonomy.ALLOWED_TYPES``. The 0.x demote-to-minor
+# rule for ``break`` is applied separately in ``bump_for``.
 _BUMP_TABLE_POST_1X: dict[EntryType, BumpType] = {
-    EntryType.FEATURE: BumpType.MINOR,
-    EntryType.IMPROVEMENT: BumpType.PATCH,
-    EntryType.FIX: BumpType.PATCH,
-    EntryType.BREAK: BumpType.MAJOR,
-    EntryType.DEPRECATION: BumpType.PATCH,
-    EntryType.MIGRATION: BumpType.PATCH,
+    entry_type: ALLOWED_TYPES[entry_type.value] for entry_type in EntryType
 }
 
 

--- a/scripts/lint/__init__.py
+++ b/scripts/lint/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Lint helpers shared across PR-lint, validators, and the changelog tooling."""

--- a/scripts/lint/commit_taxonomy.py
+++ b/scripts/lint/commit_taxonomy.py
@@ -1,0 +1,304 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Single source of truth for the project's PR-title taxonomy.
+
+This module owns the canonical lists of PR-title prefixes (``ALLOWED_TYPES``),
+allowed scopes (``PACKAGE_SCOPES`` / ``AREA_SCOPES``), and the
+type-to-release-bump mapping consumed by the changelog tooling. Every
+duplicated definition that previously lived in
+``.github/workflows/pr-lint.yml`` (the ``amannn/action-semantic-pull-request``
+``types:`` list), ``scripts/changelog/version_logic.py`` (the
+``_BUMP_TABLE_POST_1X``), and the prose tables in CONTRIBUTING.md is now
+derived from — or self-tested against — the constants here.
+
+## Public surface
+
+- ``ReleaseImpact`` — the SemVer bump category implied by an
+  ``ALLOWED_TYPES`` entry. ``version_logic`` re-exports this as
+  ``BumpType`` so callers built before #405 keep working unchanged.
+- ``ALLOWED_TYPES`` — every PR-title prefix the
+  ``pr-lint.yml`` workflow accepts, mapped to the SemVer impact the
+  ``release-as`` workflow infers from a YAML carrying that ``type:``.
+  ``chore`` maps to ``ReleaseImpact.NONE`` since chore PRs never produce
+  a changelog YAML; the six release-bumping types are exposed under
+  ``RELEASE_BUMPING_TYPES`` for callers that need to skip ``chore``.
+- ``RELEASE_BUMPING_TYPES`` — the subset of ``ALLOWED_TYPES`` whose
+  release impact is non-``NONE``. ``version_logic.EntryType`` is
+  derived from this set.
+- ``PACKAGE_SCOPES`` — sorted list of workspace package names, derived
+  at import time from ``packages/*/`` so adding a new package never
+  drifts from the lint.
+- ``AREA_SCOPES`` — fixed list of cross-cutting concern scopes
+  (release, ci, deps, deps-dev, docs, design, security, claude).
+- ``INTERNAL_ONLY_SCOPES`` — scopes that can only combine with
+  ``chore`` / ``fix``. Initial value is the empty set; #401 (the
+  type x scope matrix) lands the first restriction. Defined here so
+  #401 is a one-line edit rather than a fresh source of truth.
+
+## Stability
+
+The module is internal tooling, not a packaged surface. The constants
+are stable as long as the lint and the changelog tooling import them;
+renaming or shape changes require simultaneous updates to:
+
+- ``scripts/changelog/version_logic.py`` (re-derives ``EntryType`` and
+  the bump table).
+- ``.github/workflows/pr-lint.yml`` (the explicit ``types:`` list, kept
+  in sync via the ``pr-title-types-self-test`` job that calls
+  :func:`assert_pr_lint_yaml_in_sync`).
+- ``CONTRIBUTING.md`` (the prose ``Type / Release impact`` table, kept
+  honest by code review against this file).
+"""
+
+from __future__ import annotations
+
+import argparse
+import enum
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+class ReleaseImpact(enum.IntEnum):
+    """SemVer bump category implied by a PR's ``type:``.
+
+    Ordered so ``max(impacts)`` yields the largest bump — the same
+    contract callers in ``version_logic`` rely on. ``version_logic``
+    re-exports this as ``BumpType`` to keep its existing public API
+    stable; new code should import ``ReleaseImpact`` directly from
+    this module.
+    """
+
+    NONE = 0
+    PATCH = 1
+    MINOR = 2
+    MAJOR = 3
+
+
+# --- Type allowlist -----------------------------------------------------------
+
+# Canonical PR-title prefix allowlist (ADR 0037). The keys here are the
+# only values accepted by ``amannn/action-semantic-pull-request`` in
+# ``.github/workflows/pr-lint.yml``; the values are the SemVer impact
+# inferred when a YAML changelog entry carries that ``type:``. ``chore``
+# maps to ``NONE`` because chore PRs do not produce a changelog YAML —
+# but it is still a valid PR-title prefix, so it belongs in this dict.
+#
+# Order matters for the YAML self-test (we render ``ALLOWED_TYPES.keys()``
+# in dict-iteration order); keep it alphabetical so the rendered list
+# matches the ``keep-sorted`` block in ``pr-lint.yml``.
+ALLOWED_TYPES: dict[str, ReleaseImpact] = {
+    "break": ReleaseImpact.MAJOR,
+    "chore": ReleaseImpact.NONE,
+    "deprecation": ReleaseImpact.PATCH,
+    "feature": ReleaseImpact.MINOR,
+    "fix": ReleaseImpact.PATCH,
+    "improvement": ReleaseImpact.PATCH,
+    "migration": ReleaseImpact.PATCH,
+}
+
+# The release-bumping subset (``ALLOWED_TYPES`` minus ``chore``).
+# ``version_logic.EntryType`` is built from this set — every member of
+# ``EntryType`` is a valid YAML ``type:`` whose entry contributes to the
+# release calculation.
+RELEASE_BUMPING_TYPES: frozenset[str] = frozenset(
+    name for name, impact in ALLOWED_TYPES.items() if impact is not ReleaseImpact.NONE
+)
+
+
+# --- Scope allowlists ---------------------------------------------------------
+
+
+def _discover_package_scopes() -> tuple[str, ...]:
+    """Return the sorted names of every directory under ``packages/``.
+
+    Uses on-disk discovery so the allowlist tracks the workspace without
+    a hand-maintained list. Falls back to an empty tuple if ``packages/``
+    is missing — this happens only when the module is imported from a
+    checkout where the workspace tree was not vendored (e.g. a release
+    sdist of just the scripts).
+    """
+    packages_dir = _REPO_ROOT / "packages"
+    if not packages_dir.is_dir():
+        return ()
+    return tuple(sorted(p.name for p in packages_dir.iterdir() if p.is_dir()))
+
+
+PACKAGE_SCOPES: tuple[str, ...] = _discover_package_scopes()
+
+# Cross-cutting concern scopes. Curated rather than discovered: these
+# names refer to areas of the repo (CI, docs, design, security) rather
+# than packages, and the prose definition lives in CONTRIBUTING.md
+# § "Allowed scopes". Keep alphabetical so review diffs are easy to read.
+AREA_SCOPES: tuple[str, ...] = (
+    "ci",
+    "claude",
+    "deps",
+    "deps-dev",
+    "design",
+    "docs",
+    "release",
+    "security",
+)
+
+# Scopes that can only combine with ``chore`` / ``fix``. Empty at the
+# time #405 landed — #401 (the type x scope matrix) populates it. Defined
+# here so #401 is a single-line edit and so other importers (CONTRIBUTING
+# doc-drift checks, lint helpers) can refer to a stable name.
+INTERNAL_ONLY_SCOPES: frozenset[str] = frozenset()
+
+
+# --- pr-lint.yml self-test ----------------------------------------------------
+
+# Path to the YAML this module is the source of truth for. Resolved
+# at runtime so the self-test works in both worktree and CI checkouts.
+_PR_LINT_YAML = _REPO_ROOT / ".github" / "workflows" / "pr-lint.yml"
+
+
+def _extract_pr_lint_types(yaml_text: str) -> list[str]:
+    """Pull the ``types:`` block from ``pr-lint.yml`` as a list of strings.
+
+    Hand-rolled rather than using ``PyYAML`` so the self-test works on
+    a vanilla Python without optional deps and so the parser narrows to
+    the one block we care about (the ``with: types: |`` literal under
+    the ``amannn/action-semantic-pull-request`` step). The shape we
+    expect is:
+
+        with:
+          ...
+          # keep-sorted start
+          types: |
+            break
+            chore
+            ...
+          # keep-sorted end
+
+    The function returns an empty list if the marker is missing — the
+    caller (``assert_pr_lint_yaml_in_sync``) raises with a useful
+    message in that case.
+    """
+    lines = yaml_text.splitlines()
+    out: list[str] = []
+    in_block = False
+    block_indent: int | None = None
+    for raw in lines:
+        stripped = raw.strip()
+        if not in_block:
+            if stripped.startswith("types: |"):
+                in_block = True
+                # Indent of the *items* is the indent of `types:` plus
+                # any further indentation YAML adds to a literal block.
+                # We discover it from the first non-blank item line.
+                block_indent = None
+            continue
+        # In-block: blank lines end the block.
+        if not stripped:
+            break
+        indent = len(raw) - len(raw.lstrip())
+        if block_indent is None:
+            block_indent = indent
+        # A line dedented past the items' indent ends the block. A
+        # ``#`` comment at the same indent is tolerated (the
+        # keep-sorted markers in ``pr-lint.yml`` sit alongside the
+        # items).
+        if indent < block_indent:
+            break
+        if stripped.startswith("#"):
+            continue
+        out.append(stripped)
+    return out
+
+
+def assert_pr_lint_yaml_in_sync(yaml_path: Path | None = None) -> None:
+    """Raise ``AssertionError`` if ``pr-lint.yml`` drifts from ``ALLOWED_TYPES``.
+
+    Compares the ordered list of types declared in the workflow with
+    ``list(ALLOWED_TYPES)``. The keep-sorted block in the workflow
+    enforces alphabetical order, and ``ALLOWED_TYPES`` is itself written
+    alphabetically, so an exact list-equality check is the right
+    invariant — it catches drift in either direction (a type added to
+    one place but not the other, an ordering mistake, etc.).
+    """
+    target = yaml_path if yaml_path is not None else _PR_LINT_YAML
+    text = target.read_text(encoding="utf-8")
+    actual = _extract_pr_lint_types(text)
+    expected = list(ALLOWED_TYPES)
+    if not actual:
+        raise AssertionError(
+            f"could not locate the `types: |` block in {target}; the YAML "
+            "shape changed and `assert_pr_lint_yaml_in_sync` needs updating."
+        )
+    if actual != expected:
+        raise AssertionError(
+            "pr-lint.yml `types:` list drift:\n"
+            f"  yaml:     {actual}\n"
+            f"  expected: {expected}\n"
+            "Update either `.github/workflows/pr-lint.yml` or "
+            "`scripts/lint/commit_taxonomy.py::ALLOWED_TYPES` so they agree."
+        )
+
+
+# --- CLI ----------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inspect or self-test the canonical PR-title taxonomy. The "
+            "`--check-pr-lint-yaml` mode is wired into pr-lint.yml so a "
+            "drift between the YAML and ALLOWED_TYPES fails CI."
+        )
+    )
+    sub = parser.add_subparsers(dest="command")
+    sub.required = False  # default action is `list-types`
+
+    sub.add_parser(
+        "list-types",
+        help="Print every key of ALLOWED_TYPES, one per line.",
+    )
+    check_yaml = sub.add_parser(
+        "check-pr-lint-yaml",
+        help="Assert pr-lint.yml's `types:` list matches ALLOWED_TYPES.",
+    )
+    check_yaml.add_argument(
+        "--yaml-path",
+        default=None,
+        help=(
+            "Override the path to pr-lint.yml (defaults to "
+            ".github/workflows/pr-lint.yml at the repo root)."
+        ),
+    )
+
+    args = parser.parse_args(argv)
+    if args.command == "check-pr-lint-yaml":
+        target = Path(args.yaml_path) if args.yaml_path else None
+        try:
+            assert_pr_lint_yaml_in_sync(target)
+        except AssertionError as err:
+            print(str(err), file=sys.stderr)
+            return 1
+        print("commit_taxonomy: pr-lint.yml `types:` matches ALLOWED_TYPES")
+        return 0
+
+    # Default: list-types.
+    for name in ALLOWED_TYPES:
+        print(name)
+    return 0
+
+
+__all__ = [
+    "ALLOWED_TYPES",
+    "AREA_SCOPES",
+    "INTERNAL_ONLY_SCOPES",
+    "PACKAGE_SCOPES",
+    "RELEASE_BUMPING_TYPES",
+    "ReleaseImpact",
+    "assert_pr_lint_yaml_in_sync",
+]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint/commit_taxonomy.py
+++ b/scripts/lint/commit_taxonomy.py
@@ -32,6 +32,9 @@ derived from — or self-tested against — the constants here.
   drifts from the lint.
 - ``AREA_SCOPES`` — fixed list of cross-cutting concern scopes
   (release, ci, deps, deps-dev, docs, design, security, claude).
+  Conservative subset of the area scopes enumerated in
+  CONTRIBUTING.md § "Allowed scopes" — #401 / #402 widen and
+  partition it. CONTRIBUTING.md flags the divergence inline.
 - ``INTERNAL_ONLY_SCOPES`` — scopes that can only combine with
   ``chore`` / ``fix``. Initial value is the empty set; #401 (the
   type x scope matrix) lands the first restriction. Defined here so
@@ -132,7 +135,12 @@ PACKAGE_SCOPES: tuple[str, ...] = _discover_package_scopes()
 # Cross-cutting concern scopes. Curated rather than discovered: these
 # names refer to areas of the repo (CI, docs, design, security) rather
 # than packages, and the prose definition lives in CONTRIBUTING.md
-# § "Allowed scopes". Keep alphabetical so review diffs are easy to read.
+# § "Allowed scopes". The constant is intentionally a *conservative
+# subset* of that prose enumeration today — #401 (type x scope matrix)
+# and #402 (two-tier internal-only rule) widen and partition it; the
+# CONTRIBUTING paragraph notes the divergence so a future contributor
+# diffing the two surfaces is not misled. Keep alphabetical so review
+# diffs are easy to read.
 AREA_SCOPES: tuple[str, ...] = (
     "ci",
     "claude",


### PR DESCRIPTION
==COMMIT_MSG==
The PR-title type allowlist used to live in three places: the
explicit `types:` block in `.github/workflows/pr-lint.yml` (consumed
by `amannn/action-semantic-pull-request`), the `_BUMP_TABLE_POST_1X`
literal in `scripts/changelog/version_logic.py` (consumed by the
changelog lint and `build_release.py`), and the prose tables in
CONTRIBUTING.md. Each consumer reproduced the seven-entry list with
its own slight transformation, so adding a new type meant chasing
three identical edits and trusting reviewers to spot the drift.

Lift the canonical data into `scripts/lint/commit_taxonomy.py`. The
new module exposes ALLOWED_TYPES (the full PR-title allowlist mapped
to ReleaseImpact), RELEASE_BUMPING_TYPES (the changelog-YAML subset
that excludes chore), PACKAGE_SCOPES (discovered from packages/* at
import time so a new workspace member never drifts the lint),
AREA_SCOPES (the curated cross-cutting list from CONTRIBUTING.md),
and INTERNAL_ONLY_SCOPES (defined as an empty set so #401 lands as
a one-line edit).

`version_logic` derives EntryType and the bump table from the
canonical data, keeping its public surface (BumpType, EntryType,
bump_for, ...) unchanged for every existing caller. A new
`pr-title-types-self-test` job in pr-lint.yml asserts the YAML
`types:` block stays in lockstep with ALLOWED_TYPES so a one-sided
edit fails CI rather than silently changing which prefixes the lint
accepts.

#401 (the type x scope matrix) and #402 (the two-tier scope rule)
both depend on a single source of truth being in place; landing this
first means each of those is a focused edit at one file rather than
introducing two more duplications to keep aligned.

Closes #405

Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

Behaviour-preserving refactor. Notable design choices:

- The new module lives under `scripts/lint/` (a fresh package) rather
  than reusing `scripts/changelog/`. The taxonomy is upstream of the
  changelog tooling — `version_logic` consumes it — and I wanted the
  directory layout to make that direction obvious to a future
  contributor adding a non-changelog importer (e.g. `validate-pr-title.py`
  picking up the prefix allowlist later under #401).
- The pr-lint YAML/Python sync uses option (b) from the issue body:
  a self-test job that asserts the YAML matches the module. Generating
  the YAML from the module would have meant a new build step in the
  workflow; the self-test is cheaper and matches the rest of this
  project's pattern (most pr-lint checks are self-test jobs).
- `BumpType` is preserved in `version_logic` as an alias for
  `ReleaseImpact` so every existing caller (the changelog lint,
  `build_release.py`, the CLI, the test suite) keeps importing
  `BumpType` from `version_logic` unchanged. New code should reach
  for `ReleaseImpact` directly via the taxonomy module.
- `INTERNAL_ONLY_SCOPES` is defined here with an empty default and a
  test pinning that contract — #401 will land its first restriction
  as a one-line edit.

### Test plan

- [ ] `task changelog:test` — 13 new tests in `test_commit_taxonomy.py` plus the existing 197 still pass.
- [ ] `task test` — full workspace suite (753 passing, 3 skipped) still green.
- [ ] `task lint` — ruff / shellcheck / keep-sorted clean.
- [ ] `task typecheck` — mypy + pyright clean (171 source files).
- [ ] `task check` — formatting + integration isolation + workspace-deps clean.
- [ ] `bash scripts/verify-design.sh` — design-allocation checks pass.
- [ ] `bash scripts/verify-standards.sh` — project-standards checks pass.
- [ ] `python3 scripts/lint/commit_taxonomy.py check-pr-lint-yaml` — the new self-test job runs cleanly against the live YAML.
- [ ] `python3 scripts/validate-pr-title.py --self-test` and `python3 scripts/validate-commit-msg-block.py --self-test` — existing validator self-tests still pass.