### PR TITLE
chore(ci): migrate typecheck.yml under ci/check-lint/python

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+name: Check Lint
+
+# `workflow_call` parent shell for lint-and-static-analysis children
+# under the uv-style nested CI structure (parent issue #440, Phase 2
+# issue #453). Today the only child is `python` (mypy + pyright);
+# follow-up issues attach more children here:
+#   - #454: systems-engineering (REUSE / SPDX, treefmt --ci, ripsecrets)
+#   - #459: extends `python.yml` with ruff lint, or adds a sibling
+#
+# The aggregator below mirrors the pattern in `ci.yml`'s
+# `required-checks-passed`: a single status job that fails if any
+# child reports anything other than `success`. `if: always()` keeps
+# the aggregator running even when an upstream job fails, so the
+# failure surfaces as a single red status check rather than the
+# aggregator being skipped along with its needs.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  python:
+    name: python
+    uses: ./.github/workflows/python.yml
+    secrets: inherit
+
+  required-checks-passed:
+    name: Required checks passed
+    needs: [python]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required checks passed
+        # See the matching step in `ci.yml` for the rationale behind
+        # routing `needs` through `env:` and using `jq -e` to fail on
+        # any non-`success` result. `skipped` is treated as a failure
+        # alongside `failure`, `cancelled`, and `timed_out` — a child
+        # that legitimately opts out via `if:` must surface a
+        # `success` result rather than skipping outright.
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "${NEEDS}" \
+            | jq -e 'to_entries | all(.value.result == "success")' \
+            > /dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,18 @@ jobs:
               - '.github/workflows/**'
               - '.github/actions/**'
 
+  check-lint:
+    # First `workflow_call` child landed under the parent issue #440
+    # migration (Phase 2, issue #453). The `check-lint.yml` parent
+    # shell currently fans out to `python.yml` (mypy + pyright);
+    # follow-up issues attach more children (systems-engineering in
+    # #454, ruff in #459). Per Strategy C, the original `typecheck.yml`
+    # continues to run alongside this chain until the Phase 5 sweep.
+    name: check-lint
+    needs: [plan]
+    uses: ./.github/workflows/check-lint.yml
+    secrets: inherit
+
   required-checks-passed:
     # Repo-wide aggregator (#440 "Decisions (locked in)"): a single
     # `Required checks passed` status check sits at the top of `ci.yml`
@@ -136,7 +148,7 @@ jobs:
     # branch-protection ruleset switch from per-workflow required
     # checks to this one aggregator is tracked under #5.2.
     name: Required checks passed
-    needs: [plan]
+    needs: [plan, check-lint]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+name: Python
+
+# `workflow_call` child of `check-lint.yml` carrying the Python static
+# analysis jobs (mypy + pyright). Migrated from the standalone
+# `typecheck.yml` workflow under the uv-style nested CI structure
+# (parent issue #440, Phase 2 issue #453). Per the strategy-C decision
+# locked in 2026-05-01, the original `typecheck.yml` continues to run
+# alongside this child until the Phase 5 sweep deletes it; do not
+# remove it from here.
+#
+# The original `typecheck.yml` ran a single `typecheck` job that
+# invoked `task typecheck` (which calls `scripts/typecheck.sh` →
+# `mypy` then `pyright` sequentially). This file splits the two
+# checkers into separate sibling jobs so they parallelise across CI
+# runners and so issue #459 can extend `python.yml` with a third
+# `ruff` job without reshuffling. Each job sources
+# `scripts/_bootstrap_venv.sh` (the same helper `scripts/typecheck.sh`
+# uses) so the per-OS/arch venv is created and `UV_PROJECT_ENVIRONMENT`
+# is exported, then `exec`s its tool through `uv run --no-sync`.
+# Going through `task typecheck` would re-couple the two checkers
+# serially.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  mypy:
+    name: mypy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run mypy
+        run: |
+          set -euo pipefail
+          # shellcheck source=scripts/_bootstrap_venv.sh
+          source scripts/_bootstrap_venv.sh
+          exec uv run --no-sync mypy
+
+  pyright:
+    name: pyright
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run pyright
+        run: |
+          set -euo pipefail
+          # shellcheck source=scripts/_bootstrap_venv.sh
+          source scripts/_bootstrap_venv.sh
+          exec uv run --no-sync pyright


### PR DESCRIPTION
## Summary
- Lands the first `workflow_call` child of `ci.yml`: a new `check-lint.yml` parent shell with `python.yml` (mypy + pyright as separate parallel jobs) wired in.
- Per Strategy C (locked 2026-05-01), the original `typecheck.yml` is **not** touched and continues to run alongside until the Phase 5 sweep deletes it. The branch-protection ruleset is untouched.
- `python.yml` splits mypy and pyright into separate jobs so they parallelise and so issue #459 can extend cleanly with a ruff job.

## Review notes

### Test plan
- [ ] Workflow files syntactically valid (yq parses all three).
- [ ] `Required checks passed` (CI) runs and is green on this PR.
- [ ] Both `Typecheck / typecheck` (from old `typecheck.yml`) and the new `CI / check-lint / python / mypy` + `... / pyright` chain fire and pass.
- [ ] `typecheck.yml` and `.github/branch-protection-rulesets/` (if any) untouched — `git diff main...HEAD` only shows the three intended files.

==COMMIT_MSG==
chore(ci): migrate typecheck.yml under ci/check-lint/python

introduces the first `workflow_call` child of the `ci.yml`
orchestrator (parent issue #440, phase 2 issue #453). adds a
`check-lint.yml` parent shell with `python.yml` as its first child;
`python.yml` carries mypy and pyright as separate sibling jobs so they
parallelise and so #459 can extend with a ruff job without reshuffling.

per the strategy-c decision locked in 2026-05-01, the original
`typecheck.yml` continues to run alongside this chain — both the
existing `Typecheck / typecheck` status check and the new
`CI / check-lint / python / mypy + pyright` chain fire on every PR
until a phase-5 sweep deletes the original. the branch-protection
ruleset is untouched.

Closes #453
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==