### PR TITLE
chore(ci): migrate mutation.yml into nightly/mutation

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -4,17 +4,19 @@
 
 name: Mutation
 
-# Runtime is O(mutants × focused-test-run) and too expensive for every
-# PR. Run on a nightly schedule to catch regressions within a day of
-# landing, and expose workflow_dispatch so a reviewer can trigger a run
-# on-demand when reviewing a change to a security-critical module.
+# Daily-cadence mutation testing, invoked as a `workflow_call` child
+# of `nightly.yml` (issue #440). Runtime is O(mutants × focused-test-run)
+# and too expensive for every PR; the parent `nightly.yml` cron and
+# its `workflow_dispatch` trigger surface this job on a nightly schedule
+# and on-demand for reviewers touching a security-critical module.
 #
 # ADR 0021 documents the rationale; .claude/instructions/testing-standards.md
 # "Mutation testing on security-critical paths" is the originating standard.
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: "0 4 * * *" # 04:00 UTC nightly
+  workflow_call:
+
+permissions:
+  contents: read
 
 jobs:
   mutation:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,10 +5,10 @@
 name: Nightly
 
 # Orchestrator shell for daily-cadence checks under the uv-style
-# nested workflow_call CI structure (parent issue #440). Daily-cadence
-# checks (e.g. mutation testing, ADR 0021) migrate underneath this
-# orchestrator in follow-up issues; for now the aggregator runs alone
-# and trivially passes so the empty shell can land independently.
+# nested workflow_call CI structure (parent issue #440). Carries the
+# mutation-testing child today (ADR 0021); subsequent daily-cadence
+# checks migrate underneath this orchestrator in follow-up issues
+# and add their job names to the aggregator's `needs:` list.
 on:
   workflow_dispatch:
   schedule:
@@ -21,10 +21,42 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
+  mutation:
+    name: Mutation
+    uses: ./.github/workflows/mutation.yml
+
   required-checks-passed:
+    # Repo-wide aggregator (#440 "Decisions (locked in)"): a single
+    # `Required checks passed` status check sits at the top of each
+    # parent orchestrator and gates its child workflows. Subsequent
+    # migration issues add each `workflow_call` child workflow's job
+    # name to `needs:` here.
     name: Required checks passed
+    needs: [mutation]
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Aggregate required-checks result
-        run: echo "all required checks passed"
+      - name: Verify all required checks passed
+        # Pass `needs` through `env:` so the JSON survives shell
+        # quoting verbatim — child job names that contain colons or
+        # quotes would otherwise break the inline expansion. `jq -e`
+        # exits non-zero on a `false` boolean, so the step fails
+        # whenever any upstream `needs.*.result` is anything other
+        # than `success`. Per issue #441 ("fails on any
+        # failed/skipped/timed-out result"), `skipped` is treated as
+        # a failure alongside `failure`, `cancelled`, and `timed_out`
+        # — a child workflow that legitimately opts out via `if:`
+        # will need to surface a `success` result (e.g. via a
+        # short-circuit step) rather than skipping the job
+        # altogether.
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "${NEEDS}" \
+            | jq -e 'to_entries | all(.value.result == "success")' \
+            > /dev/null

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -2077,23 +2077,30 @@ if threshold is None:
 fi
 rm -f /tmp/verify-standards-mutation.err
 
+mutation_missing=0
+
+fail_mutation_check() {
+  echo "verify-standards: $1" >&2
+  echo "  $2" >&2
+  mutation_missing=1
+}
+
 # Worker workflow `mutation.yml` must exist and invoke the
 # mutation-testing tool. Matching on the Taskfile shim keeps us robust
 # if the workflow ever inlines the commands. The schedule lives on the
 # parent (`nightly.yml`) — see the chain check below.
 mutation_workflow=".github/workflows/mutation.yml"
-mutation_missing=0
 if [[ ! -f "${mutation_workflow}" ]]; then
-  echo "verify-standards: ${mutation_workflow} is missing." >&2
-  echo "  Add a workflow_call worker that runs the mutation gate (called from nightly.yml)." >&2
-  mutation_missing=1
+  fail_mutation_check \
+    "${mutation_workflow} is missing." \
+    "Add a workflow_call worker that runs the mutation gate (called from nightly.yml)."
 else
   # Strip comments so a disabled sample does not satisfy the gate.
   mutation_stripped="$(sed -E 's/(^|[[:space:]])#.*$//' "${mutation_workflow}")"
   if ! grep -qE "task[[:space:]]+mutation-test|mutmut[[:space:]]+run" <<<"${mutation_stripped}"; then
-    echo "verify-standards: ${mutation_workflow} does not invoke the mutation-testing gate." >&2
-    echo "  Call 'task mutation-test' (or 'mutmut run') in the workflow steps." >&2
-    mutation_missing=1
+    fail_mutation_check \
+      "${mutation_workflow} does not invoke the mutation-testing gate." \
+      "Call 'task mutation-test' (or 'mutmut run') in the workflow steps."
   fi
 fi
 
@@ -2103,29 +2110,28 @@ fi
 # the gate.
 nightly_workflow=".github/workflows/nightly.yml"
 if [[ ! -f "${nightly_workflow}" ]]; then
-  echo "verify-standards: ${nightly_workflow} is missing." >&2
-  echo "  Add the nightly orchestrator that schedules mutation.yml on a cron trigger." >&2
-  mutation_missing=1
+  fail_mutation_check \
+    "${nightly_workflow} is missing." \
+    "Add the nightly orchestrator that schedules mutation.yml on a cron trigger."
 else
   nightly_stripped="$(sed -E 's/(^|[[:space:]])#.*$//' "${nightly_workflow}")"
   if ! grep -qE "^on:" <<<"${nightly_stripped}"; then
-    echo "verify-standards: ${nightly_workflow} has no 'on:' trigger block." >&2
-    echo "  Add 'on:' with a 'schedule:' entry." >&2
-    mutation_missing=1
+    fail_mutation_check \
+      "${nightly_workflow} has no 'on:' trigger block." \
+      "Add 'on:' with a 'schedule:' entry."
   elif ! grep -qE "^[[:space:]]*schedule:" <<<"${nightly_stripped}"; then
-    echo "verify-standards: ${nightly_workflow} does not trigger on 'schedule:'." >&2
-    echo "  Add a 'schedule:' cron entry inside the 'on:' block." >&2
-    mutation_missing=1
+    fail_mutation_check \
+      "${nightly_workflow} does not trigger on 'schedule:'." \
+      "Add a 'schedule:' cron entry inside the 'on:' block."
   fi
   if ! grep -qE "uses:[[:space:]]*\./\.github/workflows/mutation\.yml" <<<"${nightly_stripped}"; then
-    echo "verify-standards: ${nightly_workflow} does not call mutation.yml." >&2
-    echo "  Add a job with 'uses: ./.github/workflows/mutation.yml' so the nightly cron runs the mutation gate." >&2
-    mutation_missing=1
+    fail_mutation_check \
+      "${nightly_workflow} does not call mutation.yml." \
+      "Add a job with 'uses: ./.github/workflows/mutation.yml' so the nightly cron runs the mutation gate."
   fi
 fi
 
 if [[ "${mutation_missing}" -ne 0 ]]; then
-  echo "  See .claude/instructions/testing-standards.md § Coverage and ADR 0021." >&2
   exit 1
 fi
 

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -81,8 +81,10 @@
 #      mark the verify step continue-on-error, so regressions in
 #      function-to-test allocation fail CI.
 #  12. A mutation-testing tool is configured (e.g. [tool.mutmut] in
-#      pyproject.toml) and a scheduled CI workflow invokes it with a
-#      documented score threshold, per
+#      pyproject.toml) with a documented score threshold, the
+#      `.github/workflows/mutation.yml` worker invokes it, and the
+#      parent `.github/workflows/nightly.yml` calls mutation.yml on
+#      a `schedule:` trigger, per
 #      .claude/instructions/testing-standards.md "Mutation testing on
 #      security-critical paths".
 #  13. A tests/fault/ directory exists and contains test files covering
@@ -2040,10 +2042,18 @@ fi
 # Mutation testing on security-critical paths.
 # ---------------------------------------------------------------------------
 # .claude/instructions/testing-standards.md (Coverage — "Mutation testing
-# on security-critical paths") requires:
+# on security-critical paths") requires every link in the chain
+# (config → mutation.yml worker → nightly.yml scheduler) to stay
+# wired so the gate cannot silently drift apart:
 #   1. A mutation-testing tool configured in pyproject.toml.
-#   2. A scheduled CI workflow that invokes it.
-#   3. A documented score threshold.
+#   2. .github/workflows/mutation.yml exists and invokes the tool
+#      (`task mutation-test` or `mutmut run`), so deleting the worker
+#      workflow fails the gate.
+#   3. .github/workflows/nightly.yml exists, has an `on: schedule:`
+#      trigger, and calls mutation.yml via
+#      `uses: ./.github/workflows/mutation.yml`, so removing the
+#      cadence (or unwiring mutation from nightly) fails the gate.
+#   4. A documented score threshold.
 #
 # The check is deliberately agnostic between mutmut / cosmic-ray — it
 # only asserts that one of the two config sections exists. The threshold
@@ -2067,29 +2077,59 @@ if threshold is None:
 fi
 rm -f /tmp/verify-standards-mutation.err
 
-# Require at least one workflow file under .github/workflows/ that
-# both has a `schedule:` trigger AND runs `task mutation-test` or calls
-# mutmut directly. Matching on the Taskfile shim keeps us robust if
-# the workflow ever inlines the commands.
-mutation_workflow_found=0
-for wf in .github/workflows/*.yml; do
-  [[ -f "${wf}" ]] || continue
-  if yq eval '.on | has("schedule")' "${wf}" 2>/dev/null | grep -qx true \
-    && grep -qE "task[[:space:]]+mutation-test|mutmut[[:space:]]+run" "${wf}"; then
-    mutation_workflow_found=1
-    mutation_workflow="${wf}"
-    break
+# Worker workflow `mutation.yml` must exist and invoke the
+# mutation-testing tool. Matching on the Taskfile shim keeps us robust
+# if the workflow ever inlines the commands. The schedule lives on the
+# parent (`nightly.yml`) — see the chain check below.
+mutation_workflow=".github/workflows/mutation.yml"
+mutation_missing=0
+if [[ ! -f "${mutation_workflow}" ]]; then
+  echo "verify-standards: ${mutation_workflow} is missing." >&2
+  echo "  Add a workflow_call worker that runs the mutation gate (called from nightly.yml)." >&2
+  mutation_missing=1
+else
+  # Strip comments so a disabled sample does not satisfy the gate.
+  mutation_stripped="$(sed -E 's/(^|[[:space:]])#.*$//' "${mutation_workflow}")"
+  if ! grep -qE "task[[:space:]]+mutation-test|mutmut[[:space:]]+run" <<<"${mutation_stripped}"; then
+    echo "verify-standards: ${mutation_workflow} does not invoke the mutation-testing gate." >&2
+    echo "  Call 'task mutation-test' (or 'mutmut run') in the workflow steps." >&2
+    mutation_missing=1
   fi
-done
+fi
 
-if [[ "${mutation_workflow_found}" -eq 0 ]]; then
-  echo "verify-standards: no scheduled workflow invokes the mutation-testing gate." >&2
-  echo "  Add a .github/workflows/*.yml that triggers on 'schedule:' and runs" >&2
-  echo "  'task mutation-test' (or 'mutmut run')." >&2
+# Scheduler workflow `nightly.yml` must exist, trigger on `schedule:`,
+# and call mutation.yml via `uses: ./.github/workflows/mutation.yml`,
+# so removing the cadence (or unwiring mutation from nightly) fails
+# the gate.
+nightly_workflow=".github/workflows/nightly.yml"
+if [[ ! -f "${nightly_workflow}" ]]; then
+  echo "verify-standards: ${nightly_workflow} is missing." >&2
+  echo "  Add the nightly orchestrator that schedules mutation.yml on a cron trigger." >&2
+  mutation_missing=1
+else
+  nightly_stripped="$(sed -E 's/(^|[[:space:]])#.*$//' "${nightly_workflow}")"
+  if ! grep -qE "^on:" <<<"${nightly_stripped}"; then
+    echo "verify-standards: ${nightly_workflow} has no 'on:' trigger block." >&2
+    echo "  Add 'on:' with a 'schedule:' entry." >&2
+    mutation_missing=1
+  elif ! grep -qE "^[[:space:]]*schedule:" <<<"${nightly_stripped}"; then
+    echo "verify-standards: ${nightly_workflow} does not trigger on 'schedule:'." >&2
+    echo "  Add a 'schedule:' cron entry inside the 'on:' block." >&2
+    mutation_missing=1
+  fi
+  if ! grep -qE "uses:[[:space:]]*\./\.github/workflows/mutation\.yml" <<<"${nightly_stripped}"; then
+    echo "verify-standards: ${nightly_workflow} does not call mutation.yml." >&2
+    echo "  Add a job with 'uses: ./.github/workflows/mutation.yml' so the nightly cron runs the mutation gate." >&2
+    mutation_missing=1
+  fi
+fi
+
+if [[ "${mutation_missing}" -ne 0 ]]; then
+  echo "  See .claude/instructions/testing-standards.md § Coverage and ADR 0021." >&2
   exit 1
 fi
 
-echo "verify-standards: mutation testing configured ([tool.mutmut] / [tool.mutation_score]) and scheduled via ${mutation_workflow}."
+echo "verify-standards: mutation testing configured ([tool.mutmut] / [tool.mutation_score]); ${mutation_workflow} invokes it, and ${nightly_workflow} schedules it."
 
 # Metrics endpoints per .claude/instructions/service-design.md
 # ("Metrics endpoint") and the deterministic regression check from


### PR DESCRIPTION
==COMMIT_MSG==
chore(ci): migrate mutation.yml into nightly/mutation

Convert mutation.yml from a standalone scheduled workflow into a
workflow_call child invoked by nightly.yml, the first daily-cadence
child to land under the uv-style nested workflow_call CI structure
(parent issue #440). Replaces nightly.yml's trivially-passing
aggregator with the canonical if: always() + needs.*.result shape
copied from ci.yml so subsequent migrations can extend needs:
without rewriting the gate.

Closes #457
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

CI-only refactor. The mutation job still fires on the same nightly
cron (now inherited from nightly.yml's schedule) and on workflow_dispatch
of the parent. References to mutation.yml in pyproject.toml,
CONTRIBUTING.md, ADR 0021, and design/SSDF.md remain accurate — the
file path is unchanged and the workflow still runs nightly.

### Test plan

- [ ] `task lint` passes locally
- [ ] `yq '.' .github/workflows/mutation.yml` and `yq '.' .github/workflows/nightly.yml` parse cleanly
- [ ] After merge, manually dispatch `nightly.yml` from the Actions tab and confirm the `Mutation` child runs and `Required checks passed` aggregates green