### PR TITLE
chore(ci): enforce two-tier scope allowlist (package or area)

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -86,6 +86,28 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: List changed files
+        # Fetch the PR's changed-files list so the validator can apply
+        # the two-tier scope rule (#402): a PR contained to a single
+        # `packages/<name>/` MUST use `(<name>)` as the scope; otherwise
+        # the scope MUST be in `commit_taxonomy.AREA_SCOPES`. We pull
+        # the list via `gh pr view --json files` instead of a checkout
+        # + `git diff` so the workflow doesn't have to fetch base-ref
+        # history; `pull_request_target` already has read access to the
+        # PR metadata via the default GITHUB_TOKEN. Output is written
+        # to RUNNER_TEMP rather than piped through a shell variable so
+        # paths with spaces or other shell metacharacters survive.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh pr view "${PR_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --json files \
+            --jq '.files[].path' \
+            > "${RUNNER_TEMP}/changed-files.txt"
+
       - name: Validate PR title prose style
         env:
           # Read the title via env var instead of inlining
@@ -95,7 +117,9 @@ jobs:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
-          python3 scripts/validate-pr-title.py "${TITLE:-}"
+          python3 scripts/validate-pr-title.py \
+            --changed-files-from "${RUNNER_TEMP}/changed-files.txt" \
+            "${TITLE:-}"
 
   pr-body-commit-msg:
     name: PR body (==COMMIT_MSG== block)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,33 +307,59 @@ stay browsable. Adding a new scope is a CONTRIBUTING edit, not an
 ad-hoc invention in a PR — if none of the scopes below fit, raise a
 PR to add one. The Python lint surface mirrors these lists in
 [`scripts/lint/commit_taxonomy.py`](scripts/lint/commit_taxonomy.py):
-`PACKAGE_SCOPES` is discovered at import time from `packages/*/`, and
-`AREA_SCOPES` currently mirrors a conservative subset of the area
-scopes documented below (the scopes already pinned by existing tests
-and tooling). #402 (the two-tier internal-only scope rule) will
-refine the constant against the full prose set; until it lands,
-expect the constant to be narrower than this section's enumeration.
+`PACKAGE_SCOPES` is discovered at import time from `packages/*/`,
+and `AREA_SCOPES` is the fixed cross-cutting-concern list documented
+below. The two surfaces are kept in lockstep by the
+`pr-title-types-self-test` job and by code review against this
+section.
 
-- **Subsystem scopes** — the module or surface the commit touches.
-  `agent-auth`, `things-bridge`, `things-cli`,
-  `things-client-cli-applescript`, `server`, `audit`, `store`,
-  `keys`, `scopes`, `rate-limit`, `tls`, `notifier`, `metrics`, `api`,
-  `benchmark`, `observability`.
-- **Area scopes** — cross-cutting concerns.
-  `release` (release automation, CHANGELOG, versioning), `ci` (CI
-  workflow / composite action changes), `deps` (runtime dep bumps),
+The validator at
+[`scripts/validate-pr-title.py`](scripts/validate-pr-title.py)
+applies a **two-tier rule** (#402) when the PR's changed-files list
+is available:
+
+1. **Package tier.** If every changed file lives under a single
+   `packages/<name>/` directory, the scope MUST be `(<name>)` —
+   `feature(server):` on a PR contained to `packages/agent-auth/`
+   is rejected with a remediation hint pointing at `(agent-auth)`.
+   Mechanically derived from the diff, so adding a new package and
+   using its name as the scope works on day one.
+2. **Area tier.** Otherwise (the diff spans multiple packages, or
+   touches files outside `packages/`), the scope MUST be in
+   `AREA_SCOPES`. Historical drift like `(merge-bot)`, `(pr-lint)`,
+   `(release-pr)`, `(release-publish)`, `(build_release)` is
+   rejected; the validator suggests `(ci)` for workflow-tweak
+   scopes and `(release)` for release-tooling scopes.
+3. **Bare scope** (no `(scope)`) is always accepted — reserved for
+   genuinely cross-cutting changes (a sweeping rename, a repo-wide
+   lint pass). Multi-package PRs that don't fit a single area name
+   should go bare too: it is the conservative answer per #402's
+   "define behaviour explicitly" rule.
+
+- **Package scopes** (the package-tier branch of the rule) — the
+  workspace package the commit is contained to. Auto-discovered
+  from `packages/*/` so adding a new package never drifts from the
+  lint: `agent-auth`, `agent-auth-common`, `gpg-bridge`, `gpg-cli`,
+  `things-bridge`, `things-cli`, `things-client-cli-applescript`.
+- **Area scopes** (the area-tier branch of the rule) — cross-cutting
+  concerns. The fixed set is `release` (release automation,
+  CHANGELOG, versioning), `ci` (CI workflow / composite action
+  changes — covers what historical drift called `(merge-bot)`,
+  `(pr-lint)`, `(dco)`, etc.), `deps` (runtime dep bumps),
   `deps-dev` (dev dep bumps), `docs` (README, CONTRIBUTING,
   CLAUDE.md, SECURITY.md, SUPPORT.md), `design` (`design/**`, ADRs),
-  `security` (SECURITY.md content, security controls, scorecard, dco,
-  supply-chain), `typecheck` (mypy / pyright), `verify-standards`
-  (`scripts/verify-standards.sh`), `python` (ruff, pytest, project
-  Python config), `setup-toolchain` (`.github/actions/setup-toolchain`),
-  `docker` (Dockerfiles, compose, image pipeline), `vscode`
-  (`.vscode/`), `claude` (CLAUDE.md / `.claude/instructions/`).
+  `security` (SECURITY.md content, security controls, scorecard,
+  dco, supply-chain), `claude` (CLAUDE.md / `.claude/instructions/`).
+  Other internal-only names that the type-x-scope matrix references
+  (`typecheck`, `verify-standards`, `python`, `setup-toolchain`,
+  `vscode`) are not first-class area scopes for the two-tier rule —
+  fold those changes under the closest area name (typically `(ci)`
+  for tooling wired into the workflow, or `(deps-dev)` for the
+  underlying dependency bump).
 
 Bare (no-scope) commits are reserved for changes that genuinely
-don't fit a single scope — a sweeping rename, a repo-wide lint pass.
-Prefer a scope when one applies.
+don't fit a single scope — a sweeping rename, a repo-wide lint pass,
+or a multi-package PR. Prefer a scope when one applies.
 
 #### Type × scope matrix
 
@@ -347,13 +373,24 @@ workflow tweak would surface in `CHANGELOG.md` as a feature and bump
 the minor version — internal plumbing isn't user-visible and
 shouldn't move the public version.
 
-| Scope class                                                                                                                                    | Allowed types                                                                 |
-| ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| **Subsystem scopes** (the package / module surface list above)                                                                                 | `feature`, `improvement`, `fix`, `chore`, `deprecation`, `migration`, `break` |
-| `release`                                                                                                                                      | `feature`, `improvement`, `fix`, `chore`                                      |
-| `deps` (runtime dep bumps — a CVE patch on a reachable dep is release-worthy)                                                                  | `feature`, `improvement`, `fix`, `chore`                                      |
-| `security` (security controls, supply-chain — fixes are release-worthy)                                                                        | `feature`, `improvement`, `fix`, `chore`                                      |
-| **Internal-only scopes:** `ci`, `deps-dev`, `typecheck`, `verify-standards`, `python`, `setup-toolchain`, `vscode`, `claude`, `design`, `docs` | `chore`, `fix` only                                                           |
+| Scope class                                                                     | Allowed types                                                                 |
+| ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| **Package scopes** (the package list above; auto-discovered from `packages/*/`) | `feature`, `improvement`, `fix`, `chore`, `deprecation`, `migration`, `break` |
+| `release`                                                                       | `feature`, `improvement`, `fix`, `chore`                                      |
+| `deps` (runtime dep bumps — a CVE patch on a reachable dep is release-worthy)   | `feature`, `improvement`, `fix`, `chore`                                      |
+| `security` (security controls, supply-chain — fixes are release-worthy)         | `feature`, `improvement`, `fix`, `chore`                                      |
+| **Internal-only scopes:** `ci`, `deps-dev`, `claude`, `design`, `docs`          | `chore`, `fix` only                                                           |
+
+`commit_taxonomy.INTERNAL_ONLY_SCOPES` carries a few extra names
+(`typecheck`, `verify-standards`, `python`, `setup-toolchain`,
+`vscode`) inherited from #401 for the matrix check. After #402,
+those names are no longer first-class area scopes — the two-tier
+rule above rejects them. Pick `(ci)` for tooling wired into the
+workflow, `(deps-dev)` for the underlying dev-dep bump, or drop the
+scope. The matrix entry for those names is preserved as a
+belt-and-braces guard so a contributor who tries them gets the
+matrix error first; the eventual cleanup is tracked in the same
+issue thread.
 
 A failing PR title produces:
 

--- a/scripts/validate-pr-title.py
+++ b/scripts/validate-pr-title.py
@@ -33,6 +33,15 @@
 #      `commit_taxonomy.INTERNAL_ONLY_SCOPES` (e.g. `feature(ci):`,
 #      `improvement(deps-dev):`). Internal plumbing changes must not
 #      surface in CHANGELOG.md or bump the public version. See #401.
+#   5. Two-tier scope allowlist: when the PR's changed-files list is
+#      available, every `(scope)` must be either the *package* the
+#      PR is contained to (single `packages/<name>/` directory in the
+#      diff -> scope MUST equal `<name>`), or one of the fixed
+#      `commit_taxonomy.AREA_SCOPES` for cross-cutting changes (CI,
+#      release, deps, docs, etc.). This rejects long-tail invented
+#      scopes like `(merge-bot)`, `(pr-lint)`, `(release-pr)`,
+#      `(release-publish)`, `(build_release)` that drift past the
+#      CONTRIBUTING.md allowlist. See #402.
 #
 # The validator runs in the `pr-title-style` job of
 # `.github/workflows/pr-lint.yml`; the title is read via the env var
@@ -72,6 +81,8 @@ if _taxonomy is None:
     sys.modules["commit_taxonomy"] = _taxonomy
     _spec.loader.exec_module(_taxonomy)
 INTERNAL_ONLY_SCOPES: frozenset[str] = _taxonomy.INTERNAL_ONLY_SCOPES
+PACKAGE_SCOPES: tuple[str, ...] = _taxonomy.PACKAGE_SCOPES
+AREA_SCOPES: tuple[str, ...] = _taxonomy.AREA_SCOPES
 
 MAX_TITLE_WIDTH = 72
 
@@ -218,7 +229,139 @@ def check_type_scope_matrix(title: str) -> None:
     )
 
 
-def validate(title: str) -> None:
+def _single_package_for(changed_files: list[str]) -> str | None:
+    """Return the package name if every changed file lives in one
+    ``packages/<name>/`` directory, else ``None``.
+
+    Path normalisation: ``gh pr view --json files --jq '.files[].path'``
+    yields forward-slash POSIX paths regardless of runner OS, so we
+    split on ``/`` rather than ``os.sep``. Empty / whitespace-only
+    lines (the ``mktemp`` rounding error from a no-op PR) are skipped
+    so a stray newline in the input file doesn't collapse the check.
+
+    The function returns ``None`` if any file lives outside
+    ``packages/`` (a workflow tweak, a docs change, a root-level
+    config edit) — those PRs fall through to the area-tier rule.
+    Returns ``None`` if the diff spans multiple packages too: a
+    multi-package PR can't claim a package-tier scope, and
+    CONTRIBUTING.md's bare-scope-for-cross-cutting rule applies.
+    Returns ``None`` if the discovered package isn't in
+    ``PACKAGE_SCOPES`` — defensive against a stale workspace
+    snapshot, though in practice ``PACKAGE_SCOPES`` is auto-derived
+    from the same ``packages/*/`` listing.
+    """
+    package: str | None = None
+    for raw in changed_files:
+        path = raw.strip()
+        if not path:
+            continue
+        parts = path.split("/")
+        if len(parts) < 2 or parts[0] != "packages":
+            return None
+        candidate = parts[1]
+        if package is None:
+            package = candidate
+        elif package != candidate:
+            return None
+    if package is None:
+        return None
+    if package not in PACKAGE_SCOPES:
+        return None
+    return package
+
+
+def _area_scope_suggestion(scope: str) -> str | None:
+    """Return the area-tier scope the offending one most likely meant.
+
+    The mapping covers the historical scope drift named in #402:
+    ``(merge-bot)`` / ``(pr-lint)`` / ``(dco)`` and friends are
+    GitHub Actions tweaks (``ci``); ``(release-pr)`` /
+    ``(release-publish)`` / ``(build_release)`` belong under
+    ``release``. Returns ``None`` when no obvious mapping exists —
+    the caller falls back to a generic remediation hint.
+    """
+    if scope in {"merge-bot", "pr-lint", "dco", "changelog-bot", "scorecard"}:
+        return "ci"
+    if scope in {"release-pr", "release-publish", "build_release", "build-release"}:
+        return "release"
+    return None
+
+
+def check_two_tier_scope(title: str, changed_files: list[str] | None) -> None:
+    """Reject scopes outside the package-tier / area-tier allowlist.
+
+    The rule, per #402:
+
+    1. **Package tier.** If every changed file lives under a single
+       ``packages/<name>/`` directory, the scope MUST be ``<name>``.
+       A PR contained to one package can't claim a different
+       package's scope or invent an area name.
+    2. **Area tier.** Otherwise, the scope MUST be in
+       ``AREA_SCOPES`` (``release``, ``ci``, ``deps``, ``deps-dev``,
+       ``docs``, ``design``, ``security``, ``claude``).
+    3. **Bare scope.** Always accepted — reserved for cross-cutting
+       changes per CONTRIBUTING.md.
+
+    The check is silent when:
+
+    - the title has no parseable ``type(scope):`` shape (the upstream
+      ``amannn/action-semantic-pull-request`` step owns prefix-shape
+      enforcement);
+    - ``changed_files`` is ``None`` (the validator was invoked locally
+      without a PR's diff context — see CLI ``--changed-files-from``);
+    - ``changed_files`` is an empty list (no files changed: nothing
+      to anchor the package-tier check against, and area-tier would
+      misfire on what is presumably a metadata-only edit).
+
+    Multi-package PRs (the diff spans ``packages/X/`` AND
+    ``packages/Y/``) fall through to the area-tier branch — and
+    therefore must use a scope from ``AREA_SCOPES`` or go bare.
+    Bare scope is the conservative answer per the issue body's
+    "define behaviour explicitly" prompt: it matches CONTRIBUTING.md's
+    existing "Bare scope is reserved for cross-cutting changes"
+    convention without forcing a contributor to invent an area name.
+    """
+    if changed_files is None:
+        return
+    if not any(line.strip() for line in changed_files):
+        return
+    match = PREFIX_RE.match(title)
+    if match is None:
+        return
+    scope = match.group("scope")
+    if scope is None:
+        # Bare scope: cross-cutting changes are always permitted.
+        return
+    package = _single_package_for(changed_files)
+    if package is not None:
+        # Package-tier: scope MUST match the contained package.
+        if scope == package:
+            return
+        raise TitleValidationError(
+            f"scope `({scope})` is not in the allowlist. The change "
+            f"is contained to `packages/{package}/`, so the scope "
+            f"MUST be `({package})`. See CONTRIBUTING.md → "
+            '"Allowed scopes".'
+        )
+    # Area-tier: scope MUST be one of the fixed area names.
+    if scope in AREA_SCOPES:
+        return
+    suggestion = _area_scope_suggestion(scope)
+    if suggestion is not None:
+        hint = f"use `({suggestion})` instead, or drop the scope for a cross-cutting change"
+    else:
+        hint = (
+            "pick a scope from `AREA_SCOPES` "
+            "(release, ci, deps, deps-dev, docs, design, security, "
+            "claude) or drop the scope for a cross-cutting change"
+        )
+    raise TitleValidationError(
+        f"scope `({scope})` is not in the allowlist; "
+        f'{hint}. See CONTRIBUTING.md → "Allowed scopes".'
+    )
+
+
+def validate(title: str, changed_files: list[str] | None = None) -> None:
     if not title.strip():
         raise TitleValidationError(
             "subject is empty — author a PR title with the "
@@ -228,18 +371,26 @@ def validate(title: str) -> None:
     check_no_trailing_period(title)
     check_imperative_mood(title)
     check_type_scope_matrix(title)
+    check_two_tier_scope(title, changed_files)
 
 
 # Inline self-test cases. The PR-title input is a single string from
 # `${{ github.event.pull_request.title }}`, so file-based fixtures
 # (the body validator's pattern) buy nothing here. Each tuple is
-# (title, expect_pass, label) — `label` shows up in the self-test
-# log so a regression points at the failing case immediately.
-_SELF_TEST_CASES: tuple[tuple[str, bool, str], ...] = (
+# (title, changed_files, expect_pass, label):
+#
+# - ``changed_files`` is ``None`` when the case doesn't exercise the
+#   two-tier scope rule (rule 5). Pre-#402 cases keep ``None`` and
+#   stay focused on the rules they were written for; the #402 cases
+#   each provide a representative diff.
+# - ``label`` shows up in the self-test log so a regression points at
+#   the failing case immediately.
+_SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
     # Passing cases: representative titles drawn from recent merged
     # PRs and the worked examples in CONTRIBUTING.md.
     (
         "chore(ci): enforce subject-style rules in pr-lint validator",
+        None,
         True,
         "passing-chore",
     ),
@@ -247,16 +398,19 @@ _SELF_TEST_CASES: tuple[tuple[str, bool, str], ...] = (
         # Package scope — release-bumping types are fine here; only
         # the internal-only scopes are restricted.
         "feature(agent-auth): add JIT approval flow for prompt-tier scope",
+        None,
         True,
         "passing-feature-package-scope",
     ),
     (
         "fix(tokens): use constant-time HMAC comparison",
+        None,
         True,
         "passing-fix",
     ),
     (
         "improvement: tighten numbered-list regex",
+        None,
         True,
         "passing-no-scope",
     ),
@@ -264,6 +418,7 @@ _SELF_TEST_CASES: tuple[tuple[str, bool, str], ...] = (
         # `release` is its own row in the matrix — release automation
         # changes can be user-visible and bump the version.
         "feature(release): wire workflow-dispatch tag re-runs",
+        None,
         True,
         "passing-feature-release-scope",
     ),
@@ -271,33 +426,39 @@ _SELF_TEST_CASES: tuple[tuple[str, bool, str], ...] = (
         # `fix` is allowed on internal-only scopes — this is the
         # escape hatch for a real bug in CI / dev-dep / docs surface.
         "fix(claude): correct outdated worktree path in plan template",
+        None,
         True,
         "passing-fix-internal-scope",
     ),
     # Failing cases: one per rule.
     (
         "fix: drop the trailing period.",
+        None,
         False,
         "failing-trailing-period",
     ),
     (
         "improvement: Fixed gpg-bridge timeout",
+        None,
         False,
         "failing-past-tense-fixed",
     ),
     (
         "feature: Added a thing",
+        None,
         False,
         "failing-past-tense-added",
     ),
     (
         # 84 chars — the example from the issue body.
         "fix(very-long-scope): a summary that runs on and on past the seventy two char cap easy",
+        None,
         False,
         "failing-too-long",
     ),
     (
         "",
+        None,
         False,
         "failing-empty",
     ),
@@ -312,37 +473,102 @@ _SELF_TEST_CASES: tuple[tuple[str, bool, str], ...] = (
     # churn rather than coverage.
     (
         "feature(ci): add release-build dry-run and post-publish smoke",
+        None,
         False,
         "failing-matrix-feature-ci",
     ),
     (
         "improvement(deps-dev): tighten pytest config",
+        None,
         False,
         "failing-matrix-improvement-deps-dev",
     ),
     (
         "break(claude): rewrite plan-template to call EnterWorktree",
+        None,
         False,
         "failing-matrix-break-claude",
     ),
     (
         "deprecation(docs): retire the legacy onboarding guide",
+        None,
         False,
         "failing-matrix-deprecation-docs",
     ),
     (
         "migration(python): bump minimum interpreter to 3.12",
+        None,
         False,
         "failing-matrix-migration-python",
+    ),
+    # Two-tier scope rule (#402). The package-tier branch fires when
+    # every changed file lives under a single ``packages/<name>/``
+    # directory; the area-tier branch is the fallback for everything
+    # else; bare scope is always accepted (cross-cutting).
+    (
+        # Package-tier accept: scope matches the contained package.
+        "feature(agent-auth): add JIT approval flow for prompt-tier scope",
+        ["packages/agent-auth/src/agent_auth/cli.py"],
+        True,
+        "passing-pkg-tier-agent-auth",
+    ),
+    (
+        # Package-tier reject: PR is contained to packages/agent-auth/
+        # but claims a fictional `(server)` scope.
+        "feature(server): rename the listener entrypoint",
+        ["packages/agent-auth/src/agent_auth/server.py"],
+        False,
+        "failing-pkg-tier-server-on-agent-auth",
+    ),
+    (
+        # Area-tier accept: workflow tweak under (ci).
+        "chore(ci): pin merge-bot action to a SHA",
+        [".github/workflows/merge-bot.yml"],
+        True,
+        "passing-area-tier-ci",
+    ),
+    (
+        # Area-tier reject: `(merge-bot)` is the historical drift the
+        # issue body calls out — the validator must point at `(ci)`.
+        "improvement(merge-bot): post link to merged PR in slack",
+        [".github/workflows/merge-bot.yml"],
+        False,
+        "failing-area-tier-merge-bot",
+    ),
+    (
+        # Area-tier reject: `(release-pr)` is another historical drift
+        # — the validator points at `(release)`.
+        "fix(release-pr): drop stale changelog YAMLs after publish",
+        [".github/workflows/release-pr.yml"],
+        False,
+        "failing-area-tier-release-pr",
+    ),
+    (
+        # Multi-package fallback: PR spans two packages -> falls
+        # through to area-tier; bare scope is accepted.
+        "chore: bump shared HTTP client default timeout",
+        [
+            "packages/agent-auth/src/agent_auth/http.py",
+            "packages/gpg-bridge/src/gpg_bridge/http.py",
+        ],
+        True,
+        "passing-multi-package-bare-scope",
+    ),
+    (
+        # Cross-cutting changes (root config, docs) accept bare scope.
+        "chore: standardise YAML extension on .yml",
+        ["Taskfile.yml", "CHANGELOG.md"],
+        True,
+        "passing-cross-cutting-bare-scope",
     ),
 )
 
 
 def _run_self_test() -> int:
     fail = 0
-    for title, expect_pass, label in _SELF_TEST_CASES:
+    for title, changed_files, expect_pass, label in _SELF_TEST_CASES:
         try:
-            validate(title)
+            validate(title, changed_files)
         except TitleValidationError as err:
             if expect_pass:
                 print(f"FAIL: {label}: expected pass, got {err}", file=sys.stderr)
@@ -360,6 +586,20 @@ def _run_self_test() -> int:
         return 1
     print(f"all {len(_SELF_TEST_CASES)} self-test cases passed")
     return 0
+
+
+def _read_changed_files(path: str) -> list[str]:
+    """Read a newline-separated path list, dropping blank lines.
+
+    Used by the ``--changed-files-from`` flag so the
+    ``pr-title-style`` job in ``pr-lint.yml`` can pipe a
+    ``gh pr view --json files --jq`` listing in without inlining the
+    paths into the run-block (and dragging shell expansion into the
+    file-name path). The reader tolerates trailing newlines and
+    BOM-prefixed UTF-8 since both happen on GitHub Actions runners.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    return text.splitlines()
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -385,13 +625,30 @@ def main(argv: list[str] | None = None) -> int:
             "regression in the validator surfaces immediately."
         ),
     )
+    parser.add_argument(
+        "--changed-files-from",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to a newline-separated list of files changed in the PR. "
+            "When provided, the two-tier scope rule (#402) runs against the "
+            "diff: a PR contained to a single `packages/<name>/` directory "
+            "must use `(<name>)` as the scope; otherwise the scope must be "
+            "in `commit_taxonomy.AREA_SCOPES` or be omitted. The "
+            "`pr-title-style` job in pr-lint.yml writes the list via "
+            "`gh pr view --json files --jq '.files[].path'`."
+        ),
+    )
     args = parser.parse_args(argv)
     if args.self_test:
         return _run_self_test()
     if args.title is None:
         parser.error("title is required unless --self-test is given")
+    changed_files: list[str] | None = None
+    if args.changed_files_from is not None:
+        changed_files = _read_changed_files(args.changed_files_from)
     try:
-        validate(args.title)
+        validate(args.title, changed_files)
     except TitleValidationError as err:
         print(f"pr-title: {err}", file=sys.stderr)
         return 1

--- a/scripts/validate-pr-title.py
+++ b/scripts/validate-pr-title.py
@@ -230,14 +230,13 @@ def check_type_scope_matrix(title: str) -> None:
 
 
 def _single_package_for(changed_files: list[str]) -> str | None:
-    """Return the package name if every changed file lives in one
-    ``packages/<name>/`` directory, else ``None``.
+    """Return the contained ``packages/<name>/`` directory, else ``None``.
 
     Path normalisation: ``gh pr view --json files --jq '.files[].path'``
     yields forward-slash POSIX paths regardless of runner OS, so we
     split on ``/`` rather than ``os.sep``. Empty / whitespace-only
-    lines (the ``mktemp`` rounding error from a no-op PR) are skipped
-    so a stray newline in the input file doesn't collapse the check.
+    lines are skipped so a trailing newline in the file written by
+    ``gh pr view`` does not collapse the check.
 
     The function returns ``None`` if any file lives outside
     ``packages/`` (a workflow tweak, a docs change, a root-level
@@ -245,10 +244,14 @@ def _single_package_for(changed_files: list[str]) -> str | None:
     Returns ``None`` if the diff spans multiple packages too: a
     multi-package PR can't claim a package-tier scope, and
     CONTRIBUTING.md's bare-scope-for-cross-cutting rule applies.
-    Returns ``None`` if the discovered package isn't in
-    ``PACKAGE_SCOPES`` — defensive against a stale workspace
-    snapshot, though in practice ``PACKAGE_SCOPES`` is auto-derived
-    from the same ``packages/*/`` listing.
+
+    The returned name is *not* filtered against ``PACKAGE_SCOPES``:
+    the caller distinguishes "registered package" (apply the
+    package-tier rule) from "unregistered ``packages/<name>/``
+    directory" (typo'd path or a brand-new package added in the same
+    PR before ``PACKAGE_SCOPES`` is reseeded) so the diagnostic can
+    name the actual problem instead of falling through to the
+    area-tier "pick from AREA_SCOPES" hint.
     """
     package: str | None = None
     for raw in changed_files:
@@ -263,10 +266,6 @@ def _single_package_for(changed_files: list[str]) -> str | None:
             package = candidate
         elif package != candidate:
             return None
-    if package is None:
-        return None
-    if package not in PACKAGE_SCOPES:
-        return None
     return package
 
 
@@ -277,13 +276,22 @@ def _area_scope_suggestion(scope: str) -> str | None:
     ``(merge-bot)`` / ``(pr-lint)`` / ``(dco)`` and friends are
     GitHub Actions tweaks (``ci``); ``(release-pr)`` /
     ``(release-publish)`` / ``(build_release)`` belong under
-    ``release``. Returns ``None`` when no obvious mapping exists —
-    the caller falls back to a generic remediation hint.
+    ``release``. The internal-only names that the type x scope
+    matrix still recognises but the two-tier rule no longer treats
+    as area scopes (``typecheck``, ``verify-standards``, ``python``,
+    ``setup-toolchain``, ``vscode``) all map to ``ci`` — they name
+    tooling / config surfaces wired into CI, so the closest
+    first-class area is ``ci`` (a contributor adjusting a dev-dep
+    pin underneath one of those names should pick ``deps-dev`` by
+    hand). Returns ``None`` when no obvious mapping exists — the
+    caller falls back to a generic remediation hint.
     """
     if scope in {"merge-bot", "pr-lint", "dco", "changelog-bot", "scorecard"}:
         return "ci"
     if scope in {"release-pr", "release-publish", "build_release", "build-release"}:
         return "release"
+    if scope in {"typecheck", "verify-standards", "python", "setup-toolchain", "vscode"}:
+        return "ci"
     return None
 
 
@@ -334,6 +342,21 @@ def check_two_tier_scope(title: str, changed_files: list[str] | None) -> None:
         return
     package = _single_package_for(changed_files)
     if package is not None:
+        if package not in PACKAGE_SCOPES:
+            # Single ``packages/<name>/`` directory found but not
+            # registered: a typo in the path, or a new package added
+            # in the same PR before ``PACKAGE_SCOPES`` is reseeded.
+            # Surface the actual problem instead of falling through
+            # to the area-tier "pick from AREA_SCOPES" hint, which is
+            # wrong here.
+            raise TitleValidationError(
+                f"changed files live under `packages/{package}/`, but "
+                f"`{package}` is not registered in `PACKAGE_SCOPES` "
+                f"({', '.join(PACKAGE_SCOPES)}). Either fix the "
+                f"directory name or add the package to the workspace "
+                'so `PACKAGE_SCOPES` picks it up. See CONTRIBUTING.md '
+                '→ "Allowed scopes".'
+            )
         # Package-tier: scope MUST match the contained package.
         if scope == package:
             return
@@ -403,8 +426,15 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
         "passing-feature-package-scope",
     ),
     (
-        "fix(tokens): use constant-time HMAC comparison",
-        None,
+        # Package-tier accept on `fix:` — exercises the `fix` prefix
+        # alongside a realistic `packages/<name>/` diff. The original
+        # fixture used `fix(tokens):` with no diff context, which the
+        # two-tier rule would reject in real CI (``tokens`` is neither
+        # a package nor in ``AREA_SCOPES``); pairing the title with a
+        # representative ``packages/agent-auth/`` path keeps the
+        # passing case honest.
+        "fix(agent-auth): use constant-time HMAC comparison",
+        ["packages/agent-auth/src/agent_auth/tokens.py"],
         True,
         "passing-fix",
     ),
@@ -555,11 +585,39 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
         "passing-multi-package-bare-scope",
     ),
     (
+        # Multi-package reject: a PR touching two packages cannot
+        # claim either package's name as its scope — once the diff
+        # spans both, the package-tier rule no longer applies and
+        # the scope must come from ``AREA_SCOPES`` (or be dropped).
+        # Symmetric with ``passing-multi-package-bare-scope``: that
+        # fixture proves bare scope is accepted, this one proves a
+        # package-named scope is not.
+        "feature(agent-auth): wire shared HTTP client retry policy",
+        [
+            "packages/agent-auth/src/agent_auth/http.py",
+            "packages/gpg-bridge/src/gpg_bridge/http.py",
+        ],
+        False,
+        "failing-multi-package-pkg-scope",
+    ),
+    (
         # Cross-cutting changes (root config, docs) accept bare scope.
         "chore: standardise YAML extension on .yml",
         ["Taskfile.yml", "CHANGELOG.md"],
         True,
         "passing-cross-cutting-bare-scope",
+    ),
+    (
+        # Unregistered ``packages/<name>/`` directory: the diff is
+        # contained to one package directory but the name is not in
+        # ``PACKAGE_SCOPES`` (a typo'd path, or a brand-new package
+        # added in the same PR before discovery is reseeded). The
+        # validator names the actual problem instead of falling
+        # through to the area-tier "pick from AREA_SCOPES" hint.
+        "feature(novel): scaffold a new package",
+        ["packages/novel/src/novel/__init__.py"],
+        False,
+        "failing-unregistered-package-dir",
     ),
 )
 


### PR DESCRIPTION
==COMMIT_MSG==
Recent main-branch commits drifted past the CONTRIBUTING.md scope
allowlist (`improvement(merge-bot):`, `improvement(pr-lint):`,
`fix(build_release):`, `fix(release-pr):`). The pr-lint type-check
ignores the scope contents, so invented names sail through.

Add a two-tier rule in scripts/validate-pr-title.py:

1. Package tier — when every changed file lives under one
   packages/<name>/, the scope MUST equal <name>.
2. Area tier — otherwise, the scope MUST be in
   commit_taxonomy.AREA_SCOPES (release, ci, deps, deps-dev, docs,
   design, security, claude).
3. Bare scope — always accepted; reserved for cross-cutting
   changes per CONTRIBUTING.md.

Multi-package PRs fall through to area-tier (and therefore can use
bare scope or pick a representative area name) — the conservative
answer per the issue's "define behaviour explicitly" prompt.

The validator gains a `--changed-files-from <path>` flag; the
pr-title-style job in pr-lint.yml fetches the PR's changed-files
list via `gh pr view --json files` and pipes it in. Co-locating the
new step with the existing prose-style validator (rather than
adding a new job) keeps related checks in one place. The trigger
surface stays on `pull_request_target` — `gh` reads PR metadata via
the default GITHUB_TOKEN's `pull-requests: read` permission, no
additional checkout needed.

Error messages quote the offending scope and point at the suggested
replacement: `(merge-bot)` -> `(ci)`, `(release-pr)` -> `(release)`,
`(server)` on a packages/agent-auth/ PR -> `(agent-auth)`. Each
ends with the CONTRIBUTING.md cross-reference so a contributor
landing on the error has a recoverable path.

CONTRIBUTING.md "Allowed scopes" documents the two-tier rule next
to the existing "Type x scope matrix" subsection. The matrix table
prunes `typecheck`, `verify-standards`, `python`, `setup-toolchain`,
`vscode` from its prose enumeration since the two-tier rule now
rejects them outright; commit_taxonomy.INTERNAL_ONLY_SCOPES retains
those names as a belt-and-braces matrix guard. Eight new self-test
fixtures cover the new branches: package-tier accept/reject,
area-tier accept/reject (with both `(merge-bot)` and `(release-pr)`
suggestions), multi-package fallback, and root-level cross-cutting.

Closes #402

Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

Implementation choices resolved in-flight (per the orchestrator's
"resolve internal decisions yourself" rule):

- **Workflow shape**: option (a) from the brief — extend the
  existing `pr-title-style` job with a "List changed files" step
  rather than spinning up a new job. Keeps related checks
  colocated and avoids a fresh `actions/checkout` round-trip; the
  `gh pr view --json files` path doesn't need a checkout at all.
- **Multi-package fallback**: bare scope (matches CONTRIBUTING.md's
  existing "Bare scope is reserved for cross-cutting changes"
  convention without forcing a contributor to invent an area name).
- **CLI shape**: a new `--changed-files-from <path>` flag on the
  validator. The list is read from disk so paths with shell
  metacharacters survive cleanly. When the flag is omitted (e.g.
  the validator's `--self-test` mode or a local invocation), the
  two-tier check is silently skipped — keeps the validator usable
  outside CI without lying about acceptance.
- **Error-message wording**: matches the issue body's worked
  example. The remediation hint includes a suggested replacement
  for the historical drift cases (`merge-bot` / `pr-lint` / `dco` /
  `changelog-bot` / `scorecard` -> `ci`; `release-pr` /
  `release-publish` / `build_release` / `build-release` ->
  `release`); other unknown scopes get a generic "pick from
  AREA_SCOPES" hint.

### Test plan

- [ ] `python3 scripts/validate-pr-title.py --self-test` — 23 cases
      pass locally (pre-existing 15 + 8 new).
- [ ] `task lint` — clean.
- [ ] `task format -- --check` — clean.
- [ ] `task typecheck` — clean.
- [ ] `task changelog:test` — 212 passes.
- [ ] `bash scripts/verify-standards.sh` — clean.
- [ ] CI: `pr-title-self-test` job re-runs the inline cases inside
      the workflow.
- [ ] CI: `pr-title-style` job runs against this PR's actual
      `chore(ci):` title and the multi-area diff (validator,
      workflow, contributing) — area-tier accept path.
- [ ] CI: `pr-title-types-self-test` (taxonomy in-sync check)
      remains green — no `ALLOWED_TYPES` change in this PR.