### PR TITLE
chore(ci): merge-bot append PR number to squash subjects

### DIFF
--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -730,10 +730,20 @@ jobs:
           # the body content. `sha` is included so a race that
           # advances the head past the SHA we evaluated produces a
           # documented 409 rather than a silent merge of new code.
+          #
+          # Append ` (#<n>)` to the commit subject so GitHub renders
+          # it as a clickable link to the originating PR in the
+          # commit log. The `PUT /pulls/{n}/merge` REST endpoint does
+          # NOT auto-append the suffix the way the web UI's "Squash
+          # and merge" button does — the bot has to add it
+          # explicitly. `pr-lint.yml`'s `pr-title-style` job budgets
+          # for the suffix at PR-author time
+          # (`validate-pr-title.py --pr-number`) so the projected
+          # subject still respects the 72-char hard cap. See #399.
           if gh api --method PUT \
             "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/merge" \
             -f merge_method=squash \
-            -f commit_title="${PR_TITLE}" \
+            -f commit_title="${PR_TITLE} (#${PR_NUMBER})" \
             -f "commit_message=$(cat "${COMMIT_MESSAGE_PATH}")" \
             -f sha="${HEAD_SHA}" \
             > "${RUNNER_TEMP}/merge.out" 2> "${RUNNER_TEMP}/merge.err"; then

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -115,10 +115,19 @@ jobs:
           # the env-var path keeps shell expansion off the title and
           # mirrors the injection-safety pattern of pr-body-commit-msg.
           TITLE: ${{ github.event.pull_request.title }}
+          # Same env-var pattern for the PR number so the suffix-aware
+          # length cap (#399) runs against the projected squash-merge
+          # subject (un-suffixed title + ` (#<n>)`). The number is an
+          # integer in the event payload, but routing it through env
+          # rather than inlining ${{ github.event.pull_request.number }}
+          # keeps `pull_request_target` workflows off CodeQL's
+          # `js/actions/command-injection` flagged channel.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           python3 scripts/validate-pr-title.py \
             --changed-files-from "${RUNNER_TEMP}/changed-files.txt" \
+            --pr-number "${PR_NUMBER}" \
             "${TITLE:-}"
 
   pr-body-commit-msg:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -769,7 +769,7 @@ A subset of the rules below is **CI-enforced**; the rest are
 | Rule                                                                             | Enforced by                                                                                                                       |
 | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Title prefix in the Palantir allowlist                                           | CI (`pr-title` job, `amannn/action-semantic-pull-request`)                                                                        |
-| Title ≤ 72 chars                                                                 | CI (`pr-title-style` job, `scripts/validate-pr-title.py`)                                                                         |
+| Title ≤ 72 chars (after `merge-bot.yml` appends ` (#<n>)`)                       | CI (`pr-title-style` job, `scripts/validate-pr-title.py --pr-number`)                                                             |
 | Title has no trailing period                                                     | CI (`pr-title-style` job)                                                                                                         |
 | Title does not open with a past-tense / participle verb in the closed list       | CI (`pr-title-style` job — list: `Added` / `Fixed` / `Updated` / `Changed` / `Removed` / `Refactored` / `Implemented` / `Bumped`) |
 | Title summary ≤ 50 chars (soft target on the post-prefix summary)                | Convention only                                                                                                                   |
@@ -811,7 +811,13 @@ A subset of the rules below is **CI-enforced**; the rest are
   style prefixes — the prefix alone eats the budget. The 50-char soft
   target is therefore measured on the post-prefix summary; the
   72-char hard cap (CI-enforced separately) is on the full title
-  including the prefix and is the immutable line.
+  including the prefix and is the immutable line. The hard cap is
+  applied to the *projected* squash-merge subject — the bot appends
+  ` (#<n>)` at merge time so GitHub renders the commit subject as a
+  clickable link in the commit log, and the validator (passed
+  `--pr-number` by `pr-lint.yml`) budgets for the suffix at PR-author
+  time. Authoring a 72-char un-suffixed title is therefore over the
+  cap; aim for ≤ 64 chars or so to leave headroom for the suffix.
 
 ##### Body (`==COMMIT_MSG==` block)
 

--- a/docs/release/merge-bot-setup.md
+++ b/docs/release/merge-bot-setup.md
@@ -37,8 +37,13 @@ workflow:
    fails the job rather than burning further CI cycles. See
    [Auto-update on BEHIND](#auto-update-on-behind) below.
 4. Otherwise calls `PUT /repos/aidanns/agent-auth/pulls/{n}/merge`
-   with `merge_method: squash`, `commit_title: <PR title>`,
-   `commit_message: <extracted block>`.
+   with `merge_method: squash`,
+   `commit_title: <PR title> (#<n>)`,
+   `commit_message: <extracted block>`. The bot appends ` (#<n>)`
+   to the subject so GitHub renders the squash-merge commit subject
+   as a clickable link to the originating PR in the commit log;
+   the REST merge endpoint does not auto-append the suffix the
+   way the web UI's "Squash and merge" button does. See #399.
 5. Comments `Claude: Merged via bot.` on success, or
    `Claude: Cannot merge — <reason>` on any pre-merge failure
    (label stays applied so the next green run retriggers the

--- a/scripts/validate-pr-title.py
+++ b/scripts/validate-pr-title.py
@@ -16,7 +16,14 @@
 #   1. Length: 72-char hard cap on the full subject (prefix + summary).
 #      The 50-char soft target on the post-prefix summary documented in
 #      CONTRIBUTING.md is *not* enforced (false-positive risk on long
-#      scopes); only the hard cap is mechanical.
+#      scopes); only the hard cap is mechanical. When ``--pr-number``
+#      is provided, the cap is applied to the *projected* squash-merge
+#      subject — the un-suffixed PR title plus the ``(#<n>)`` suffix
+#      ``merge-bot.yml`` appends. The REST merge endpoint does not
+#      auto-append the suffix the way GitHub's UI "Squash and merge"
+#      button does, so the bot adds it explicitly to keep commit
+#      subjects clickable in the commit log; the validator therefore
+#      has to budget for the suffix at PR-author time. See #399.
 #   2. No trailing period: the subject is a fragment, not a sentence.
 #   3. Imperative mood: reject subjects whose summary opens with a
 #      narrow, closed list of past-tense / participle / gerund verbs
@@ -144,12 +151,47 @@ def _strip_prefix(title: str) -> str:
     return title[match.end() :]
 
 
-def check_length(title: str) -> None:
-    if len(title) > MAX_TITLE_WIDTH:
+def _projected_suffix(pr_number: int | None) -> str:
+    """Return the ``(#<n>)`` suffix ``merge-bot.yml`` will append, or ``""``.
+
+    Kept as a helper so the suffix's exact shape lives in one place;
+    the bot's `commit_title="${PR_TITLE} (#${PR_NUMBER})"` mirrors this
+    string verbatim. Returns the empty string when no PR number was
+    provided so the caller's length math degrades to the un-suffixed
+    cap.
+    """
+    if pr_number is None:
+        return ""
+    return f" (#{pr_number})"
+
+
+def check_length(title: str, pr_number: int | None = None) -> None:
+    """Reject titles that overflow the 72-char cap on the squash subject.
+
+    When ``pr_number`` is provided, the cap is applied to the
+    *projected* subject (un-suffixed title + ``(#<n>)``), since the
+    merge bot pastes that exact string into the squash-merge commit
+    title. The error message surfaces the un-suffixed length, the
+    suffix length, and the projected total so a contributor can see
+    which constraint is binding without having to redo the arithmetic
+    themselves. See #399.
+    """
+    suffix = _projected_suffix(pr_number)
+    projected = len(title) + len(suffix)
+    if projected <= MAX_TITLE_WIDTH:
+        return
+    if not suffix:
         raise TitleValidationError(
             f"subject is {len(title)} chars (limit {MAX_TITLE_WIDTH}) — "
             "shorten the summary or drop the scope."
         )
+    raise TitleValidationError(
+        f"subject would be {projected} chars after merge-bot appends "
+        f"`{suffix.lstrip()}` ({len(title)}-char title + {len(suffix)}-char "
+        f"suffix; limit {MAX_TITLE_WIDTH}) — shorten the summary or drop "
+        "the scope. The bot appends the PR number so GitHub renders the "
+        "commit subject as a link in the commit log; see #399."
+    )
 
 
 def check_no_trailing_period(title: str) -> None:
@@ -384,13 +426,17 @@ def check_two_tier_scope(title: str, changed_files: list[str] | None) -> None:
     )
 
 
-def validate(title: str, changed_files: list[str] | None = None) -> None:
+def validate(
+    title: str,
+    changed_files: list[str] | None = None,
+    pr_number: int | None = None,
+) -> None:
     if not title.strip():
         raise TitleValidationError(
             "subject is empty — author a PR title with the "
             "Palantir-style `prefix: summary` shape."
         )
-    check_length(title)
+    check_length(title, pr_number)
     check_no_trailing_period(title)
     check_imperative_mood(title)
     check_type_scope_matrix(title)
@@ -400,19 +446,24 @@ def validate(title: str, changed_files: list[str] | None = None) -> None:
 # Inline self-test cases. The PR-title input is a single string from
 # `${{ github.event.pull_request.title }}`, so file-based fixtures
 # (the body validator's pattern) buy nothing here. Each tuple is
-# (title, changed_files, expect_pass, label):
+# (title, changed_files, pr_number, expect_pass, label):
 #
 # - ``changed_files`` is ``None`` when the case doesn't exercise the
 #   two-tier scope rule (rule 5). Pre-#402 cases keep ``None`` and
 #   stay focused on the rules they were written for; the #402 cases
 #   each provide a representative diff.
+# - ``pr_number`` is ``None`` for cases that don't exercise the
+#   suffix-aware length rule (#399). The suffix-aware fixtures below
+#   each pass a representative number so the cap math runs against a
+#   real ``(#<n>)`` width.
 # - ``label`` shows up in the self-test log so a regression points at
 #   the failing case immediately.
-_SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
+_SELF_TEST_CASES: tuple[tuple[str, list[str] | None, int | None, bool, str], ...] = (
     # Passing cases: representative titles drawn from recent merged
     # PRs and the worked examples in CONTRIBUTING.md.
     (
         "chore(ci): enforce subject-style rules in pr-lint validator",
+        None,
         None,
         True,
         "passing-chore",
@@ -421,6 +472,7 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
         # Package scope — release-bumping types are fine here; only
         # the internal-only scopes are restricted.
         "feature(agent-auth): add JIT approval flow for prompt-tier scope",
+        None,
         None,
         True,
         "passing-feature-package-scope",
@@ -435,11 +487,13 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
         # passing case honest.
         "fix(agent-auth): use constant-time HMAC comparison",
         ["packages/agent-auth/src/agent_auth/tokens.py"],
+        None,
         True,
         "passing-fix",
     ),
     (
         "improvement: tighten numbered-list regex",
+        None,
         None,
         True,
         "passing-no-scope",
@@ -449,6 +503,7 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
         # changes can be user-visible and bump the version.
         "feature(release): wire workflow-dispatch tag re-runs",
         None,
+        None,
         True,
         "passing-feature-release-scope",
     ),
@@ -457,6 +512,7 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
         # escape hatch for a real bug in CI / dev-dep / docs surface.
         "fix(claude): correct outdated worktree path in plan template",
         None,
+        None,
         True,
         "passing-fix-internal-scope",
     ),
@@ -464,17 +520,20 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
     (
         "fix: drop the trailing period.",
         None,
+        None,
         False,
         "failing-trailing-period",
     ),
     (
         "improvement: Fixed gpg-bridge timeout",
         None,
+        None,
         False,
         "failing-past-tense-fixed",
     ),
     (
         "feature: Added a thing",
+        None,
         None,
         False,
         "failing-past-tense-added",
@@ -483,11 +542,13 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
         # 84 chars — the example from the issue body.
         "fix(very-long-scope): a summary that runs on and on past the seventy two char cap easy",
         None,
+        None,
         False,
         "failing-too-long",
     ),
     (
         "",
+        None,
         None,
         False,
         "failing-empty",
@@ -504,11 +565,13 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
     (
         "feature(ci): add release-build dry-run and post-publish smoke",
         None,
+        None,
         False,
         "failing-matrix-feature-ci",
     ),
     (
         "improvement(deps-dev): tighten pytest config",
+        None,
         None,
         False,
         "failing-matrix-improvement-deps-dev",
@@ -516,17 +579,20 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
     (
         "break(claude): rewrite plan-template to call EnterWorktree",
         None,
+        None,
         False,
         "failing-matrix-break-claude",
     ),
     (
         "deprecation(docs): retire the legacy onboarding guide",
         None,
+        None,
         False,
         "failing-matrix-deprecation-docs",
     ),
     (
         "migration(python): bump minimum interpreter to 3.12",
+        None,
         None,
         False,
         "failing-matrix-migration-python",
@@ -539,6 +605,7 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
         # Package-tier accept: scope matches the contained package.
         "feature(agent-auth): add JIT approval flow for prompt-tier scope",
         ["packages/agent-auth/src/agent_auth/cli.py"],
+        None,
         True,
         "passing-pkg-tier-agent-auth",
     ),
@@ -547,6 +614,7 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
         # but claims a fictional `(server)` scope.
         "feature(server): rename the listener entrypoint",
         ["packages/agent-auth/src/agent_auth/server.py"],
+        None,
         False,
         "failing-pkg-tier-server-on-agent-auth",
     ),
@@ -554,6 +622,7 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
         # Area-tier accept: workflow tweak under (ci).
         "chore(ci): pin merge-bot action to a SHA",
         [".github/workflows/merge-bot.yml"],
+        None,
         True,
         "passing-area-tier-ci",
     ),
@@ -562,6 +631,7 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
         # issue body calls out — the validator must point at `(ci)`.
         "improvement(merge-bot): post link to merged PR in slack",
         [".github/workflows/merge-bot.yml"],
+        None,
         False,
         "failing-area-tier-merge-bot",
     ),
@@ -570,6 +640,7 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
         # — the validator points at `(release)`.
         "fix(release-pr): drop stale changelog YAMLs after publish",
         [".github/workflows/release-pr.yml"],
+        None,
         False,
         "failing-area-tier-release-pr",
     ),
@@ -581,6 +652,7 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
             "packages/agent-auth/src/agent_auth/http.py",
             "packages/gpg-bridge/src/gpg_bridge/http.py",
         ],
+        None,
         True,
         "passing-multi-package-bare-scope",
     ),
@@ -597,6 +669,7 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
             "packages/agent-auth/src/agent_auth/http.py",
             "packages/gpg-bridge/src/gpg_bridge/http.py",
         ],
+        None,
         False,
         "failing-multi-package-pkg-scope",
     ),
@@ -604,6 +677,7 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
         # Cross-cutting changes (root config, docs) accept bare scope.
         "chore: standardise YAML extension on .yml",
         ["Taskfile.yml", "CHANGELOG.md"],
+        None,
         True,
         "passing-cross-cutting-bare-scope",
     ),
@@ -616,17 +690,69 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, bool, str], ...] = (
         # through to the area-tier "pick from AREA_SCOPES" hint.
         "feature(novel): scaffold a new package",
         ["packages/novel/src/novel/__init__.py"],
+        None,
         False,
         "failing-unregistered-package-dir",
+    ),
+    # Suffix-aware length rule (#399). The merge bot appends
+    # ``(#<n>)`` to the squash-merge subject so GitHub renders it as
+    # a clickable link in the commit log; ``check_length`` budgets
+    # for the suffix at PR-author time when ``--pr-number`` is
+    # threaded in. Three fixtures cover the matrix:
+    #
+    # - the un-suffixed title fits but the projected total exceeds
+    #   the cap (the regression these fixtures exist to catch);
+    # - both un-suffixed and suffixed totals fit (positive control);
+    # - the un-suffixed title already overflows the cap (the error
+    #   message must still surface both lengths so the contributor
+    #   sees that the title alone is the binding constraint).
+    (
+        # 72-char title + " (#9999)" (8 chars) = 80-char projected
+        # subject, 8 over the cap. The un-suffixed title sits exactly
+        # at the 72-char cap so the un-suffixed-only length check
+        # accepts it; only the suffix-aware path catches the overflow.
+        # Without the suffix-aware rule the bug from the issue body's
+        # example would land verbatim on `main` (the bot appends the
+        # suffix at merge time and GitHub silently truncates the
+        # commit subject in the commit log view).
+        "improvement(agent-auth): tighten the JIT approval audit-log emit pathway",
+        None,
+        9999,
+        False,
+        "failing-suffixed-overflow",
+    ),
+    (
+        # 47-char title + " (#9999)" (8 chars) = 55-char projected
+        # subject, well under the 72-char cap. Positive control: the
+        # suffix-aware path must accept titles that leave headroom.
+        "improvement(agent-auth): tighten audit log emit",
+        None,
+        9999,
+        True,
+        "passing-suffixed-fits",
+    ),
+    (
+        # 84-char un-suffixed title — the existing failing-too-long
+        # fixture, this time with a PR number passed in. Catches the
+        # regression where the suffix-aware path drops the title
+        # length out of the error message: the contributor must still
+        # see both totals (un-suffixed length + suffix width = projected
+        # total) so they know the title alone is over the cap, not the
+        # suffix.
+        "fix(very-long-scope): a summary that runs on and on past the seventy two char cap easy",
+        None,
+        9999,
+        False,
+        "failing-too-long-with-pr-number",
     ),
 )
 
 
 def _run_self_test() -> int:
     fail = 0
-    for title, changed_files, expect_pass, label in _SELF_TEST_CASES:
+    for title, changed_files, pr_number, expect_pass, label in _SELF_TEST_CASES:
         try:
-            validate(title, changed_files)
+            validate(title, changed_files, pr_number)
         except TitleValidationError as err:
             if expect_pass:
                 print(f"FAIL: {label}: expected pass, got {err}", file=sys.stderr)
@@ -697,6 +823,21 @@ def main(argv: list[str] | None = None) -> int:
             "`gh pr view --json files --jq '.files[].path'`."
         ),
     )
+    parser.add_argument(
+        "--pr-number",
+        default=None,
+        type=int,
+        metavar="N",
+        help=(
+            "PR number this title belongs to. When provided, the 72-char "
+            "length cap is applied to the *projected* squash-merge subject "
+            "(un-suffixed title + ` (#<n>)`), since `merge-bot.yml` "
+            "appends the suffix at merge time so GitHub renders the "
+            "commit subject as a clickable link in the commit log. The "
+            "`pr-title-style` job in pr-lint.yml passes "
+            "`github.event.pull_request.number`. See #399."
+        ),
+    )
     args = parser.parse_args(argv)
     if args.self_test:
         return _run_self_test()
@@ -706,7 +847,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.changed_files_from is not None:
         changed_files = _read_changed_files(args.changed_files_from)
     try:
-        validate(args.title, changed_files)
+        validate(args.title, changed_files, args.pr_number)
     except TitleValidationError as err:
         print(f"pr-title: {err}", file=sys.stderr)
         return 1

--- a/scripts/validate-pr-title.py
+++ b/scripts/validate-pr-title.py
@@ -732,7 +732,7 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, int | None, bool, str], ...
         "passing-suffixed-fits",
     ),
     (
-        # 84-char un-suffixed title — the existing failing-too-long
+        # 86-char un-suffixed title — the existing failing-too-long
         # fixture, this time with a PR number passed in. Catches the
         # regression where the suffix-aware path drops the title
         # length out of the error message: the contributor must still
@@ -744,6 +744,21 @@ _SELF_TEST_CASES: tuple[tuple[str, list[str] | None, int | None, bool, str], ...
         9999,
         False,
         "failing-too-long-with-pr-number",
+    ),
+    (
+        # 72-char title with ``pr_number=None`` — positive control for
+        # the un-suffixed boundary that local invocations and the
+        # ``pr-title-self-test`` job rely on. Locks down the no-
+        # ``--pr-number`` path so a future regression that re-applies
+        # the suffix-aware cap (e.g. a refactor of ``_projected_suffix``
+        # that returns ``" (#)"`` for the ``None`` case, eating four
+        # chars of headroom) trips the self-test instead of landing
+        # silently.
+        "improvement(agent-auth): tighten the JIT approval audit-log emit pathway",
+        None,
+        None,
+        True,
+        "passing-unsuffixed-at-cap",
     ),
 )
 


### PR DESCRIPTION
## Summary

`merge-bot.yml` calls `PUT /pulls/{n}/merge` to land the squash-merge
commit. Unlike GitHub's web UI "Squash and merge" button, the REST
endpoint does not auto-append the `(#<n>)` PR-number suffix to the
commit subject. Without it, the resulting commit subjects (e.g.
[`7ab4c6a`](https://github.com/aidanns/agent-auth/commit/7ab4c6a90a1b283dbd12fce0a89af3642d1ca259) — `chore: standardise YAML extension on .yml`)
do not render as clickable links to the originating PR in `git log` /
the GitHub commit log view, breaking the bisect-and-trace workflow
that pre-merge-bot squashes (e.g. [`f72b2a2`](https://github.com/aidanns/agent-auth/commit/f72b2a2)) supported.

This PR threads the PR number through the merge-bot's title arg
(`commit_title="${PR_TITLE} (#${PR_NUMBER})"`) and updates the
PR-title length lint to budget for the suffix at PR-author time so
the 72-char hard cap on the squash subject still holds. Per the
issue body's option (2): the documented limit holds.

## Changes

- `scripts/validate-pr-title.py` — `check_length` gains a
  `pr_number: int | None` parameter; when provided, the cap is
  applied to `len(title) + len(" (#<n>)")` and the error message
  surfaces both the un-suffixed length and the suffix width so a
  contributor sees which constraint is binding. New `--pr-number N`
  CLI flag (kept optional so the no-pr-number path still works
  inline / locally).
- `.github/workflows/pr-lint.yml` — `pr-title-style` job passes
  `--pr-number` through the same env-var pattern the title already
  uses (`PR_NUMBER: ${{ github.event.pull_request.number }}` →
  `--pr-number "${PR_NUMBER}"`), keeping the
  `pull_request_target` workflow off CodeQL's
  `js/actions/command-injection` flagged channel.
- `.github/workflows/merge-bot.yml` — append ` (#${PR_NUMBER})` to
  `commit_title`. The existing idempotency guards (early-exit on
  state != OPEN, `Re-check PR is still open` step, "already been
  merged" → no-op) are untouched.
- Self-test fixtures — three new cases (suffix-aware overflow,
  positive control, un-suffixed-overflow with PR number passed)
  cover the new length-math branch. Existing fixtures keep
  `pr_number=None` so they stay focused on the rules they were
  written for.
- `CONTRIBUTING.md` + `docs/release/merge-bot-setup.md` — note the
  suffix and the projected-subject accounting.

## Internal decisions

- CLI arg shape: `--pr-number N` (explicit, mirrors
  `--changed-files-from`). Env-var threading was rejected because
  CLI args are easier to test locally and read against the existing
  `--self-test` / `--changed-files-from` flag set.
- Helper named `_projected_suffix` keeps the suffix string in one
  place; the bot's `commit_title="${PR_TITLE} (#${PR_NUMBER})"` is
  the single source of truth and the helper mirrors it verbatim.
- The validator's existing `check_length` un-suffixed error message
  is preserved for the `--pr-number=None` path so locally-invoked
  validations (no PR context) keep their existing diagnostic.

==COMMIT_MSG==
chore(ci): merge-bot append PR number to squash subjects

The `PUT /pulls/{n}/merge` REST endpoint does not auto-append the
`(#<n>)` PR-number suffix the way the web UI's "Squash and merge"
button does. Without it, GitHub does not render the commit subject
as a clickable link to the originating PR in the commit log — the
existing `7ab4c6a` "chore: standardise YAML extension on .yml" lands
flat in `git log`, while pre-merge-bot squashes (e.g. `f72b2a2`) keep
the `(#335)` suffix and link cleanly.

Fix the bot's `commit_title` arg to append ` (#<n>)` explicitly, and
budget for the suffix at PR-author time so the 72-char hard cap on
the squash subject still holds: `validate-pr-title.py` gains a
`--pr-number` flag and `pr-lint.yml`'s `pr-title-style` job passes
`github.event.pull_request.number` through the same env-var pattern
the title already uses (keeps the `pull_request_target` workflow off
CodeQL's `js/actions/command-injection` flagged channel). The
validator's error message surfaces both the un-suffixed length and
the suffix width so a contributor whose 70-char title now fails sees
which constraint is binding.

Three new self-test fixtures (suffix-aware overflow, positive
control, un-suffixed-overflow with PR number passed) cover the new
length-math branch; the existing fixtures keep `pr_number=None` so
they stay focused on the rules they were written for.

Closes #399
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

### Test plan

- [ ] `python3 scripts/validate-pr-title.py --self-test` passes locally (28 cases).
- [ ] `python3 scripts/validate-pr-title.py --pr-number 9999 "improvement(agent-auth): tighten the JIT approval audit-log emit pathway"` exits 1 with the suffix-aware error message (un-suffixed 72, suffix 8, projected 80).
- [ ] `python3 scripts/validate-pr-title.py --pr-number 9999 "chore(ci): merge-bot append PR number to squash subjects"` exits 0.
- [ ] CI's `PR title validator self-test` job passes against this PR.
- [ ] CI's `PR title (subject style)` job passes against this PR's own title with `--pr-number` threaded in.
- [ ] On merge, the squash commit subject in `main` reads `chore(ci): merge-bot append PR number to squash subjects (#<this-pr>)` and renders as a clickable link in the GitHub commit log.

Closes #399
