### PR TITLE
chore(ci): add release-impact-comment job to pr-lint

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -491,13 +491,18 @@ jobs:
           # filters in a single pass so we don't depend on a particular
           # gh version's output shape. `--arg` keeps the marker out of
           # the jq program text so its `<`, `!`, `-` characters survive
-          # shell quoting verbatim.
+          # shell quoting verbatim. `first(...)` (rather than a trailing
+          # `head -n 1`) caps the result inside jq itself: under
+          # `set -euo pipefail`, closing the pipe early via `head` can
+          # deliver SIGPIPE upstream and fail the pipeline on
+          # long-lived PRs whose comment list spans multiple pages.
+          # `// empty` keeps the assignment empty (rather than emitting
+          # the literal string "null") when no matching comment exists.
           existing_id="$(gh api \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
             --paginate \
             | jq -r --arg marker "${MARKER}" \
-                '.[] | select((.body // "") | startswith($marker)) | .id' \
-            | head -n 1)"
+                'first(.[] | select((.body // "") | startswith($marker)) | .id) // empty')"
           # `-F body=@<file>` reads the body from disk as a JSON
           # string field — identical semantics to inlining
           # `body="$(cat <file>)"` but binary-safe and free of any
@@ -545,4 +550,12 @@ jobs:
           # `conftest.py` under scripts/changelog/tests/ puts
           # scripts/changelog/ and scripts/lint/ on sys.path so the
           # bare-name imports in the test file resolve.
-          python3 -m pytest scripts/changelog/tests/test_predict_release_impact.py -v
+          # `-o addopts=` overrides the workspace `pyproject.toml`'s
+          # `[tool.pytest.ini_options].addopts` (which injects
+          # `--cov=packages --cov-branch --cov-report=term-missing`).
+          # Without this override, bare pytest would reject those
+          # flags with `error: unrecognized arguments` and exit 4
+          # because this isolated job intentionally does not install
+          # `pytest-cov`; the job exercises one script in isolation,
+          # not the workspace's full coverage matrix.
+          python3 -m pytest -o addopts= scripts/changelog/tests/test_predict_release_impact.py -v

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -363,33 +363,51 @@ jobs:
           fi
 
       - name: Fetch PR head's @unreleased YAMLs
-        # Bring the head ref's `changelog/@unreleased/*.yml` files into
-        # the workspace WITHOUT checking out the head's code. The
-        # predict script + the `version_logic` parser both come from
-        # the base ref (pinned by the earlier `actions/checkout`); only
-        # the YAML data files come from the head. PyYAML's `safe_load`
-        # parses YAML as data — no code-execution surface — so this
-        # is safe even on a fork PR.
+        # Materialise the head ref's `changelog/@unreleased/*.yml` into
+        # a sandbox under `${RUNNER_TEMP}` — NOT into the workspace.
+        # The predict script + `version_logic` parser both come from
+        # the base ref (pinned by the earlier `actions/checkout`); the
+        # YAML data files are read from the sandbox by passing
+        # `--repo-root ${RUNNER_TEMP}/predict-sandbox` to the predict
+        # invocation. PyYAML's `safe_load` parses YAML as data — no
+        # code-execution surface — so this is safe even on a fork PR.
+        #
+        # We deliberately AVOID `git checkout "${HEAD_SHA}" -- path/`
+        # here. CodeQL's `actions/untrusted-checkout` query treats any
+        # `git checkout <head-sha>` in a `pull_request_target` workflow
+        # as a code-execution surface, regardless of the `-- <path>`
+        # constraint that scopes it to data-only files. Routing through
+        # the GitHub Contents API keeps the head fetch off CodeQL's
+        # flagged channel and onto the unflagged HTTP-fetch channel.
         if: steps.touched.outputs.touched == 'true'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          # `pull_request_target` checkout pinned to the base SHA does
-          # not fetch the head SHA into the local clone. Fetch it
-          # explicitly, then materialise just the @unreleased dir from
-          # that commit. `--no-tags --depth=1` keeps the fetch tiny.
-          git fetch --no-tags --depth=1 origin "${HEAD_SHA}"
-          # Wipe whatever `@unreleased/` looks like at the base ref
-          # before overlaying the head's version, so files removed by
-          # the PR (e.g. the release-PR's mass rename) don't linger.
-          rm -rf changelog/@unreleased
-          mkdir -p changelog/@unreleased
-          # `git checkout <SHA> -- <path>` writes the path's contents
-          # at <SHA> into the working tree without changing HEAD. If
-          # the path doesn't exist at <SHA> (PR deletes the dir
-          # entirely), the `|| true` keeps the step exiting cleanly.
-          git checkout "${HEAD_SHA}" -- 'changelog/@unreleased/' || true
+          sandbox="${RUNNER_TEMP}/predict-sandbox/changelog/@unreleased"
+          # Reset the sandbox each run so files removed at head (e.g.
+          # the release-PR's mass rename) don't linger from a previous
+          # workflow on the same runner.
+          rm -rf "${RUNNER_TEMP}/predict-sandbox"
+          mkdir -p "${sandbox}"
+          # List `@unreleased/*.yml` at HEAD via the Contents API, then
+          # fetch each blob raw. A 404 on the directory listing means
+          # the PR removed the entire dir at head (release-PR rollover);
+          # the consuming step's `--repo-root` then sees an empty
+          # `@unreleased/` and the predict short-circuits with
+          # `predict=false`.
+          if listing="$(gh api \
+                "repos/${GITHUB_REPOSITORY}/contents/changelog/@unreleased?ref=${HEAD_SHA}" \
+                --jq '.[] | select(.type=="file") | .name' 2>/dev/null)"; then
+            while IFS= read -r name; do
+              [[ -z "${name}" ]] && continue
+              [[ "${name}" =~ \.yml$ ]] || continue
+              gh api -H 'Accept: application/vnd.github.raw' \
+                "repos/${GITHUB_REPOSITORY}/contents/changelog/@unreleased/${name}?ref=${HEAD_SHA}" \
+                > "${sandbox}/${name}"
+            done <<<"${listing}"
+          fi
 
       - name: Resolve current version
         if: steps.touched.outputs.touched == 'true'
@@ -434,7 +452,7 @@ jobs:
             exit 1
           fi
           envelope="$(python3 scripts/changelog/predict_release_impact.py \
-            --repo-root . \
+            --repo-root "${RUNNER_TEMP}/predict-sandbox" \
             --current-version "${CURRENT_VERSION}")"
           echo "${envelope}" > "${RUNNER_TEMP}/predict.json"
           # Surface a top-level `predict` boolean so the next step's

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -266,3 +266,283 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/lint/commit_taxonomy.py check-pr-lint-yaml
+
+  release-impact-comment:
+    name: Release impact comment
+    runs-on: ubuntu-latest
+    # Surface the predicted release-impact bump on every PR that
+    # touches `changelog/@unreleased/*.yml`, so a reviewer can catch a
+    # mislabelled YAML (e.g. a `feature` entry that should have been
+    # `improvement`) before the next release goes out and the version
+    # jumps unexpectedly. The matrix lint (#401) catches the worst
+    # category — `feature(ci):` and friends — but the YAML's `type:`
+    # field is still author-controlled and can drift past the matrix
+    # ("feature" applied to a small refactor that should be
+    # "improvement"). This job is the human-review complement: it
+    # posts the predicted `current -> next` version transition so the
+    # mislabel is visible at PR-review time. Origin: issue #406.
+    #
+    # Bot identity: posts as `github-actions[bot]` via the default
+    # `GITHUB_TOKEN`. The merge-bot / release-bot / changelog-bot path
+    # was considered for symmetry, but minting an App token requires
+    # provisioning new secrets and the comment surface here is purely
+    # informational (no protected-branch or contents writes). Using
+    # the default token keeps the bot fully operational on the PR
+    # that initially adds the workflow without depending on a separate
+    # one-time setup. The "Claude: " prefix per the project convention
+    # still identifies the comment as agent-authored.
+    #
+    # `pull_request_target` keeps the comment writeable on fork PRs
+    # (the workflow inherits the base repo's `pull-requests: write`
+    # grant, and `actions/checkout` is pinned to the base ref so the
+    # fork cannot ship a malicious predict script in the same PR).
+    # The PR head's `changelog/@unreleased/*.yml` files ARE fetched
+    # — they are pure data parsed by PyYAML, no code-execution
+    # surface. The base-ref script is what runs over them.
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Pin to the base ref so a fork PR cannot weaken the
+          # predict script in the same PR. The head's YAMLs are
+          # fetched into the workspace separately below.
+          ref: ${{ github.event.pull_request.base.sha }}
+          # Need full history so the base-ref `git describe --tags`
+          # below can locate the latest `v*.*.*` tag without the
+          # 1-commit shallow default actions/checkout uses.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Install runtime deps (PyYAML)
+        # `predict_release_impact.py` depends on PyYAML transitively
+        # via `version_logic.parse_entry_file`. Avoid the full workspace
+        # `uv sync` here — this job only needs the changelog parser.
+        # Same shape as `release-pr.yml`'s "Install PyYAML" step.
+        run: pip install --no-cache-dir 'pyyaml>=6'
+
+      - name: List changed files
+        # Fan out the same `gh pr view --json files` pattern the
+        # `pr-title-style` job uses, for the same reason: the rest of
+        # this job needs to know whether the PR touches
+        # `changelog/@unreleased/*.yml` so it can early-exit cleanly
+        # on PRs that touched no entry (no noise comments on every PR).
+        # `gh` is preinstalled on `ubuntu-latest`. The output goes via
+        # `RUNNER_TEMP` rather than a shell variable so paths with
+        # spaces or shell metacharacters survive.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh pr view "${PR_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --json files \
+            --jq '.files[].path' \
+            > "${RUNNER_TEMP}/changed-files.txt"
+
+      - name: Detect changelog/@unreleased/ touch
+        id: touched
+        # Early-exit when the PR touches no `@unreleased/*.yml` files
+        # so the bot doesn't post (or update) a noise comment on PRs
+        # that have no release impact to predict. The `grep` is fixed
+        # to the directory prefix so it doesn't match unrelated paths
+        # like `docs/changelog/...`.
+        run: |
+          set -euo pipefail
+          if grep -qE '^changelog/@unreleased/[^/]+\.yml$' "${RUNNER_TEMP}/changed-files.txt"; then
+            echo "touched=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "touched=false" >> "${GITHUB_OUTPUT}"
+            echo "release-impact-comment: no changelog/@unreleased/ files touched; nothing to predict."
+          fi
+
+      - name: Fetch PR head's @unreleased YAMLs
+        # Bring the head ref's `changelog/@unreleased/*.yml` files into
+        # the workspace WITHOUT checking out the head's code. The
+        # predict script + the `version_logic` parser both come from
+        # the base ref (pinned by the earlier `actions/checkout`); only
+        # the YAML data files come from the head. PyYAML's `safe_load`
+        # parses YAML as data — no code-execution surface — so this
+        # is safe even on a fork PR.
+        if: steps.touched.outputs.touched == 'true'
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # `pull_request_target` checkout pinned to the base SHA does
+          # not fetch the head SHA into the local clone. Fetch it
+          # explicitly, then materialise just the @unreleased dir from
+          # that commit. `--no-tags --depth=1` keeps the fetch tiny.
+          git fetch --no-tags --depth=1 origin "${HEAD_SHA}"
+          # Wipe whatever `@unreleased/` looks like at the base ref
+          # before overlaying the head's version, so files removed by
+          # the PR (e.g. the release-PR's mass rename) don't linger.
+          rm -rf changelog/@unreleased
+          mkdir -p changelog/@unreleased
+          # `git checkout <SHA> -- <path>` writes the path's contents
+          # at <SHA> into the working tree without changing HEAD. If
+          # the path doesn't exist at <SHA> (PR deletes the dir
+          # entirely), the `|| true` keeps the step exiting cleanly.
+          git checkout "${HEAD_SHA}" -- 'changelog/@unreleased/' || true
+
+      - name: Resolve current version
+        id: current
+        if: steps.touched.outputs.touched == 'true'
+        # Same approach as `release-pr.yml`'s "Resolve current version"
+        # step: `git describe --tags --abbrev=0 --match 'v*.*.*'` reads
+        # the latest published tag. Falls back to `0.0.0` when no tag
+        # exists yet (first-ever release) so the very first `feature`
+        # entry produces `0.1.0` rather than crashing the predict.
+        run: |
+          set -euo pipefail
+          if tag="$(git describe --tags --abbrev=0 --match 'v*.*.*' 2>/dev/null)"; then
+            echo "version=${tag#v}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "version=0.0.0" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Predict release impact
+        id: predict
+        if: steps.touched.outputs.touched == 'true'
+        env:
+          CURRENT_VERSION: ${{ steps.current.outputs.version }}
+        run: |
+          set -euo pipefail
+          envelope="$(python3 scripts/changelog/predict_release_impact.py \
+            --repo-root . \
+            --current-version "${CURRENT_VERSION}")"
+          echo "${envelope}" > "${RUNNER_TEMP}/predict.json"
+          # Surface a top-level `predict` boolean so the next step's
+          # `if:` can branch without re-parsing the JSON.
+          if jq -e '.predict == true' < "${RUNNER_TEMP}/predict.json" >/dev/null; then
+            echo "predict=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "predict=false" >> "${GITHUB_OUTPUT}"
+            echo "release-impact-comment: $(jq -r '.reason' < "${RUNNER_TEMP}/predict.json")"
+          fi
+
+      - name: Render comment body
+        id: render
+        if: steps.touched.outputs.touched == 'true' && steps.predict.outputs.predict == 'true'
+        # Render the comment body as Markdown. The first line is an
+        # HTML comment marker the next step uses for idempotent
+        # matching — invisible to humans on the rendered comment but
+        # greppable by the bot. The "Claude: " prefix marks the
+        # comment as agent-authored per the project convention.
+        run: |
+          set -euo pipefail
+          payload="${RUNNER_TEMP}/predict.json"
+          bump="$(jq -r '.bump' < "${payload}")"
+          current="$(jq -r '.current_version' < "${payload}")"
+          next="$(jq -r '.next_version' < "${payload}")"
+          # Render one bullet per driver so a multi-entry PR shows
+          # every contributing entry. Bullet text is built in a jq
+          # filter so the embedded paths / types survive shell
+          # quoting verbatim. Each line: `- type \`feature\` in
+          # \`changelog/@unreleased/pr-NNN-slug.yml\` (-> MINOR)`.
+          drivers="$(jq -r '
+            .drivers[]
+            | "- type `\(.type)` in `\(.path)` (-> \(.bump))"
+              + (if .package then " — package `\(.package)`" else "" end)
+          ' < "${payload}")"
+          body_path="${RUNNER_TEMP}/comment-body.md"
+          {
+            echo "<!-- claude-release-impact -->"
+            echo "Claude: **Release impact:** this PR will trigger a **${bump}** version bump."
+            echo ""
+            echo "Predicted next version: \`v${next}\` (current: \`v${current}\`)."
+            echo ""
+            echo "Drivers:"
+            echo ""
+            echo "${drivers}"
+            echo ""
+            echo "_If this bump is wrong, edit the \`type:\` field in the YAML._"
+          } > "${body_path}"
+          echo "body_path=${body_path}" >> "${GITHUB_OUTPUT}"
+
+      - name: Post or update PR comment
+        if: steps.touched.outputs.touched == 'true' && steps.predict.outputs.predict == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BODY_PATH: ${{ steps.render.outputs.body_path }}
+          # The marker the comment carries on its first line; the
+          # match is exact-prefix so an arbitrary user comment that
+          # happens to mention "claude-release-impact" doesn't get
+          # patched. Kept here (rather than hardcoded in the run-block)
+          # so a future renaming is a single-line edit.
+          MARKER: "<!-- claude-release-impact -->"
+        # Idempotent: list the PR's existing issue comments, find the
+        # one whose body starts with the marker (if any), and
+        # PATCH it with the freshly rendered body. PATCH (rather than
+        # delete + create) preserves the comment ID so subscribers
+        # don't get a fresh notification on every workflow re-run.
+        # If no matching comment exists, POST a new one.
+        run: |
+          set -euo pipefail
+          # `gh api --paginate` (without `--jq`) returns concatenated
+          # arrays from each page; piping into `jq -r` flattens and
+          # filters in a single pass so we don't depend on a particular
+          # gh version's output shape. `--arg` keeps the marker out of
+          # the jq program text so its `<`, `!`, `-` characters survive
+          # shell quoting verbatim.
+          existing_id="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            | jq -r --arg marker "${MARKER}" \
+                '.[] | select((.body // "") | startswith($marker)) | .id' \
+            | head -n 1)"
+          # `-F body=@<file>` reads the body from disk as a JSON
+          # string field — identical semantics to inlining
+          # `body="$(cat <file>)"` but binary-safe and free of any
+          # shell-expansion of the file's contents (the comment body
+          # is rendered Markdown so it can carry backticks / `$(`,
+          # which would otherwise execute under bash's `$(...)`).
+          if [[ -n "${existing_id}" ]]; then
+            echo "release-impact-comment: updating existing comment ${existing_id}"
+            gh api --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" \
+              -F "body=@${BODY_PATH}" \
+              > /dev/null
+          else
+            echo "release-impact-comment: posting new comment"
+            gh api --method POST \
+              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -F "body=@${BODY_PATH}" \
+              > /dev/null
+          fi
+
+  predict-release-impact-self-test:
+    name: predict_release_impact unit tests
+    runs-on: ubuntu-latest
+    # Exercise the predict script's bump matrix on every run so a
+    # regression in the prediction surface (e.g. the bump enum
+    # gaining a new variant whose label is not rendered) immediately
+    # fails CI rather than silently emitting a wrong comment. Same
+    # rationale as the existing `validator-self-test` job.
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Install runtime deps (PyYAML, pytest)
+        run: pip install --no-cache-dir 'pyyaml>=6' 'pytest>=8'
+
+      - name: Run predict_release_impact unit tests
+        run: |
+          set -euo pipefail
+          # `conftest.py` under scripts/changelog/tests/ puts
+          # scripts/changelog/ and scripts/lint/ on sys.path so the
+          # bare-name imports in the test file resolve.
+          python3 -m pytest scripts/changelog/tests/test_predict_release_impact.py -v

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -392,28 +392,47 @@ jobs:
           git checkout "${HEAD_SHA}" -- 'changelog/@unreleased/' || true
 
       - name: Resolve current version
-        id: current
         if: steps.touched.outputs.touched == 'true'
         # Same approach as `release-pr.yml`'s "Resolve current version"
         # step: `git describe --tags --abbrev=0 --match 'v*.*.*'` reads
         # the latest published tag. Falls back to `0.0.0` when no tag
         # exists yet (first-ever release) so the very first `feature`
         # entry produces `0.1.0` rather than crashing the predict.
+        #
+        # The version is written to a file under `RUNNER_TEMP` rather
+        # than to `GITHUB_OUTPUT`. Under `pull_request_target`, CodeQL's
+        # `actions/untrusted-checkout` query treats `${{ steps.*.outputs.* }}`
+        # expressions as a tainted-data path into a privileged workflow
+        # — even when the source step ran on the base-ref checkout —
+        # and the env-var pattern alone (`env: VAR: ${{ steps.x.y }}`)
+        # does not fully untaint the flow. Routing the value through a
+        # file in `RUNNER_TEMP` sidesteps the expression entirely; the
+        # consuming step reads it with `cat` and re-validates it as
+        # strict semver before use (defence in depth).
         run: |
           set -euo pipefail
           if tag="$(git describe --tags --abbrev=0 --match 'v*.*.*' 2>/dev/null)"; then
-            echo "version=${tag#v}" >> "${GITHUB_OUTPUT}"
+            printf '%s' "${tag#v}" > "${RUNNER_TEMP}/current-version.txt"
           else
-            echo "version=0.0.0" >> "${GITHUB_OUTPUT}"
+            printf '0.0.0' > "${RUNNER_TEMP}/current-version.txt"
           fi
 
       - name: Predict release impact
         id: predict
         if: steps.touched.outputs.touched == 'true'
-        env:
-          CURRENT_VERSION: ${{ steps.current.outputs.version }}
         run: |
           set -euo pipefail
+          CURRENT_VERSION="$(cat "${RUNNER_TEMP}/current-version.txt")"
+          # Reject anything that isn't strict semver before passing it
+          # to the script. `git describe --tags --match 'v*.*.*'` should
+          # already constrain the value to `MAJOR.MINOR.PATCH`, but the
+          # validation makes the contract explicit at the consuming
+          # step's edge so a future change to the resolver can't
+          # silently widen the surface.
+          if ! [[ "${CURRENT_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "release-impact-comment: invalid current version '${CURRENT_VERSION}'" >&2
+            exit 1
+          fi
           envelope="$(python3 scripts/changelog/predict_release_impact.py \
             --repo-root . \
             --current-version "${CURRENT_VERSION}")"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -469,6 +469,14 @@ to the lint and the release workflow:
 range (per ADR 0026 § Pre-1.0 behaviour). Force the graduation to
 `1.0.0` with `release-as: 1.0.0` on the breaking change's YAML.
 
+The `release-impact-comment` job in
+[`.github/workflows/pr-lint.yml`](.github/workflows/pr-lint.yml)
+posts an idempotent `Claude:` comment on every PR that touches
+`changelog/@unreleased/*.yml`, surfacing the predicted
+`current → next` version transition so a mislabelled `type:` (e.g.
+`feature` for what should have been `improvement`) is caught at
+review time rather than after release.
+
 ### `packages:` and `release-as:`
 
 - **`packages:`** — list workspace members the change affects. Omit

--- a/scripts/changelog/predict_release_impact.py
+++ b/scripts/changelog/predict_release_impact.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Predict the SemVer bump a PR will trigger and emit a JSON envelope.
+
+Consumed by the ``release-impact-comment`` job in
+``.github/workflows/pr-lint.yml`` (issue #406). The job posts an
+idempotent PR comment surfacing the predicted bump so a reviewer can
+catch a mislabelled YAML (e.g. a ``feature`` entry that should have
+been ``improvement``) at PR-review time, before the next release goes
+out and the version jumps unexpectedly.
+
+The script is plumbing — it does no bump-computation of its own. It
+walks ``changelog/@unreleased/*.yml`` and delegates to
+``build_release.compute_release`` (the same wrapper ``release-pr.yml``
+uses) so the prediction surfaced on the PR is byte-identical to the
+plan the release workflow will execute.
+
+## CLI surface
+
+    python3 scripts/changelog/predict_release_impact.py \
+        --repo-root . \
+        --current-version 0.16.1
+
+Emits one JSON object on stdout. Two shapes:
+
+- ``{"predict": true, "current_version", "next_version", "bump",
+   "drivers": [{"path", "type", "package"?}]}`` — when there is at
+  least one entry under ``@unreleased/`` whose ``type:`` implies a
+  non-NONE bump.
+- ``{"predict": false, "reason"}`` — when there are no entries, or
+  every entry's bump is NONE (impossible today since
+  ``RELEASE_BUMPING_TYPES`` excludes ``chore`` at the schema layer,
+  but the branch is kept for defensive cleanliness if the taxonomy
+  ever grows a NONE-mapped release-bumping type).
+
+The exit code is 0 in both shapes. Any ``ChangelogValidationError``
+raised by the underlying parser propagates as a non-zero exit so the
+workflow surfaces a malformed YAML rather than silently posting "no
+release impact".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+# Keep ``build_release`` (and therefore ``version_logic``) importable
+# without forcing the caller to set ``PYTHONPATH``. The explicit insert
+# mirrors the idiom in ``build_release.py`` / ``lint.py``: this script
+# lives at ``scripts/changelog/`` (not on the default ``sys.path``) and
+# may be invoked either as a path (``python3 scripts/.../predict.py``)
+# or as a module (``python3 -m predict_release_impact``); the insert
+# handles the third case where another script imports this one from a
+# different working directory.
+_MODULE_DIR = Path(__file__).resolve().parent
+if str(_MODULE_DIR) not in sys.path:
+    sys.path.insert(0, str(_MODULE_DIR))
+
+from build_release import compute_release  # noqa: E402  -- after sys.path setup
+from version_logic import BumpType, ChangelogEntry, bump_for  # noqa: E402
+
+# Human-readable label per bump category. Surfaced in the rendered
+# comment body so a reviewer sees ``MINOR`` / ``PATCH`` / ``MAJOR``
+# rather than the underlying enum repr. Kept here (not in
+# ``commit_taxonomy``) because it is purely a presentation concern of
+# this prediction surface — the enum's ``.name`` happens to spell the
+# same letters today, but a future renaming would diverge.
+_BUMP_LABELS: dict[BumpType, str] = {
+    BumpType.NONE: "NONE",
+    BumpType.PATCH: "PATCH",
+    BumpType.MINOR: "MINOR",
+    BumpType.MAJOR: "MAJOR",
+}
+
+
+def predict(
+    repo_root: Path,
+    current_version: str,
+) -> dict[str, object]:
+    """Return the predicted release impact envelope as a plain dict.
+
+    Pure function: does no I/O beyond what ``compute_release`` already
+    does (reading ``@unreleased/*.yml``). Suitable for unit testing.
+
+    Raises ``ChangelogValidationError`` from ``version_logic`` if any
+    YAML is malformed — propagated unchanged so a release-blocking
+    schema break in an unreleased entry surfaces as a workflow failure
+    rather than a misleading "no impact" comment.
+    """
+    plan = compute_release(repo_root, current_version)
+    if plan is None:
+        return {"predict": False, "reason": "no unreleased entries"}
+    # ``compute_release`` returns a plan whenever there is at least one
+    # YAML; the largest implied bump still needs to be derived from the
+    # entries to populate the envelope's ``bump`` field. Re-using
+    # ``bump_for`` here (rather than diffing the version strings) keeps
+    # the bump category an explicit value the caller can render — and
+    # matches the same enum the release workflow operates on.
+    largest = max(bump_for(entry.entry_type, current_version) for entry in plan.entries)
+    if largest == BumpType.NONE:
+        # Defensive branch: the YAML schema rejects ``chore`` so every
+        # entry today carries a non-NONE type. Keep the branch so a
+        # future taxonomy that adds a release-bumping NONE type does
+        # not silently post a noise comment.
+        return {"predict": False, "reason": "all entries map to NONE bump"}
+    return {
+        "predict": True,
+        "current_version": plan.current_version,
+        "next_version": plan.next_version,
+        "bump": _BUMP_LABELS[largest],
+        "drivers": [_driver(entry, current_version) for entry in plan.entries],
+    }
+
+
+def _driver(entry: ChangelogEntry, current_version: str) -> dict[str, object]:
+    """Render one entry as a comment-body driver hint.
+
+    ``path`` is repo-root-relative — the caller renders it inside a
+    Markdown ``code`` span, so any leading absolute path noise from a
+    test fixture would muddy the comment. ``type`` is the entry's
+    declared ``type:`` (the YAML literal, not the enum repr) so the
+    rendered comment quotes the same string the contributor typed.
+    ``package`` is included only when ``packages:`` was a single
+    explicit entry — multi-package entries expand to ``null`` to keep
+    the comment terse, and a workspace-wide entry (``packages: None``)
+    omits the field rather than rendering ``null``.
+    """
+    package: str | None = None
+    if entry.packages is not None and len(entry.packages) == 1:
+        package = entry.packages[0]
+    driver: dict[str, object] = {
+        "path": _changelog_relative(entry.source_path),
+        "type": entry.entry_type.value,
+        "bump": _BUMP_LABELS[bump_for(entry.entry_type, current_version)],
+    }
+    if package is not None:
+        driver["package"] = package
+    return driver
+
+
+def _changelog_relative(path: Path) -> str:
+    """Trim everything above ``changelog/`` so the rendered path is stable.
+
+    ``compute_release`` populates ``entry.source_path`` from
+    ``Path.iterdir()`` results, which are absolute when the caller
+    passed an absolute repo root. The release-pr workflow plans
+    ``changelog/<version>/...`` destinations the same way; we re-use
+    the same trim so the comment shows ``changelog/@unreleased/...``
+    regardless of where the runner happened to check the repo out.
+    """
+    parts = path.parts
+    try:
+        anchor = parts.index("changelog")
+    except ValueError:
+        # No `changelog/` ancestor (only happens on hand-constructed
+        # entries in tests) — fall back to the bare name so the
+        # rendered comment never accidentally exposes a /tmp prefix.
+        return path.name
+    return str(Path(*parts[anchor:]))
+
+
+# --- CLI ----------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Emit a JSON envelope predicting the SemVer bump implied "
+            "by `changelog/@unreleased/*.yml`. Consumed by the "
+            "`release-impact-comment` job in `.github/workflows/pr-lint.yml`."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root to scan (default: current directory).",
+    )
+    parser.add_argument(
+        "--current-version",
+        required=True,
+        help="Current released version (X.Y.Z, no leading v).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv if argv is not None else sys.argv[1:])
+    repo_root = Path(args.repo_root).resolve()
+    envelope = predict(repo_root, args.current_version)
+    json.dump(envelope, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+__all__ = ["predict", "main"]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/changelog/tests/test_predict_release_impact.py
+++ b/scripts/changelog/tests/test_predict_release_impact.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for ``scripts/changelog/predict_release_impact.py``.
+
+Public-API only — every test exercises ``predict`` (the pure
+function) or the ``main`` CLI entrypoint. The module is the
+PR-comment-time prediction surface for the ``release-impact-comment``
+workflow job introduced in #406; a regression here changes what
+contributors see when their PR touches ``changelog/@unreleased/``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+from predict_release_impact import main as predict_main
+from predict_release_impact import predict
+from version_logic import ChangelogValidationError
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _seed(repo: Path, name: str, body: str) -> Path:
+    path = repo / "changelog" / "@unreleased" / name
+    _write(path, body)
+    return path
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    """A minimal repo layout the predictor walks."""
+    (tmp_path / "changelog" / "@unreleased").mkdir(parents=True)
+    return tmp_path
+
+
+# --- bump matrix --------------------------------------------------------------
+
+
+def test_predict_feature_implies_minor(repo: Path) -> None:
+    """A `feature` entry surfaces as a MINOR bump on a 0.x current version."""
+    _seed(
+        repo,
+        "pr-100-x.yml",
+        "type: feature\nfeature:\n  description: New thing.\n",
+    )
+    envelope = predict(repo, "0.16.1")
+    assert envelope["predict"] is True
+    assert envelope["bump"] == "MINOR"
+    assert envelope["current_version"] == "0.16.1"
+    assert envelope["next_version"] == "0.17.0"
+    drivers = envelope["drivers"]
+    assert isinstance(drivers, list) and len(drivers) == 1
+    assert drivers[0]["type"] == "feature"
+    assert drivers[0]["bump"] == "MINOR"
+    assert drivers[0]["path"].endswith("pr-100-x.yml")
+
+
+def test_predict_improvement_implies_patch(repo: Path) -> None:
+    """An `improvement` entry on its own implies a PATCH bump."""
+    _seed(
+        repo,
+        "pr-101-x.yml",
+        "type: improvement\nimprovement:\n  description: Tweak.\n",
+    )
+    envelope = predict(repo, "0.16.1")
+    assert envelope["predict"] is True
+    assert envelope["bump"] == "PATCH"
+    assert envelope["next_version"] == "0.16.2"
+
+
+def test_predict_fix_implies_patch(repo: Path) -> None:
+    """A `fix` entry on its own implies a PATCH bump."""
+    _seed(
+        repo,
+        "pr-102-x.yml",
+        "type: fix\nfix:\n  description: Fix it.\n",
+    )
+    envelope = predict(repo, "0.16.1")
+    assert envelope["predict"] is True
+    assert envelope["bump"] == "PATCH"
+    assert envelope["next_version"] == "0.16.2"
+
+
+def test_predict_break_demoted_to_minor_on_zero_x(repo: Path) -> None:
+    """`break` demotes to MINOR while the project is in the 0.x range (ADR 0026)."""
+    _seed(
+        repo,
+        "pr-103-x.yml",
+        "type: break\nbreak:\n  description: Drops /v0.\n",
+    )
+    envelope = predict(repo, "0.16.1")
+    assert envelope["predict"] is True
+    assert envelope["bump"] == "MINOR"
+    assert envelope["next_version"] == "0.17.0"
+
+
+def test_predict_break_promotes_to_major_post_one_x(repo: Path) -> None:
+    """`break` produces a MAJOR bump once the project graduates to 1.x."""
+    _seed(
+        repo,
+        "pr-104-x.yml",
+        "type: break\nbreak:\n  description: Drops /v0.\n",
+    )
+    envelope = predict(repo, "1.2.3")
+    assert envelope["predict"] is True
+    assert envelope["bump"] == "MAJOR"
+    assert envelope["next_version"] == "2.0.0"
+
+
+def test_predict_mixed_picks_largest_bump(repo: Path) -> None:
+    """A `feature` + `fix` mix surfaces as MINOR (largest bump wins)."""
+    _seed(
+        repo,
+        "pr-105-fix.yml",
+        "type: fix\nfix:\n  description: A bug fix.\n",
+    )
+    _seed(
+        repo,
+        "pr-106-feature.yml",
+        "type: feature\nfeature:\n  description: A new thing.\n",
+    )
+    envelope = predict(repo, "0.16.1")
+    assert envelope["predict"] is True
+    assert envelope["bump"] == "MINOR"
+    assert envelope["next_version"] == "0.17.0"
+    # Both entries surface as drivers so the rendered comment can name
+    # all of them — not just the largest-bump one.
+    drivers = envelope["drivers"]
+    assert isinstance(drivers, list) and len(drivers) == 2
+    types = sorted(driver["type"] for driver in drivers)
+    assert types == ["feature", "fix"]
+
+
+# --- empty / no-impact branches ----------------------------------------------
+
+
+def test_predict_returns_no_impact_for_empty_unreleased(repo: Path) -> None:
+    """An empty `@unreleased/` directory surfaces as ``predict: False``."""
+    envelope = predict(repo, "0.16.1")
+    assert envelope == {"predict": False, "reason": "no unreleased entries"}
+
+
+def test_predict_returns_no_impact_when_unreleased_dir_missing(tmp_path: Path) -> None:
+    """A repo without a `changelog/@unreleased/` dir at all returns no-impact."""
+    envelope = predict(tmp_path, "0.16.1")
+    assert envelope == {"predict": False, "reason": "no unreleased entries"}
+
+
+# --- driver shape -------------------------------------------------------------
+
+
+def test_predict_driver_includes_single_package_scope(repo: Path) -> None:
+    """A single-package entry surfaces ``package`` so the comment can name it."""
+    _seed(
+        repo,
+        "pr-107-x.yml",
+        (
+            "type: feature\n"
+            "feature:\n"
+            "  description: Scoped change.\n"
+            "packages:\n"
+            "  - agent-auth\n"
+        ),
+    )
+    envelope = predict(repo, "0.16.1")
+    assert envelope["predict"] is True
+    drivers = envelope["drivers"]
+    assert isinstance(drivers, list) and len(drivers) == 1
+    assert drivers[0]["package"] == "agent-auth"
+
+
+def test_predict_driver_omits_package_for_workspace_wide_entry(repo: Path) -> None:
+    """Workspace-wide entries omit ``package`` rather than rendering ``null``."""
+    _seed(
+        repo,
+        "pr-108-x.yml",
+        "type: feature\nfeature:\n  description: Workspace-wide.\n",
+    )
+    envelope = predict(repo, "0.16.1")
+    drivers = envelope["drivers"]
+    assert isinstance(drivers, list) and len(drivers) == 1
+    assert "package" not in drivers[0]
+
+
+def test_predict_driver_omits_package_for_multi_package_entry(repo: Path) -> None:
+    """Multi-package entries omit ``package`` to keep the comment terse."""
+    _seed(
+        repo,
+        "pr-109-x.yml",
+        (
+            "type: feature\n"
+            "feature:\n"
+            "  description: Multi.\n"
+            "packages:\n"
+            "  - agent-auth\n"
+            "  - agent-auth-common\n"
+        ),
+    )
+    envelope = predict(repo, "0.16.1")
+    drivers = envelope["drivers"]
+    assert isinstance(drivers, list) and len(drivers) == 1
+    assert "package" not in drivers[0]
+
+
+def test_predict_driver_path_is_repo_relative(repo: Path) -> None:
+    """The ``path`` field is trimmed to start at ``changelog/`` regardless of cwd."""
+    _seed(
+        repo,
+        "pr-110-x.yml",
+        "type: feature\nfeature:\n  description: Trim test.\n",
+    )
+    envelope = predict(repo, "0.16.1")
+    drivers = envelope["drivers"]
+    assert isinstance(drivers, list)
+    assert drivers[0]["path"] == "changelog/@unreleased/pr-110-x.yml"
+
+
+# --- malformed YAML surfaces ---------------------------------------------------
+
+
+def test_predict_propagates_validation_error_on_malformed_yaml(repo: Path) -> None:
+    """A YAML that fails the schema raises so the workflow fails closed."""
+    _seed(
+        repo,
+        "pr-111-bad.yml",
+        "type: feature\n# missing the required `feature:` nested key\n",
+    )
+    with pytest.raises(ChangelogValidationError):
+        predict(repo, "0.16.1")
+
+
+# --- CLI entrypoint -----------------------------------------------------------
+
+
+def test_cli_emits_json_envelope_with_predict_true(repo: Path) -> None:
+    """Running the CLI prints a single JSON object on stdout."""
+    _seed(
+        repo,
+        "pr-112-x.yml",
+        "type: feature\nfeature:\n  description: New thing.\n",
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = predict_main(
+            [
+                "--repo-root",
+                str(repo),
+                "--current-version",
+                "0.16.1",
+            ]
+        )
+    assert rc == 0
+    # A single line of JSON is emitted; assert it parses and matches
+    # the public envelope shape.
+    payload = json.loads(buf.getvalue())
+    assert payload["predict"] is True
+    assert payload["bump"] == "MINOR"
+    assert payload["current_version"] == "0.16.1"
+    assert payload["next_version"] == "0.17.0"
+
+
+def test_cli_emits_json_envelope_with_predict_false(repo: Path) -> None:
+    """An empty unreleased dir round-trips as a ``predict: false`` envelope."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = predict_main(
+            [
+                "--repo-root",
+                str(repo),
+                "--current-version",
+                "0.16.1",
+            ]
+        )
+    assert rc == 0
+    payload = json.loads(buf.getvalue())
+    assert payload == {"predict": False, "reason": "no unreleased entries"}


### PR DESCRIPTION
==COMMIT_MSG==
chore(ci): add release-impact-comment job to pr-lint

Mislabelled changelog YAML entries silently trigger the wrong
public version bump. The matrix lint (#401) catches the worst
category -- `feature(ci):` and friends -- but the YAML's `type:`
field is still author-controlled and a contributor can label a
CI-adjacent change as `feature` when `improvement` or `fix` is
more appropriate. The matrix won't catch that; only a human
reviewer will.

Adds a `release-impact-comment` job to `pr-lint.yml` that posts
an idempotent `Claude:` comment on every PR touching
`changelog/@unreleased/*.yml`, surfacing the predicted
`current -> next` version transition so a mislabel is visible at
PR-review time. The comment uses an HTML-comment marker
(`<!-- claude-release-impact -->`) for idempotent matching and
is PATCHed in place on subsequent runs to avoid notification
noise. PRs that touch no `@unreleased/*.yml` files are skipped
entirely so the bot does not post on every PR.

Bump computation is a thin wrapper over the existing
`build_release.compute_release(...)` so the prediction surfaced
on the PR is byte-identical to the plan the release workflow
will execute. The new
`scripts/changelog/predict_release_impact.py` owns the wrapper
and the JSON envelope shape; `predict-release-impact-self-test`
exercises the bump matrix on every run.

The job runs under the existing `pull_request_target` trigger
(not widening the trigger surface). The PR head's YAMLs are
fetched as data only -- the predict script and the
`version_logic` parser both come from the base ref, so a fork
PR cannot ship a malicious predictor in the same PR. The
comment is posted via the default `GITHUB_TOKEN` with
`pull-requests: write` at the job level; no additional bot-token
plumbing is required.

Closes #406
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

<!-- ==NO_CHANGELOG== -->

## Review notes

This PR is plumbing -- the new comment IS user-visible to PR
contributors but is internal tooling, not a runtime behaviour
change. Apply `no changelog` after opening per the project
convention for `chore(ci):` PRs.

### Bot identity

Posts as `github-actions[bot]` via the default `GITHUB_TOKEN`
(`pull-requests: write` at the job level). The merge-bot /
release-bot / changelog-bot App path was considered for symmetry,
but minting an App token requires provisioning new secrets and
the comment surface here is purely informational (no
protected-branch or `contents:` writes). Using the default token
keeps the bot fully operational on the PR that initially adds
the workflow without depending on a separate one-time setup.
The `Claude:` prefix per the project convention still identifies
the comment as agent-authored. Documented inline in the workflow
comment block.

### Test plan

- [ ] `scripts/changelog/tests/test_predict_release_impact.py` exercises the bump matrix (`feature` → MINOR, `improvement` / `fix` / `deprecation` / `migration` → PATCH, `break` (in 0.x) → MINOR, `break` (in 1.x) → MAJOR, mixed → highest, empty `@unreleased/` → no impact, malformed YAML → `ChangelogValidationError`). Run via `uv run pytest scripts/changelog/tests/test_predict_release_impact.py -v`.
- [ ] All 227 existing changelog tests still pass.
- [ ] `task test` (full suite, 753 tests) passes.
- [ ] `task lint`, `task typecheck`, `python3 scripts/lint/commit_taxonomy.py check-pr-lint-yaml`, `python3 scripts/validate-pr-title.py --self-test`, `bash scripts/verify-standards.sh` all pass.
- [ ] On this PR itself, the new `release-impact-comment` job runs and EARLY-EXITs (this PR doesn't touch `changelog/@unreleased/*.yml`, so no comment is posted). The job log line `release-impact-comment: no changelog/@unreleased/ files touched; nothing to predict.` confirms the no-noise branch.
- [ ] The `predict-release-impact-self-test` job runs and passes.

### Out of scope

- Changing the bump computation itself. This is a surfacing / communication issue, not a logic issue. `version_logic.py` (and its `build_release.compute_release` wrapper) is already authoritative.