### PR TITLE
improvement(release): bullet entries within section headings

### DIFF
--- a/changelog/@unreleased/pr-430-bullet-section-entries.yml
+++ b/changelog/@unreleased/pr-430-bullet-section-entries.yml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+type: improvement
+improvement:
+  description: |
+    The release-PR `==COMMIT_MSG==` block now emits one bullet per
+    changelog entry under each section heading, regardless of entry
+    count. The shape is identical for single-entry and multi-entry
+    sections, so `git log` and the GitHub release page scan
+    uniformly. Replaces the historical semicolon-joined prose
+    paragraph per section.
+  links:
+    - https://github.com/aidanns/agent-auth/issues/397
+    - https://github.com/aidanns/agent-auth/pull/430

--- a/design/decisions/0041-yaml-driven-release-workflow.md
+++ b/design/decisions/0041-yaml-driven-release-workflow.md
@@ -112,11 +112,14 @@ workflow that handles tag + GitHub-Release creation lives in
   implementation in shell or workflow YAML to drift.
 - **`==COMMIT_MSG==` block in the release PR.** The PR body is
   auto-rendered to satisfy `pr-lint.yml`'s commit-msg-block
-  validator: prose-only paragraphs (no markdown bullets, no
-  headings), wrapped at 72 chars, single `Signed-off-by:` trailer.
-  The release notes (the human-friendly view) live below the block
-  in the `## Review notes` section, alongside the file-move list and
-  the rendered CHANGELOG section preview.
+  validator: each section heading (`Improvements:`, `Fixes:`,
+  ...) is followed by one bullet per entry (#397, replacing the
+  pre-#397 semicolon-joined prose paragraph), wrapped at 72
+  chars, single `Signed-off-by:` trailer. Markdown headings,
+  task checkboxes, and image embeds remain banned. The release
+  notes (the human-friendly view) live below the block in the
+  `## Review notes` section, alongside the file-move list and the
+  rendered CHANGELOG section preview.
 - **Bypass for `changelog-lint.yml` on `release/*` branches.** A
   release PR DELETES every `@unreleased/*.yml` (renaming them under
   `<X.Y.Z>/`) rather than adding one, so the file-presence check

--- a/scripts/changelog/build_release.py
+++ b/scripts/changelog/build_release.py
@@ -304,10 +304,13 @@ def render_release_notes(entries: Sequence[ChangelogEntry], next_version: str) -
     :data:`COMMIT_MSG_WRAP` characters.
 
     The release-PR ``==COMMIT_MSG==`` block has its own renderer
-    (``render_commit_msg_block``) that emits prose-only — bullets
-    here are fine for the GitHub Release surface but the per-PR
-    commit body deliberately collapses them to semicolon-joined
-    sentences, see that function's docstring.
+    (``render_commit_msg_block``) that emits the same
+    heading-plus-bullets shape (#397). The GitHub Release body
+    accepts arbitrary markdown either way; this renderer keeps
+    its leading ``Release vX.Y.Z.`` header where the version is
+    load-bearing, while the commit-msg renderer omits it because
+    the ``chore(release): X.Y.Z`` subject already carries the
+    version.
 
     The shape:
 
@@ -323,12 +326,6 @@ def render_release_notes(entries: Sequence[ChangelogEntry], next_version: str) -
         ...
 
     The leading bullets here are emitted with a single ``- `` prefix.
-    Bullets are valid in the *==COMMIT_MSG== block* too post-#345,
-    but ``render_commit_msg_block`` historically emits semicolon-
-    joined prose and there is no reason to change that purely on
-    the back of the validator relaxation. ``render_release_notes``
-    is the GitHub Release body; that surface accepts arbitrary
-    markdown either way.
     """
     grouped = _grouped(entries)
     parts: list[str] = [f"Release v{next_version}.", ""]
@@ -364,52 +361,77 @@ def render_commit_msg_block(entries: Sequence[ChangelogEntry], next_version: str
 
     Differs from ``render_release_notes`` in that:
 
-    - No markdown bullets — prose is grouped by type and joined
-      with semicolons.
+    - No ``Release vX.Y.Z.`` header — the
+      ``chore(release): X.Y.Z`` subject already conveys the
+      version (#396).
     - Lines wrap at :data:`COMMIT_MSG_WRAP` chars.
 
-    The bullet ban here is a *historical* shape, not a hard
-    requirement: pre-#345 the validator's ``DISALLOWED_PATTERNS``
-    rejected bullets in the block, and this renderer was written
-    around that. Post-#345 plain bullets are valid in the block,
-    but the semicolon-joined prose form remains the renderer's
-    output because it predates the relaxation and there is no
-    behavioural reason to churn it. The validator's remaining
-    ``DISALLOWED_PATTERNS`` (markdown headings, task checkboxes,
-    image embeds) still pass trivially — the renderer emits none
-    of those.
+    The shape per section is a heading line followed by one
+    bullet per entry, regardless of how many entries land in the
+    section. Single-entry sections render the same way as
+    multi-entry ones so the body is uniformly scannable in
+    ``git log`` and on the GitHub release page (#397):
 
-    The body opens directly with the first per-section paragraph
-    (e.g. ``Improvements: ...``); the ``chore(release): X.Y.Z``
-    subject already conveys the version, so a leading
-    ``Release vX.Y.Z.`` paragraph would only duplicate it (#396).
+        Improvements:
+        - <description 1>
+        - <description 2>
+
+    Pre-#345 the validator's ``DISALLOWED_PATTERNS`` rejected
+    bullets in the block, so this renderer originally emitted
+    semicolon-joined prose. Post-#345 plain bullets are valid in
+    the block; #397 switched to bullets because they scan more
+    cleanly than a giant prose paragraph per heading. The
+    validator's remaining ``DISALLOWED_PATTERNS`` (markdown
+    headings, task checkboxes, image embeds) still pass trivially
+    — the renderer emits none of those.
     """
     grouped = _grouped(entries)
-    paragraphs: list[str] = []
+    sections: list[str] = []
     for entry_type in SECTION_ORDER:
         bucket = grouped[entry_type]
         if not bucket:
             continue
-        # One paragraph per group: "<heading>: <desc1>; <desc2>; ...".
-        sentences = [_flatten_description(entry.description) for entry in bucket]
-        paragraph = f"{SECTION_HEADINGS[entry_type]}: " + "; ".join(sentences)
-        if not paragraph.endswith("."):
-            paragraph += "."
-        paragraphs.append(_wrap_paragraph(paragraph, COMMIT_MSG_WRAP))
-    return "\n\n".join(paragraphs)
+        # One section per group: a heading line followed by one
+        # bullet per entry. Each bullet is wrapped to
+        # COMMIT_MSG_WRAP with continuation lines indented two
+        # spaces so wrapped prose visually nests under its bullet.
+        section_lines: list[str] = [f"{SECTION_HEADINGS[entry_type]}:"]
+        for entry in bucket:
+            sentence = _flatten_description(entry.description)
+            if not sentence.endswith("."):
+                sentence += "."
+            section_lines.append(_wrap_bullet(sentence, COMMIT_MSG_WRAP))
+        sections.append("\n".join(section_lines))
+    return "\n\n".join(sections)
+
+
+def _wrap_bullet(text: str, width: int) -> str:
+    """Render ``text`` as a ``- ``-prefixed bullet wrapped at ``width``.
+
+    Continuation lines are indented two spaces so the wrapped
+    prose visually nests under the bullet marker. Reuses
+    :func:`_wrap_paragraph` for the underlying width / numeric-
+    token handling, then prepends the marker / continuation
+    indent line by line.
+    """
+    wrapped = _wrap_paragraph(text, width - 2)
+    lines = wrapped.splitlines() or [""]
+    out = [f"- {lines[0]}"]
+    for line in lines[1:]:
+        out.append(f"  {line}")
+    return "\n".join(out)
 
 
 def _flatten_description(text: str) -> str:
     """Collapse a multi-line YAML description into a single sentence.
 
     YAML `description: |` block scalars routinely span multiple lines
-    (the schema encourages prose). The renderer historically emits
-    semicolon-joined prose into the ==COMMIT_MSG== block (the
-    pre-#345 bullet ban shaped this; the shape is kept post-#345
-    for stability — see ``render_commit_msg_block``). Each entry
-    is therefore collapsed to a single semicolon-separated phrase.
-    Trailing periods are trimmed so the final paragraph period
-    (added by the caller) doesn't double up.
+    (the schema encourages prose). The ==COMMIT_MSG== block renders
+    one bullet per entry (#397), and a bullet body wraps cleaner if
+    the source prose is one logical sentence rather than a sequence
+    of hard-wrapped fragments — so the renderer collapses internal
+    newlines to spaces here. Trailing periods are trimmed so the
+    final period (re-added by the caller) doesn't double up.
     """
     flat = " ".join(line.strip() for line in text.splitlines() if line.strip())
     return flat.rstrip(".")

--- a/scripts/changelog/tests/test_build_release.py
+++ b/scripts/changelog/tests/test_build_release.py
@@ -276,6 +276,60 @@ def test_render_commit_msg_block_keeps_lines_under_72(repo: Path) -> None:
         assert len(line) <= 72, f"line too wide: {line!r}"
 
 
+# --- bullet shape (#397) ----------------------------------------------------
+#
+# The ==COMMIT_MSG== block historically joined entries with `; ` into
+# a single prose paragraph per section heading. That shape was hard
+# to scan once a release accumulated several entries, and the
+# inconsistency between single-entry sections (one prose sentence)
+# and multi-entry sections (semicolon-joined run-on) was the worst
+# of it. #397 switched the renderer to always emit a bulleted list
+# under each section heading, regardless of entry count.
+#
+# These tests pin the user-visible shape: bullets are present, the
+# semicolon-joined run-on is absent, and the same shape applies to
+# single-entry sections as to multi-entry ones.
+
+
+def test_render_commit_msg_block_emits_bullet_per_entry_in_multi_entry_section(
+    repo: Path,
+) -> None:
+    """Multi-entry sections render one ``- `` bullet per entry, not ``; ``."""
+    _seed_unreleased(
+        repo,
+        "pr-100-imp-a.yml",
+        "type: improvement\nimprovement:\n  description: First improvement.\n",
+    )
+    _seed_unreleased(
+        repo,
+        "pr-101-imp-b.yml",
+        "type: improvement\nimprovement:\n  description: Second improvement.\n",
+    )
+    plan = compute_release(repo, "0.4.0")
+    assert plan is not None
+    block = render_commit_msg_block(plan.entries, plan.next_version)
+
+    assert "Improvements:\n- First improvement.\n- Second improvement." in block
+    # The historical semicolon-joined run-on must not reappear.
+    assert "; " not in block
+
+
+def test_render_commit_msg_block_emits_bullet_for_single_entry_section(
+    repo: Path,
+) -> None:
+    """Single-entry sections render the same bullet shape as multi-entry."""
+    _seed_unreleased(
+        repo,
+        "pr-100-fix.yml",
+        "type: fix\nfix:\n  description: Only fix.\n",
+    )
+    plan = compute_release(repo, "0.4.0")
+    assert plan is not None
+    block = render_commit_msg_block(plan.entries, plan.next_version)
+
+    assert block == "Fixes:\n- Only fix."
+
+
 # --- numbered-reference wrap regressions ------------------------------------
 #
 # Greedy wrap on 72 chars used to land tokens like `0011.` (from


### PR DESCRIPTION
==COMMIT_MSG==
improvement(release): bullet entries within section headings

The release-PR `==COMMIT_MSG==` block historically rendered each
section as a single prose paragraph with entries joined by `; ` —
hard to scan in `git log` and on the GitHub release page once a
release accumulated more than a couple of entries, and visually
inconsistent across releases (single-entry sections rendered as
one prose sentence; multi-entry sections as a semicolon-joined
run-on).

Switch `render_commit_msg_block` to always emit a bulleted list
under each section heading, regardless of entry count. The shape
is now identical for one-entry and many-entry sections, which
makes `git log` and the release page scan uniformly. Bullets
have been valid in the block since #345 (the historical ban was
the only reason for the semicolon-prose form); the remaining
`DISALLOWED_PATTERNS` (markdown headings, task checkboxes,
image embeds) still pass trivially. Verified the new shape on a
synthesised 5-entry release to confirm it stays under #395's
verbose-body soft cap (32 non-blank lines / 250 words) — 21
lines / 167 words.

Closes #397
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

## Review notes

Manually authored changelog entry will be added once the PR
number is assigned.

### Test plan

- [ ] `uv run pytest scripts/changelog/tests/test_build_release.py` — all existing + 2 new bullet-shape tests pass
- [ ] `uv run pytest scripts/changelog/tests/` — full changelog test suite green (229 tests)
- [ ] Render the current `@unreleased/` bin via the CLI; body opens with `Improvements:` followed by a `- ` bullet (single-entry shape)
- [ ] Synthesised 5-entry render stays under #395's 32-line / 250-word verbose-body soft cap
- [ ] `==COMMIT_MSG==` block of this PR passes `scripts/validate-commit-msg-block.py`