### PR TITLE
chore(ci): migrate verify-standards.yml under ci/check-standards

### DIFF
--- a/.github/workflows/check-standards.yml
+++ b/.github/workflows/check-standards.yml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+name: Check Standards
+
+# Project-standards check for the uv-style nested `workflow_call` CI
+# structure (parent issue #440, this slot #455). Runs the cross-project
+# standards verifier (`task verify-standards` -> `scripts/verify-standards.sh`):
+# Taskfile coverage, Dependabot ecosystem coverage, bash CI gating, and
+# `uv.lock` sync. The slot has no nested `check-*` parent shell — there
+# is only ever one logical check here, so this workflow is a direct
+# child of `ci.yml`, sibling of `check-docs` / `check-lint` / etc.
+#
+# The aggregator in `ci.yml` treats `skipped` as a failure alongside
+# `failure` / `cancelled` / `timed_out`, so this job must actually run
+# and report `success`. Do not gate it behind any `if:` that could
+# resolve to a `skipped` outcome.
+#
+# Per the migration plan (issue #455 strategy C), the original
+# top-level `verify-standards.yml` workflow stays in place and runs in
+# parallel with this child until Phase 5 of #440 retires it. The
+# branch-protection ruleset is untouched in this PR.
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-standards:
+    name: verify-standards
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify Project Standards
+        run: task verify-standards

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,16 @@ jobs:
     needs: [plan]
     uses: ./.github/workflows/check-docs.yml
 
+  check-standards:
+    # Project-standards slot (issue #455). Runs `task verify-standards`
+    # via `scripts/verify-standards.sh`. Until Phase 5 of #440 retires
+    # the original top-level workflow, the legacy `verify-standards.yml`
+    # continues to run in parallel; this PR does not delete it and does
+    # not modify the branch-protection ruleset (strategy C).
+    name: check-standards
+    needs: [plan]
+    uses: ./.github/workflows/check-standards.yml
+
   required-checks-passed:
     # Repo-wide aggregator (#440 "Decisions (locked in)"): a single
     # `Required checks passed` status check sits at the top of `ci.yml`
@@ -145,7 +155,7 @@ jobs:
     # branch-protection ruleset switch from per-workflow required
     # checks to this one aggregator is tracked under #5.2.
     name: Required checks passed
-    needs: [plan, check-docs]
+    needs: [plan, check-docs, check-standards]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/check-standards.yml` (`workflow_call`) carrying the `task verify-standards` invocation, sibling of `check-docs` under `ci.yml`.
- Wires `check-standards` into `ci.yml`'s `required-checks-passed` aggregator (`needs:`).
- Strategy C: leaves `.github/workflows/verify-standards.yml` and the branch-protection ruleset untouched; the legacy workflow runs in parallel until Phase 5 of #440 retires it.

## Review notes

### Test plan
- [ ] CI workflow file syntactically valid.
- [ ] `Required checks passed` (CI) runs and is green.
- [ ] Both `verify-standards` (from old workflow) and the new `ci / check-standards / verify-standards` chain fire and pass.

==COMMIT_MSG==
chore(ci): migrate verify-standards.yml under ci/check-standards

Adds the next slot in the uv-style nested `workflow_call` CI tree
(parent #440): a `check-standards` child wired directly under
`ci.yml` and into the `required-checks-passed` aggregator. The
new workflow carries the existing `task verify-standards`
invocation byte-for-byte. Per strategy C decided 2026-05-01, the
original `verify-standards.yml` stays in place and runs in
parallel until Phase 5 of #440 retires it; the branch-protection
ruleset is untouched.

Closes #455
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==