### PR TITLE
chore(ci): add Co-Authored-By trailer fixture

### DIFF
--- a/.github/workflows/tests/pr-lint-fixtures/invalid-blank-before-co-authored-by.md
+++ b/.github/workflows/tests/pr-lint-fixtures/invalid-blank-before-co-authored-by.md
@@ -1,0 +1,17 @@
+==COMMIT_MSG==
+Add a thing.
+
+The body has a blank line between `Closes #N` and the
+`Co-Authored-By:` trailer (mixed-case spelling).
+`git interpret-trailers --parse` would treat the blank as the
+body/trailer boundary and silently drop both `Closes` and the
+co-author attribution from the trailer set, so the validator must
+reject this shape. The mixed-case `Co-Authored-By:` matches the
+canonical `Co-authored-by` token case-insensitively, so this fixture
+also pins the case-insensitive token recognition path.
+
+Closes #403
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
+==COMMIT_MSG==

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -895,8 +895,15 @@ So the canonical shape is:
 <body paragraph>
 
 Closes #NNN
+Co-authored-by: <name> <email>
 Signed-off-by: <name> <email>
 ```
+
+`Co-authored-by:` is the canonical case (matching git's
+`interpret-trailers` and GitHub's co-author rendering), but token
+matching is case-insensitive — `Co-Authored-By:` from a pair-bot or
+copy-paste is recognised the same way and must stack contiguously
+with the other trailers.
 
 #### Worked examples
 
@@ -955,6 +962,7 @@ in a tight loop with a candidate token whose first byte matches.
 
 Fixes: 9c4f1a2b3d5e ("improvement(tokens): inline parse_token hot path")
 Closes #456
+Co-authored-by: A. Reviewer <reviewer@example.com>
 Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
 ==COMMIT_MSG==
 


### PR DESCRIPTION
==COMMIT_MSG==
chore(ci): add Co-Authored-By trailer fixture

`Co-Authored-By:` is a trailer in the same RFC-5322 / kernel sense as
`Closes:` and `Signed-off-by:`, so a blank line above it would cause
`git interpret-trailers --parse` to silently drop both the
co-authorship attribution and any trailers stacked above it. The
contiguity check from #400 already covers this since
`KNOWN_TRAILER_TOKENS` includes `Co-authored-by` and the token match
is case-insensitive, but the rule was uncovered by the fixture suite
so a future regression that skipped mixed-case `Co-Authored-By:`
recognition would land silently.

Add a fixture that places a blank line between `Closes #N` and a
mixed-case `Co-Authored-By:` line — the validator must reject it.
The fixture also exercises the case-insensitive token recognition
path so a future change that narrowed `is_trailer_token` to exact
case would fail CI rather than ship.

Extend the canonical-shape and `fix:` worked examples in
CONTRIBUTING.md to show `Co-authored-by:` stacked contiguously with
`Closes` / `Signed-off-by:` so a contributor copying either example
gets the rule right.

Closes #403
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

### Test plan

- [ ] CI: `validator-self-test` job iterates the new fixture and
      asserts exit 1.
- [ ] Manual:
      `python3 scripts/validate-commit-msg-block.py .github/workflows/tests/pr-lint-fixtures/invalid-blank-before-co-authored-by.md`
      exits 1 with a "blank line(s) between trailers" error naming
      `Closes #403` and `Co-Authored-By: ...` as the trailers
      straddling the blank.
- [ ] Manual: every existing valid / invalid fixture still produces
      its expected exit code (loop the fixture directory locally).