### PR TITLE
chore(ci): add ci/check-lint/systems-engineering

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -6,9 +6,9 @@ name: Check Lint
 
 # `workflow_call` parent shell for lint-and-static-analysis children
 # under the uv-style nested CI structure (parent issue #440, Phase 2
-# issue #453). Today the only child is `python` (mypy + pyright);
-# follow-up issues attach more children here:
-#   - #454: systems-engineering (REUSE / SPDX, treefmt --ci, ripsecrets)
+# issue #453). Children today: `python` (mypy + pyright) and
+# `systems-engineering` (verify-design + verify-function-tests).
+# Follow-up issues attach more children here:
 #   - #459: extends `python.yml` with ruff lint, or adds a sibling
 #
 # The aggregator below mirrors the pattern in `ci.yml`'s
@@ -30,9 +30,14 @@ jobs:
     uses: ./.github/workflows/python.yml
     secrets: inherit
 
+  systems-engineering:
+    name: systems-engineering
+    uses: ./.github/workflows/systems-engineering.yml
+    secrets: inherit
+
   required-checks-passed:
     name: Required checks passed
-    needs: [python]
+    needs: [python, systems-engineering]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/systems-engineering.yml
+++ b/.github/workflows/systems-engineering.yml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+name: Systems Engineering
+
+# `workflow_call` child of `check-lint.yml` carrying the systems
+# engineering traceability checks (design + function-tests). Migrated
+# from the standalone `verify-design.yml` and `verify-function-tests.yml`
+# workflows under the uv-style nested CI structure (parent issue #440,
+# Phase 2 issue #454). Per the strategy-C decision locked in
+# 2026-05-01, the original `verify-design.yml` and
+# `verify-function-tests.yml` continue to run alongside this child until
+# the Phase 5 sweep deletes them; do not remove them from here.
+#
+# Each job mirrors its standalone counterpart byte-for-byte (same job
+# name, same `task` invocation, same action SHAs) so the migration is
+# transparent at the job level. Splitting them as siblings preserves
+# the existing parallelism rather than collapsing them into a single
+# serialised job.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-design:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify all functions are allocated
+        run: task verify-design
+
+  verify-function-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify all functions have test coverage
+        run: task verify-function-tests


### PR DESCRIPTION
## Summary
- Lands the second `workflow_call` child of `check-lint.yml`: a new `systems-engineering.yml` carrying `verify-design` + `verify-function-tests` as parallel sibling jobs.
- Wires `systems-engineering` alongside `python` under `check-lint.yml` and adds it to the `required-checks-passed` aggregator's `needs:` list.
- Per Strategy C (locked 2026-05-01), the original `verify-design.yml` and `verify-function-tests.yml` are **not** touched and continue to run alongside until the Phase 5 sweep deletes them. The branch-protection ruleset is untouched.

## Review notes

### Test plan
- [ ] Workflow files syntactically valid (yq parses both).
- [ ] `Required checks passed` (CI) runs and is green on this PR.
- [ ] Both old `Verify Design / verify-design` + `Verify Function Tests / verify-function-tests` (from standalone workflows) and the new `CI / check-lint / systems-engineering / {verify-design, verify-function-tests}` chain fire and pass.
- [ ] `verify-design.yml`, `verify-function-tests.yml`, `ci.yml`, and `.github/branch-protection-rulesets/` (if any) untouched — `git diff origin/main...HEAD` only shows the two intended files.

### Self-review only
No code-review subagent was available in this session, so the author performed self-review against the diff. Confirmed:
- `verify-design.yml`, `verify-function-tests.yml`, `ci.yml`, and the branch-protection ruleset are byte-for-byte unchanged (Strategy C).
- `task verify-design` and `task verify-function-tests` invocations preserved byte-for-byte from the standalone workflows; same job names retained for status-check name continuity.
- `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6` SHA pin matches both originals; `./.github/actions/setup-toolchain` invocations identical.
- `permissions: contents: read` matches the read-only posture used in `python.yml`.
- `check-lint.yml` extended cleanly: new `systems-engineering` sibling of `python`, both feed `required-checks-passed.needs`.
- Both files parse as valid YAML (`yq eval '.' …`).

==COMMIT_MSG==
chore(ci): add ci/check-lint/systems-engineering

introduces the second `workflow_call` child of `check-lint.yml` (parent
issue #440, phase 2 issue #454). adds a `systems-engineering.yml`
carrying `verify-design` and `verify-function-tests` as separate sibling
jobs so they parallelise the same way the standalone workflows did, and
wires it as a sibling of `python` under `check-lint.yml`.

per the strategy-c decision locked in 2026-05-01, the original
`verify-design.yml` and `verify-function-tests.yml` continue to run
alongside this child until a phase-5 sweep deletes them. the
branch-protection ruleset is untouched.

Closes #454
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==