### PR TITLE
chore(ci): submit dependency snapshot on pull_request

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -8,14 +8,25 @@
 # treefmt, go-task, d2, uv, mdformat + plugins). See ADR 0031.
 #
 # Renovate owns the bump channel (custom managers in .github/renovate.json);
-# this workflow owns the CVE-alert channel. Runs on push to main and on
-# a weekly cron so the snapshot stays current. No pull_request trigger —
-# a PR cannot rewrite the snapshot for its own sha.
+# this workflow owns the CVE-alert channel. Runs on push to main, on a
+# weekly cron, and on every pull_request so the dependency-review action
+# (.github/workflows/dependency-review.yml) has a head-SHA snapshot to
+# diff against — without it, dep-review prints "No snapshots were found
+# for the head SHA <sha>" and any tool-versions.yml bump to a CVE-bearing
+# version slips past the PR-time gate (issue #412).
+#
+# Snapshots are keyed by head SHA, so a PR-triggered submission against
+# the PR's own head does not overwrite main's snapshot — nothing is
+# rewritten. Fork PRs receive a read-only GITHUB_TOKEN, so the POST
+# would 403; the job-level `if:` guard skips submission cleanly on fork
+# PRs while leaving push / cron / workflow_dispatch unaffected.
 
 name: Dependency Submission
 
 on:
   push:
+    branches: [main]
+  pull_request:
     branches: [main]
   schedule:
     # Weekly at 04:00 UTC on Mondays — same cadence as Renovate bump runs
@@ -31,6 +42,10 @@ jobs:
   submit:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Skip on fork PRs: GITHUB_TOKEN is read-only there, so the POST
+    # would 403 and fail the job. Push / cron / workflow_dispatch always
+    # run in the main repo context and are unaffected.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -79,8 +79,13 @@ on:
   # the bot. Adding a new required-check workflow requires updating
   # this list — that's intentional. Excludes:
   #   - Merge Bot itself (anti-recursion).
-  #   - Release / publish / scorecard / dependency-submission /
-  #     mutation / benchmark workflows that don't run on PRs.
+  #   - Release / publish / scorecard / mutation / benchmark workflows
+  #     that don't run on PRs.
+  #   - Dependency Submission, which now runs on PRs (issue #412) but
+  #     intentionally skips on fork PRs (read-only GITHUB_TOKEN), so
+  #     it can't be a required gate without blocking external
+  #     contributions; PR-time CVE gating is enforced by Dependency
+  #     Review against the head-SHA snapshot it produces.
   #   - Release Tag (only fires on PR `closed`, well after merge).
   workflow_run:
     workflows:

--- a/design/decisions/0031-renovate-custom-managers-and-dependency-submission.md
+++ b/design/decisions/0031-renovate-custom-managers-and-dependency-submission.md
@@ -102,8 +102,12 @@ signal.
 - Snapshot uses PURLs (`pkg:github/koalaman/shellcheck@v0.10.0`,
   `pkg:pypi/mdformat@0.7.22`, …) so Dependabot Alerts fire on the
   same advisory ingestion path as any first-class ecosystem.
-- Runs on each push to `main` and on a weekly cron so the snapshot
-  stays current between pushes.
+- Runs on each push to `main`, on every `pull_request` (so the
+  PR-time `dependency-review-action` has a head-SHA snapshot to diff
+  against — without it, dep-review prints "No snapshots were found for
+  the head SHA" and a `tool-versions.yml` bump to a CVE-bearing
+  version slips past the PR gate, issue #412), and on a weekly cron
+  so the snapshot stays current between pushes.
 
 ### Verification
 
@@ -135,9 +139,16 @@ a dropped config would silently regress the whole policy.
   captured in-repo. The config ships ready; enabling it is a
   checkbox in the Renovate dashboard.
 - The Dependency Submission workflow runs with
-  `contents: write, id-token: none` and is gated on the push/schedule
-  trigger — no pull-request path — so a malicious PR cannot poison
-  the snapshot.
+  `contents: write, id-token: none`. It now also runs on
+  `pull_request` (issue #412) so the PR-time `dependency-review-action`
+  has a head-SHA snapshot to diff against. A PR-triggered submission
+  is keyed by the PR's head SHA, so it cannot rewrite `main`'s
+  snapshot — nothing is poisoned. Fork PRs receive a read-only
+  `GITHUB_TOKEN` (the POST would 403); the job-level `if:` guard
+  skips submission cleanly on those, accepted as a coverage gap for
+  the solo-maintained repo. `pull_request_target` was rejected
+  because it would execute PR-author code with elevated token
+  permissions for marginal benefit at this scale.
 
 **Follow-up gaps (none blocking):**
 


### PR DESCRIPTION
==COMMIT_MSG==
chore(ci): submit dependency snapshot on pull_request

Without a head-SHA snapshot, actions/dependency-review-action prints
"No snapshots were found for the head SHA <sha>" on every PR and
silently downgrades to native pyproject.toml parsing. The CI tools
declared in .github/tool-versions.yml (shellcheck, ruff, uv, ...) are
not exercised by the PR-time CVE gate, so a PR bumping one of those
to a CVE-bearing version slips past dep-review and only surfaces in
the next Monday cron-driven main-branch snapshot.

Add `pull_request` to dependency-submission.yml's trigger list so
the snapshot is also submitted for the PR head SHA. Snapshots are
keyed by SHA, so a PR-triggered submission cannot rewrite main's
snapshot — the original "no pull_request trigger" rationale was
outdated. Fork PRs receive a read-only GITHUB_TOKEN, so the POST
would 403; a job-level `if:` guard skips submission cleanly on fork
PRs while leaving push / cron / workflow_dispatch unaffected. The
condition is written in the skip-only-on-fork-PR direction
(`event_name != 'pull_request' || head.repo == repo`) so adding new
non-pull_request triggers later doesn't accidentally gate them on
the fork check.

Update ADR 0031 to reflect the new trigger and replace the
"no pull-request path — malicious PR cannot poison the snapshot"
rationale with the head-SHA-keying argument plus the fork-skip
mitigation. Update merge-bot.yml's exclusion comment so the
dependency-submission line is no longer claimed to "not run on
PRs"; it does run on PRs but is intentionally not a required gate
because making it required would block fork PRs from ever merging.

Closes #412
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

Internal implementation choices, resolved per the dispatch instructions:

- **Guard direction:** chose `if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository` (skip-only-on-fork-PR) over the equivalent `event_name == 'pull_request' && head.repo == repo` form. The chosen form means non-`pull_request` triggers (push / cron / workflow_dispatch) keep running unchanged regardless of the fork-context fields, which is the safer default for any future trigger added to the `on:` list.
- **No `paths:` filter on `pull_request`:** the issue's first acceptance criterion is that the dep-review "No snapshots were found" warning disappears on _every_ PR, not just PRs that touch `tool-versions.yml`. A `paths:` filter would re-introduce the warning on every other PR.
- **ADR 0031 update:** the previous "no pull-request path — malicious PR cannot poison the snapshot" trade-off is now incorrect, so it's replaced with the head-SHA-keying argument plus the fork-skip mitigation. The ADR's overall decision (Renovate + Dependency Submission API) is unchanged.
- **merge-bot comment update:** `Dependency Submission` is now run on PRs but stays off the merge-bot `workflow_run` list because making it a required gate would block every fork PR from merging. The exclusion comment is updated to call this out so a future maintainer doesn't promote it without realising.
- **CodeQL audit:** `dependency-submission.yml` has a single `run:` step that invokes `bash scripts/ci/submit-dependency-snapshot.sh` with no inline `${{ }}` interpolation of PR-author-controlled fields. No `env:`-block conversion required.

### Test plan

- [ ] After this PR opens, the `Dependency Review` comment on the PR's head SHA does NOT include the "No snapshots were found for the head SHA" warning. (Acceptance criterion #1 — verified post-push.)
- [ ] A new `Dependency Submission` workflow run appears on this PR's head SHA in the Actions tab and reports a successful POST. (Sanity check that the trigger fires and the guard does not skip on a same-repo PR.)
- [ ] CVE-bumping fixture (acceptance criterion #2 in the issue) — left for manual verification by the user; out of scope for this PR per the dispatch instructions.
