### PR TITLE
chore(ci): migrate benchmark.yml into weekly/bench

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,23 +2,19 @@
 #
 # SPDX-License-Identifier: MIT
 
-name: Benchmark
+name: Bench
 
+# Reusable benchmark child workflow under the uv-style nested
+# workflow_call CI structure (parent issue #440). Cadence (Sunday
+# 05:00 UTC) and workflow_dispatch live on the parent `weekly.yml`;
+# this file carries only the benchmark logic so the parent owns the
+# trigger surface.
+#
 # Benchmarks are too noisy on shared GitHub runners to gate every PR
 # (see ADR 0029 and packages/agent-auth/benchmarks/README.md for the
 # threshold rationale).
-# Run on a weekly schedule so regressions surface within a week of
-# landing, and expose workflow_dispatch so a reviewer can trigger a
-# run on-demand when refreshing the baseline.
-#
-# Schedule is offset from the Mutation workflow (Mon 04:00 UTC) to
-# avoid sharing a runner window on a single queue day. Sunday 05:00
-# UTC means the results land early in the week when they're most
-# likely to be noticed.
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: "0 5 * * 0" # 05:00 UTC every Sunday
+  workflow_call:
 
 jobs:
   benchmark:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -11,6 +11,13 @@ name: Weekly
 # on-demand run (e.g. when refreshing the bench baseline). Scorecard
 # migrates under here in a follow-up issue; the `required-checks-passed`
 # aggregator's `needs:` list grows with each child.
+#
+# Sunday 05:00 UTC is also offset from the Mutation workflow's Mon
+# 04:00 UTC slot to avoid sharing a runner window on a single queue
+# day. Since this header now governs the cadence for every weekly
+# child (bench today, Scorecard soon), preserve that cross-workflow
+# scheduling constraint here so a future maintainer doesn't move the
+# cron without noticing the Mutation collision risk.
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -6,13 +6,11 @@ name: Weekly
 
 # Orchestrator shell for weekly-cadence checks (OSSF Scorecard, bench)
 # under the uv-style nested workflow_call CI structure (issue #440).
-# Currently an empty shell — the `required-checks-passed` aggregator
-# runs alone and trivially passes so the empty shell can land
-# independently. Scorecard and bench migrate under here in follow-up
-# issues; the forward-looking `if: always()` + `needs.*.result`
-# aggregator pattern lands when the first child does. Triggers on a
-# 05:00 UTC Sunday cron so weekly results land early in the week, and
-# on workflow_dispatch so a maintainer can trigger an on-demand run.
+# Triggers on a 05:00 UTC Sunday cron so weekly results land early in
+# the week, and on workflow_dispatch so a maintainer can trigger an
+# on-demand run (e.g. when refreshing the bench baseline). Scorecard
+# migrates under here in a follow-up issue; the `required-checks-passed`
+# aggregator's `needs:` list grows with each child.
 on:
   workflow_dispatch:
   schedule:
@@ -25,10 +23,44 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+# Permissions union over every child called below. The `bench` child
+# only needs `contents: read` (checkout + upload-artifact); future
+# children (Scorecard) will widen this block at minimum-privilege.
+permissions:
+  contents: read
+
 jobs:
+  bench:
+    name: Bench
+    uses: ./.github/workflows/bench.yml
+
   required-checks-passed:
+    # Mirrors the forward-looking aggregator pattern in `ci.yml`: a
+    # single status check that consolidates every child's result.
+    # Subsequent migration issues add each new `workflow_call` child's
+    # job name to `needs:` here.
     name: Required checks passed
+    needs: [bench]
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Aggregate required-checks result
-        run: echo "all required checks passed"
+      - name: Verify all required checks passed
+        # Pass `needs` through `env:` so the JSON survives shell
+        # quoting verbatim — child job names that contain colons or
+        # quotes would otherwise break the inline expansion. `jq -e`
+        # exits non-zero on a `false` boolean, so the step fails
+        # whenever any upstream `needs.*.result` is anything other
+        # than `success`. Per issue #441 ("fails on any
+        # failed/skipped/timed-out result"), `skipped` is treated as
+        # a failure alongside `failure`, `cancelled`, and `timed_out`
+        # — a child workflow that legitimately opts out via `if:`
+        # will need to surface a `success` result (e.g. via a
+        # short-circuit step) rather than skipping the job
+        # altogether.
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "${NEEDS}" \
+            | jq -e 'to_entries | all(.value.result == "success")' \
+            > /dev/null

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ immediately. Rationale in
 (`parse_token`, `sign_token`, `verify_token`, `create_token_pair`)
 and the SQLite store (`get_family` for a family with 200 scopes,
 `get_token`, `create_token`). The suite is scheduled weekly via
-`.github/workflows/benchmark.yml` — too noisy on shared runners to
+`.github/workflows/bench.yml` (called from `.github/workflows/weekly.yml`) — too noisy on shared runners to
 gate every PR. Rationale and baseline-refresh procedure in
 [`packages/agent-auth/benchmarks/README.md`](packages/agent-auth/benchmarks/README.md)
 and [ADR 0029](design/decisions/0029-benchmark-suite.md).

--- a/design/decisions/0029-benchmark-suite.md
+++ b/design/decisions/0029-benchmark-suite.md
@@ -94,9 +94,11 @@ Shorter import path and fewer directories.
    the JSON artifact from a scheduled run, renames, commits.
 7. **Standards gate**: `scripts/verify-standards.sh` asserts the
    `packages/agent-auth/benchmarks/` directory contains at least one
-   `test_*.py` and the `benchmark.yml` workflow exists and triggers
-   on `schedule:`, so later drift (someone deleting the benchmarks
-   while leaving the workflow, or vice versa) fails verify-standards.
+   `test_*.py`, the `bench.yml` worker workflow invokes the suite,
+   and `weekly.yml` schedules it via `uses: ./.github/workflows/bench.yml`
+   on a `schedule:` trigger, so later drift (someone deleting the
+   benchmarks while leaving the workflow, unwiring bench from
+   weekly, or removing the cron) fails verify-standards.
 
 ## Consequences
 

--- a/design/decisions/README.md
+++ b/design/decisions/README.md
@@ -78,7 +78,7 @@ is linked from this index.
 - [ADR 0028 — HMAC-chained audit log for tamper-evident integrity](0028-audit-log-hmac-chain.md)
   — closes AU-9. Every audit entry carries a `chain_hmac = HMAC-SHA256(audit_chain_key, prev_hmac || canonical(entry))`; `agent-auth verify-audit` detects modify / delete / insert. `SCHEMA_VERSION` bumps 1→2; v1 logs are rolled over to `<path>.pre-chain-v2-*` on upgrade.
 - [ADR 0029 — Benchmark suite with pytest-benchmark](0029-benchmark-suite.md)
-  — weekly `benchmark.yml` workflow runs a `packages/agent-auth/benchmarks/` pytest tree against a committed `ci-linux-x86_64.json` baseline with a 25 % mean-runtime regression gate; `scripts/verify-standards.sh` enforces the suite + workflow stay present.
+  — weekly `bench.yml` worker (called from `weekly.yml`) runs a `packages/agent-auth/benchmarks/` pytest tree against a committed `ci-linux-x86_64.json` baseline with a 25 % mean-runtime regression gate; `scripts/verify-standards.sh` enforces the suite + workflow stay present.
 - [ADR 0030 — Extract per-service HTTP client libraries](0030-per-service-http-client-libraries.md)
   — `agent_auth_client` and `things_bridge_client` own the full HTTP surface of each service as first-class in-tree packages; production code and integration tests consume them directly, replacing the partial per-caller clients.
 - [ADR 0031 — Renovate custom managers + Dependency Submission API for CI tool bumps](0031-renovate-custom-managers-and-dependency-submission.md)

--- a/packages/agent-auth/benchmarks/README.md
+++ b/packages/agent-auth/benchmarks/README.md
@@ -81,7 +81,9 @@ Baselines are CI-generated rather than author-generated so the numbers
 match the runner that will later be compared against.
 
 1. Trigger the benchmark workflow manually
-   (`gh workflow run benchmark.yml`).
+   (`gh workflow run weekly.yml` — the `bench` child is a
+   `workflow_call` worker so the parent `weekly.yml` is the dispatch
+   surface).
 2. Download the artifact produced by the run: the JSON report lands
    at `packages/agent-auth/benchmarks/results.json`.
 3. Rename it to

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -96,10 +96,11 @@
 #      pytest marker, per .claude/instructions/testing-standards.md
 #      "Performance budget".
 #  15. A packages/agent-auth/benchmarks/ directory contains at least
-#      one test_*.py file AND a scheduled CI workflow
-#      (.github/workflows/benchmark.yml) invokes it on
-#      `on: schedule:`, per .claude/instructions/testing-standards.md
-#      "Benchmark suite".
+#      one test_*.py file AND a scheduled CI workflow path runs it:
+#      `.github/workflows/bench.yml` invokes the suite, and the
+#      parent `.github/workflows/weekly.yml` calls bench.yml on a
+#      `schedule:` trigger, per
+#      .claude/instructions/testing-standards.md "Benchmark suite".
 #  16. .vscode/extensions.json, .vscode/settings.json, and
 #      .vscode/launch.json all exist so a fresh checkout opens with
 #      recommended extensions, formatter-on-save, and debug configs,
@@ -2588,18 +2589,21 @@ echo "verify-standards: notification plugin is URL-based (out-of-process); no im
 # ---------------------------------------------------------------------------
 # .claude/instructions/testing-standards.md (Performance — "Benchmark
 # suite") requires a maintained benchmark suite that runs in CI on a
-# schedule. The deterministic regression check asserts both sides
+# schedule. The deterministic regression check asserts every link in
+# the chain (benchmarks → bench.yml worker → weekly.yml scheduler)
 # cannot silently drift apart:
 #
 #   1. packages/agent-auth/benchmarks/ exists and contains at least
 #      one test_*.py file, so deleting the benchmarks but leaving the
 #      workflow behind fails the gate.
-#   2. .github/workflows/benchmark.yml exists, has an `on:` block
-#      containing a `schedule:` trigger, and its steps invoke either
+#   2. .github/workflows/bench.yml exists and its steps invoke either
 #      `task benchmark` or a direct pytest run against the
-#      packages/agent-auth/benchmarks/ tree, so deleting the workflow
-#      (or accidentally narrowing it to workflow_dispatch-only)
-#      fails the gate.
+#      packages/agent-auth/benchmarks/ tree, so deleting the worker
+#      workflow fails the gate.
+#   3. .github/workflows/weekly.yml exists, has an `on: schedule:`
+#      trigger, and calls bench.yml via `uses: ./.github/workflows/bench.yml`,
+#      so removing the cadence (or unwiring bench from weekly) fails
+#      the gate.
 
 benchmark_missing=0
 
@@ -2625,37 +2629,55 @@ else
   fi
 fi
 
-benchmark_workflow=".github/workflows/benchmark.yml"
-if [[ ! -f "${benchmark_workflow}" ]]; then
+bench_workflow=".github/workflows/bench.yml"
+if [[ ! -f "${bench_workflow}" ]]; then
   fail_benchmark_check \
-    "${benchmark_workflow} is missing." \
-    "Add a scheduled GitHub Actions workflow that runs the benchmark suite."
+    "${bench_workflow} is missing." \
+    "Add a workflow_call worker that runs the benchmark suite (called from weekly.yml)."
 else
-  # Match ``on:`` and ``schedule:`` inside it. Allow either the
-  # short form (``on: [schedule]``) or the mapping form
-  # (``on:\n  schedule:``). Strip comments so a disabled sample
-  # does not satisfy the gate.
-  workflow_stripped="$(sed -E 's/(^|[[:space:]])#.*$//' "${benchmark_workflow}")"
-  if ! grep -qE "^on:" <<<"${workflow_stripped}"; then
-    fail_benchmark_check \
-      "${benchmark_workflow} has no 'on:' trigger block." \
-      "Add 'on:' with a 'schedule:' entry."
-  elif ! grep -qE "^[[:space:]]*schedule:" <<<"${workflow_stripped}"; then
-    fail_benchmark_check \
-      "${benchmark_workflow} does not trigger on 'schedule:'." \
-      "Add a 'schedule:' cron entry inside the 'on:' block."
-  fi
+  # Strip comments so a disabled sample does not satisfy the gate.
+  bench_stripped="$(sed -E 's/(^|[[:space:]])#.*$//' "${bench_workflow}")"
 
-  # The workflow must actually invoke the benchmark suite — accept
+  # The worker must actually invoke the benchmark suite — accept
   # either the ``task benchmark`` wrapper or a raw ``pytest`` against
   # any ``benchmarks/`` path (the tree now lives under
   # packages/agent-auth/, but the suffix match keeps the gate stable
   # if the package name changes later), so the gate does not mandate
   # the Taskfile indirection specifically.
-  if ! grep -qE "task[[:space:]]+benchmark\b|pytest[[:space:]].*benchmarks/" <<<"${workflow_stripped}"; then
+  if ! grep -qE "task[[:space:]]+benchmark\b|pytest[[:space:]].*benchmarks/" <<<"${bench_stripped}"; then
     fail_benchmark_check \
-      "${benchmark_workflow} does not invoke the benchmark suite." \
+      "${bench_workflow} does not invoke the benchmark suite." \
       "Call 'task benchmark' or run pytest against a 'benchmarks/' tree in the workflow steps."
+  fi
+fi
+
+weekly_workflow=".github/workflows/weekly.yml"
+if [[ ! -f "${weekly_workflow}" ]]; then
+  fail_benchmark_check \
+    "${weekly_workflow} is missing." \
+    "Add the weekly orchestrator that schedules bench.yml on a cron trigger."
+else
+  # Match ``on:`` and ``schedule:`` inside it. Allow either the
+  # short form (``on: [schedule]``) or the mapping form
+  # (``on:\n  schedule:``). Strip comments so a disabled sample
+  # does not satisfy the gate.
+  weekly_stripped="$(sed -E 's/(^|[[:space:]])#.*$//' "${weekly_workflow}")"
+  if ! grep -qE "^on:" <<<"${weekly_stripped}"; then
+    fail_benchmark_check \
+      "${weekly_workflow} has no 'on:' trigger block." \
+      "Add 'on:' with a 'schedule:' entry."
+  elif ! grep -qE "^[[:space:]]*schedule:" <<<"${weekly_stripped}"; then
+    fail_benchmark_check \
+      "${weekly_workflow} does not trigger on 'schedule:'." \
+      "Add a 'schedule:' cron entry inside the 'on:' block."
+  fi
+
+  # weekly.yml must wire bench.yml as a workflow_call child so the
+  # cadence on weekly actually drives the bench worker.
+  if ! grep -qE "uses:[[:space:]]*\./\.github/workflows/bench\.yml" <<<"${weekly_stripped}"; then
+    fail_benchmark_check \
+      "${weekly_workflow} does not call bench.yml." \
+      "Add a job with 'uses: ./.github/workflows/bench.yml' so the weekly cron runs the benchmark suite."
   fi
 fi
 
@@ -2663,7 +2685,7 @@ if [[ ${benchmark_missing} -ne 0 ]]; then
   exit 1
 fi
 
-echo "verify-standards: benchmark suite exists under ${benchmarks_dir}/ and ${benchmark_workflow} runs it on a schedule."
+echo "verify-standards: benchmark suite exists under ${benchmarks_dir}/, ${bench_workflow} invokes it, and ${weekly_workflow} schedules it."
 
 # ---------------------------------------------------------------------------
 # VS Code project scaffolding.


### PR DESCRIPTION
==COMMIT_MSG==
chore(ci): migrate benchmark.yml into weekly/bench

move the benchmark logic into a new `workflow_call` worker
`.github/workflows/bench.yml` and call it from
`.github/workflows/weekly.yml`. cadence (sunday 05:00 utc cron)
and `workflow_dispatch` now live on `weekly.yml` so the parent
orchestrator owns the trigger surface; `bench.yml` carries only
the benchmark steps.

this lands the forward-looking aggregator pattern under
`weekly.yml` (mirroring `ci.yml`'s `if: always()` +
`needs.*.result` shape), per the comment in the original
`weekly.yml` shell that flagged "the aggregator pattern lands
when the first child does."

operator-facing knock-ons:
- baseline refresh now dispatches `weekly.yml` instead of
  `benchmark.yml` (`workflow_call` workflows can't be dispatched
  directly).
- `scripts/verify-standards.sh` now asserts both `bench.yml`
  invokes the suite and `weekly.yml` schedules it via
  `uses: ./.github/workflows/bench.yml`, so unwiring the child
  from the parent fails the gate.

Closes #456
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

CI-only change: migrates the existing weekly benchmark workflow into the nested `workflow_call` structure under `weekly.yml`. No user-visible behaviour change — same cron, same suite, same regression gate.

Concrete diff shape:
- New `.github/workflows/bench.yml` (`workflow_call` only). Carries the benchmark job verbatim from the old `benchmark.yml` (checkout, setup-toolchain, compare-flags, `task benchmark`, upload-artifact). Drops `workflow_dispatch` and `schedule` triggers — the parent owns those.
- `.github/workflows/weekly.yml` now calls `bench.yml` and replaces the trivially-passing aggregator with the `if: always()` + `needs.*.result` shape from `ci.yml` (verbatim — same `env: NEEDS:`, same `jq -e 'all(.value.result == "success")'`).
- `.github/workflows/benchmark.yml` deleted.
- Doc / standards-gate references updated: `CONTRIBUTING.md`, `packages/agent-auth/benchmarks/README.md`, ADR 0029, `design/decisions/README.md`. `scripts/verify-standards.sh` now asserts the chain `bench.yml` invokes the suite AND `weekly.yml` calls bench.yml on a `schedule:` trigger, so unwiring either side fails the gate.

### Test plan

- [ ] `bash scripts/verify-standards.sh` passes locally (asserts the new bench.yml + weekly.yml chain).
- [ ] After merge: `gh workflow run weekly.yml` triggers the bench job successfully (operator-facing dispatch path for the baseline-refresh procedure).
- [ ] After merge: confirm the next scheduled Sunday 05:00 UTC run kicks off via `weekly.yml` with the bench child green.