### PR TITLE
chore(ci): add check-docs as always-passing placeholder

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+name: Check Docs
+
+# Placeholder docs-build child workflow for the uv-style nested
+# `workflow_call` CI structure (parent issue #440). agent-auth has no
+# docs site today, but the slot is reserved in `ci.yml`'s aggregator so
+# the structure stays uniform across migration issues — when a docs
+# site is introduced this workflow will run the real build, and no
+# wiring change in `ci.yml` will be needed.
+#
+# The aggregator in `ci.yml` treats `skipped` as a failure alongside
+# `failure` / `cancelled` / `timed_out`, so this job must actually run
+# and report `success`. Do not gate it behind any `if:` that could
+# resolve to a `skipped` outcome.
+#
+# TODO(aidanns): replace this no-op with a real docs build (e.g.
+# `mkdocs build --strict`) once agent-auth gains a docs site.
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check-docs:
+    name: check-docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder docs build
+        run: echo "no docs site yet — placeholder always-passing job"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,15 @@ jobs:
               - '.github/workflows/**'
               - '.github/actions/**'
 
+  check-docs:
+    # Placeholder docs-build slot (issue #464). The slot is reserved
+    # so the migration structure stays uniform; the child workflow is
+    # always-passing until agent-auth gains a docs site. See
+    # `.github/workflows/check-docs.yml` for the TODO marker.
+    name: check-docs
+    needs: [plan]
+    uses: ./.github/workflows/check-docs.yml
+
   required-checks-passed:
     # Repo-wide aggregator (#440 "Decisions (locked in)"): a single
     # `Required checks passed` status check sits at the top of `ci.yml`
@@ -136,7 +145,7 @@ jobs:
     # branch-protection ruleset switch from per-workflow required
     # checks to this one aggregator is tracked under #5.2.
     name: Required checks passed
-    needs: [plan]
+    needs: [plan, check-docs]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
==COMMIT_MSG==
chore(ci): add check-docs as always-passing placeholder

Reserve the `check-docs` slot in `ci.yml`'s nested workflow_call
structure (issue #440) so subsequent migrations land against a stable
shape. agent-auth has no docs site today, so the child workflow runs a
single no-op step that exits zero. A TODO(aidanns) marker in the file
header points at the future replacement (e.g. `mkdocs build --strict`)
once a docs site is introduced.

The aggregator in `ci.yml` treats `skipped` alongside failure for any
required check, so the job runs unconditionally rather than gated
behind an `if:` that could short-circuit to `skipped`. The caller job
is wired into `required-checks-passed`'s `needs:` list so the
aggregate status check covers it from day one.

Closes #464
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

CI-only placeholder; no user-visible behaviour change. The new child
workflow runs a single `echo` step so the aggregator sees a `success`
result rather than a `skipped` one (the aggregator treats `skipped` as
a failure). The caller job in `ci.yml` is wired into
`required-checks-passed`'s `needs:` list so the aggregate status check
covers it from day one.

### Test plan

- [ ] `Required checks passed` reports green on this PR (proves the
      caller's `needs: [plan, check-docs]` aggregator wiring works
      end-to-end).
- [ ] The `Check Docs / check-docs` job appears in the PR's checks
      list and reports `success` (not `skipped`).
- [ ] `reuse.yml` passes (proves the SPDX header on the new file is
      well-formed).