### PR TITLE
chore(ci): migrate scorecard.yml under weekly/open-ssf-scorecard

### DIFF
--- a/.github/workflows/open-ssf-scorecard.yml
+++ b/.github/workflows/open-ssf-scorecard.yml
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+name: OpenSSF Scorecard
+
+# Reusable child workflow for the weekly orchestrator (parent
+# `weekly.yml`, issue #458 under #440). Carries the OpenSSF Scorecard
+# logic from the standalone `scorecard.yml` byte-for-byte: same
+# action SHAs, same permissions, same publish + gate split. The
+# standalone `scorecard.yml` keeps running in parallel under
+# Strategy C (#440 Phase 5) until a sweep PR retires it; until then
+# this child is invoked from `weekly.yml`'s `workflow_call` slot and
+# the standalone `push: branches: [main]` + cron triggers stay
+# unchanged on the original file.
+#
+# OpenSSF Scorecard runs the project through ~20 automated supply-
+# chain checks (Branch-Protection, Pinned-Dependencies,
+# Signed-Releases, Token-Permissions, SAST, Code-Review,
+# Dangerous-Workflow, ...) and emits per-check scores plus an
+# aggregate 0–10 score. The aggregate score is gated against
+# `SCORECARD_MIN_SCORE` — a regression below the floor fails the
+# workflow so a dependency bump or workflow change that drops a
+# check can't slip onto main unnoticed. The floor is deliberately
+# set to the current observed score so future changes ratchet
+# rather than regress.
+#
+# Split into two jobs because scorecard-action's publish endpoint
+# rejects any publishing job that contains a non-`uses:` step (see
+# https://github.com/ossf/scorecard-action#workflow-restrictions).
+# `publish` holds only `uses:` steps so the signed publication to
+# api.securityscorecards.dev succeeds; `gate` re-runs scorecard-action
+# without publication so it can pair the JSON output with a `run:`
+# threshold check.
+#
+# See also:
+#   - design/SELF_ASSESSMENT.md → "OpenSSF Scorecard" for the target
+#     and publication policy.
+#   - design/SSDF.md RV.1.2 for the SDLC-standard mapping.
+on:
+  workflow_call:
+
+permissions: read-all
+
+jobs:
+  publish:
+    name: Scorecard analysis (publish)
+    runs-on: ubuntu-latest
+    permissions:
+      # For uploading SARIF to the GitHub Security tab.
+      security-events: write
+      # For publishing signed results to api.securityscorecards.dev.
+      id-token: write
+      # Read-only access to workflow runs for the Token-Permissions check.
+      actions: read
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard (SARIF)
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to api.securityscorecards.dev so the badge
+          # on the README stays live and downstream scanners can query
+          # the latest score.
+          publish_results: true
+
+      - name: Upload Scorecard SARIF artefact
+        uses: actions/upload-artifact@v7
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 14
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif
+
+  gate:
+    name: Scorecard threshold gate
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      # scorecard-action reads workflow runs for the Token-Permissions check
+      # even when publish_results is false.
+      actions: read
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard (JSON)
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: results.json
+          results_format: json
+          # Gate-only run; publication happens in the `publish` job.
+          publish_results: false
+
+      - name: Gate on aggregate score
+        env:
+          # Initial floor of 0.0 so the first scheduled run establishes a
+          # baseline without red-lighting CI before we know the observed score.
+          # Raise to `observed_score - 0.5` after the first publication and
+          # ratchet upward as supply-chain hardening lands (pinned deps, token
+          # permissions, signed releases, fuzzing, ...).
+          SCORECARD_MIN_SCORE: "0.0"
+        run: |
+          set -euo pipefail
+          score=$(jq -r '.score' results.json)
+          threshold="${SCORECARD_MIN_SCORE}"
+          echo "Scorecard aggregate score: ${score} (floor ${threshold})"
+          awk -v s="${score}" -v t="${threshold}" \
+            'BEGIN { if (s + 0 < t + 0) { exit 1 } }'

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -6,13 +6,17 @@ name: Weekly
 
 # Orchestrator shell for weekly-cadence checks (OSSF Scorecard, bench)
 # under the uv-style nested workflow_call CI structure (issue #440).
-# Currently an empty shell — the `required-checks-passed` aggregator
-# runs alone and trivially passes so the empty shell can land
-# independently. Scorecard and bench migrate under here in follow-up
-# issues; the forward-looking `if: always()` + `needs.*.result`
-# aggregator pattern lands when the first child does. Triggers on a
-# 05:00 UTC Sunday cron so weekly results land early in the week, and
-# on workflow_dispatch so a maintainer can trigger an on-demand run.
+# OSSF Scorecard migrates underneath this orchestrator via the
+# `open-ssf-scorecard` child below (#458); bench follows in a later
+# issue. Triggers on a 05:00 UTC Sunday cron so weekly results land
+# early in the week, and on workflow_dispatch so a maintainer can
+# trigger an on-demand run.
+#
+# Strategy C (#440 Phase 5): the standalone `scorecard.yml` keeps
+# running in parallel until a sweep PR retires it. This orchestrator
+# adds a second (weekly Sunday) Scorecard run on top of the existing
+# (weekly Monday + push: main) standalone runs; the duplication is
+# intentional and short-lived.
 on:
   workflow_dispatch:
   schedule:
@@ -25,10 +29,57 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
+  open-ssf-scorecard:
+    # OpenSSF Scorecard child workflow (#458). The child holds the
+    # full publish + gate split; this slot in `weekly.yml` only wires
+    # it into the aggregator below. Action SHAs, permissions
+    # (`security-events: write`, `id-token: write`), and the
+    # SCORECARD_MIN_SCORE floor are preserved byte-for-byte from the
+    # standalone `scorecard.yml`. See
+    # `.github/workflows/open-ssf-scorecard.yml`.
+    name: open-ssf-scorecard
+    permissions:
+      # Permissions for `workflow_call` children are capped by the
+      # caller job's permission set, so we re-declare the union of
+      # the child's per-job permissions here. The child's `publish`
+      # job needs `security-events: write` + `id-token: write` for
+      # SARIF upload and signed publication; both jobs need
+      # `actions: read` for the Token-Permissions check.
+      security-events: write
+      id-token: write
+      actions: read
+      contents: read
+    uses: ./.github/workflows/open-ssf-scorecard.yml
+
   required-checks-passed:
+    # Repo-wide aggregator for the weekly cadence (#440 "Decisions
+    # (locked in)"). Subsequent migration issues (e.g. bench) will
+    # add each `workflow_call` child workflow's job name to `needs:`
+    # here. `if: always()` + the `needs.*.result` JSON walk lets the
+    # aggregator distinguish `success` from
+    # `failure`/`cancelled`/`skipped`/`timed_out` — `skipped` is
+    # treated as a failure alongside the others, matching the
+    # `ci.yml` aggregator pattern (issue #441).
     name: Required checks passed
+    needs: [open-ssf-scorecard]
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Aggregate required-checks result
-        run: echo "all required checks passed"
+      - name: Verify all required checks passed
+        # Pass `needs` through `env:` so the JSON survives shell
+        # quoting verbatim — child job names that contain colons or
+        # quotes would otherwise break the inline expansion. `jq -e`
+        # exits non-zero on a `false` boolean, so the step fails
+        # whenever any upstream `needs.*.result` is anything other
+        # than `success`.
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "${NEEDS}" \
+            | jq -e 'to_entries | all(.value.result == "success")' \
+            > /dev/null


### PR DESCRIPTION
## Summary
- Add `.github/workflows/open-ssf-scorecard.yml` as a `workflow_call` child carrying the OpenSSF Scorecard logic byte-for-byte (same action SHAs, same `publish` + `gate` split, same `SCORECARD_MIN_SCORE` floor).
- Wire the child into `weekly.yml` and switch its aggregator from the empty-shell placeholder to the `if: always()` + `needs.*.result` JSON pattern that mirrors `ci.yml`.
- Strategy C (#440 Phase 5): the standalone `scorecard.yml` is **not** modified — it keeps running on its existing `push: branches: [main]` and weekly Monday cron triggers until a Phase 5 sweep PR retires it. This PR just adds a parallel weekly Sunday Scorecard run via the orchestrator.

## Review notes

### Test plan
- [ ] `weekly.yml` parses; the `Required checks passed` aggregator on `weekly.yml` passes (manually trigger with `gh workflow run weekly.yml` if needed).
- [ ] No regression on the existing `scorecard.yml` weekly cron.

==COMMIT_MSG==
chore(ci): migrate scorecard.yml under weekly/open-ssf-scorecard

Move the OpenSSF Scorecard logic into a `workflow_call` child under
`weekly.yml` (parent #440) so the weekly cadence has its first real
participating check. Strategy C: the standalone `scorecard.yml`
keeps running in parallel with the `push: branches: [main]` and
weekly Monday cron triggers untouched until a Phase 5 sweep PR
retires it; this PR adds a parallel weekly Sunday Scorecard run via
the orchestrator. Action SHAs, per-job permissions
(`security-events: write` + `id-token: write` on publish, `actions:
read` on gate), and the SCORECARD_MIN_SCORE floor are carried over
byte-for-byte. The `weekly.yml` aggregator switches from the empty
placeholder to the `if: always()` + `needs.*.result` JSON pattern
to match `ci.yml`'s shape.

Closes #458
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==