### PR TITLE
improvement(release): drop redundant "Release vX.Y.Z." line

### DIFF
--- a/changelog/@unreleased/pr-425-drop-redundant-release-version-paragraph.yml
+++ b/changelog/@unreleased/pr-425-drop-redundant-release-version-paragraph.yml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+type: improvement
+improvement:
+  description: |
+    Release-PR squash-merge commit bodies (rendered by
+    `render_commit_msg_block`) no longer open with a redundant
+    `Release vX.Y.Z.` paragraph — the version is already in the
+    `chore(release): X.Y.Z` subject, so the body now opens directly
+    with the first per-section paragraph (`Improvements: ...`,
+    `Fixes: ...`). `render_release_notes` (the GitHub Release surface)
+    keeps its `Release vX.Y.Z.` header where the version is
+    load-bearing.
+  links:
+    - https://github.com/aidanns/agent-auth/issues/396
+    - https://github.com/aidanns/agent-auth/pull/425

--- a/scripts/changelog/build_release.py
+++ b/scripts/changelog/build_release.py
@@ -378,9 +378,14 @@ def render_commit_msg_block(entries: Sequence[ChangelogEntry], next_version: str
     ``DISALLOWED_PATTERNS`` (markdown headings, task checkboxes,
     image embeds) still pass trivially — the renderer emits none
     of those.
+
+    The body opens directly with the first per-section paragraph
+    (e.g. ``Improvements: ...``); the ``chore(release): X.Y.Z``
+    subject already conveys the version, so a leading
+    ``Release vX.Y.Z.`` paragraph would only duplicate it (#396).
     """
     grouped = _grouped(entries)
-    paragraphs: list[str] = [f"Release v{next_version}."]
+    paragraphs: list[str] = []
     for entry_type in SECTION_ORDER:
         bucket = grouped[entry_type]
         if not bucket:


### PR DESCRIPTION
==COMMIT_MSG==
improvement(release): drop redundant "Release vX.Y.Z." line

The release-PR commit body opened with `Release v{next_version}.`,
which only duplicated information already in the
`chore(release): X.Y.Z` subject. `git log --oneline` plus the body's
first paragraph repeated the version verbatim, padding every release
commit with a no-information line. Drop the seed paragraph from
`render_commit_msg_block` so the body opens directly with the first
per-section paragraph (`Improvements: ...`, `Fixes: ...`).

`render_release_notes` (the GitHub Release surface) keeps its
`Release vX.Y.Z.` opener — that surface is consumed in isolation
and the version header is load-bearing there. `render_pr_body`'s
`## Review notes` section also keeps the version reference; that
text is dropped at squash-merge time and never enters git history.

Closes #396
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

## Review notes

The `render_commit_msg_block` change is a one-line edit: the
`paragraphs` list seed drops from `[f"Release v{next_version}."]`
to `[]`. Existing test assertions on `Release v...` are all on
`render_release_notes` / the `render-notes` CLI path (not the
commit-msg block), so no test edits were required. The validator
integration test (`test_render_pr_body_passes_validate_commit_msg_block`)
still passes — trailer-block contiguity (#400) and the SHA-shape
exception (#420) are unaffected, and the verbose-body soft cap
from #422 only sees the body shorten by one line.

### Test plan

- [ ] `uv run python -m pytest -o addopts= scripts/changelog/tests/test_build_release.py` — full suite passes (26 tests).
- [ ] `uv run python -m pytest -o addopts= scripts/changelog/tests/test_build_release.py::test_render_pr_body_passes_validate_commit_msg_block` — validator integration test passes.
- [ ] Render a sample commit-msg block manually and confirm it opens with `Improvements: ...` (not `Release v...`).
