### PR TITLE
improvement: backport pr-lint rule 8 to validator wheel

### DIFF
--- a/changelog/@unreleased/pr-500-pr-lint-validator-rule-8.yml
+++ b/changelog/@unreleased/pr-500-pr-lint-validator-rule-8.yml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+type: improvement
+improvement:
+  description: |
+    `pr-lint-validator` backports rule 8 (no leading subject line in the `==COMMIT_MSG==` block) so the wheel matches the canonical in-tree script.
+  links:
+    - https://github.com/aidanns/agent-auth/issues/499
+    - https://github.com/aidanns/agent-auth/pull/500
+packages:
+  - pr-lint-validator

--- a/packages/pr-lint-validator/README.md
+++ b/packages/pr-lint-validator/README.md
@@ -107,14 +107,14 @@ GitHub Actions provides.
 ### Validate a `==COMMIT_MSG==` block
 
 ```bash
-pr-lint-validator commit-msg \
-  pr-body.md \
-  --title 'feature(agent-auth): add JIT approval flow'
+pr-lint-validator commit-msg pr-body.md
 ```
 
-The body file is the PR's full markdown. The `--title` flag is
-optional; passing it enables the "first body line duplicates the PR
-title" check, which is the rule with title context.
+The body file is the PR's full markdown. Post-#478 the block is the
+commit body (and trailers) only — the squash commit's subject comes
+from the PR title — so the validator rejects any first line whose
+shape matches the Conventional-Commit subject allowlist (rule 8,
+`check_no_leading_subject_line`).
 
 ### Self-test mode
 

--- a/packages/pr-lint-validator/src/pr_lint_validator/cli.py
+++ b/packages/pr-lint-validator/src/pr_lint_validator/cli.py
@@ -85,7 +85,7 @@ def _run_commit_msg(args: argparse.Namespace) -> int:
         return 2
     body = Path(args.body_path).read_text(encoding="utf-8")
     try:
-        commit_msg.validate(body, title=args.title)
+        commit_msg.validate(body)
     except commit_msg.ValidationError as err:
         print(f"pr-lint: {err}", file=sys.stderr)
         return 1
@@ -170,15 +170,6 @@ def _build_parser() -> argparse.ArgumentParser:
         nargs="?",
         default=None,
         help="Path to a file containing the PR body markdown.",
-    )
-    commit_msg_parser.add_argument(
-        "--title",
-        default=None,
-        help=(
-            "PR title (the squash-merge subject). When provided, the "
-            "first body line is also checked for duplication of the "
-            "title."
-        ),
     )
     commit_msg_parser.add_argument(
         "--self-test",

--- a/packages/pr-lint-validator/src/pr_lint_validator/commit_msg.py
+++ b/packages/pr-lint-validator/src/pr_lint_validator/commit_msg.py
@@ -400,37 +400,43 @@ def check_first_line_non_blank(block: str) -> None:
     if first_idx > 0:
         raise ValidationError(
             f"`{MARKER}` block opens with {first_idx} blank line(s) "
-            "before the subject. The first content line must be the "
-            "commit subject so the bot's pasted body renders correctly "
-            "in `git log` — drop the leading blank line(s)."
+            "before the body. The first content line must be the "
+            "first line of the commit body so the bot's pasted body "
+            "renders correctly in `git log` — drop the leading "
+            "blank line(s)."
         )
 
 
-def check_first_line_not_subject_dup(lines: list[str], title: str | None) -> None:
-    """Reject a body whose first line duplicates the PR title."""
-    if title is None or not lines:
+# Conventional-Commit subject shape — the project's PR-title prefix
+# allowlist (ADR 0037) followed by `: <text>`. Used by
+# ``check_no_leading_subject_line`` to detect a leading subject line in
+# the block, which post-#478 belongs in the PR title (rendered as the
+# squash commit's `commit_title`), not the body. Matched on the first
+# non-blank content line of the block.
+LEADING_SUBJECT_RE = re.compile(
+    r"^(feature|improvement|fix|deprecation|migration|break|chore)(\([^)]+\))?: .+$"
+)
+
+
+def check_no_leading_subject_line(lines: list[str]) -> None:
+    """Reject a body whose first line looks like a Conventional-Commit subject.
+
+    The block is body + trailers only (issue #478): the squash
+    commit's subject comes from the PR title via the merge API's
+    ``commit_title`` field, so a leading subject line in the block
+    would render twice on ``main`` — once as the subject, once as the
+    first body line. The check fires on the first non-blank content
+    line.
+    """
+    first_line = next((line for line in lines if line.strip()), None)
+    if first_line is None:
         return
-    title_summary = _strip_title_prefix(title).strip().rstrip(".")
-    first_line = lines[0].strip().rstrip(".")
-    if not title_summary or not first_line:
-        return
-    if first_line.lower() == title_summary.lower():
+    if LEADING_SUBJECT_RE.match(first_line.strip()):
         raise ValidationError(
-            f"`{MARKER}` block's first line duplicates the PR title "
-            f"({first_line!r}). The PR title becomes the squash-merge "
-            "subject; drop the duplicate from the body and lead with "
-            "the rationale."
+            f"`{MARKER}` block is now the body only — remove the "
+            "leading subject line; the PR title is the source for "
+            "the squash commit subject."
         )
-
-
-PR_TITLE_PREFIX_RE = re.compile(r"^[A-Za-z]+(?:\([^)]+\))?:\s+")
-
-
-def _strip_title_prefix(title: str) -> str:
-    match = PR_TITLE_PREFIX_RE.match(title)
-    if match is None:
-        return title
-    return title[match.end() :]
 
 
 def check_fixes_trailer_shape(lines: list[str]) -> None:
@@ -452,10 +458,22 @@ def check_fixes_trailer_shape(lines: list[str]) -> None:
 
 
 def _body_region(lines: list[str]) -> list[str]:
-    """Return the body region of a commit-msg block (no subject, no trailers)."""
+    """Return the body region of a commit-msg block.
+
+    Post-#478 the block is body + trailers only, so the body region
+    is the block content with the trailer block (identified by
+    :func:`_trailer_block_start_index`) removed. Trailing blank lines
+    inside the resulting region are stripped so a body whose last
+    paragraph is followed by the canonical blank-then-trailers tail
+    contributes only its content lines to the region.
+
+    Used by :func:`check_verbose_body` to size the body alone,
+    separately from the trailer block (which is structurally bounded
+    — every trailer is one line).
+    """
     if not lines:
         return []
-    body = lines[1:]
+    body = list(lines)
     first_trailer_idx = _trailer_block_start_index(body)
     if first_trailer_idx is not None:
         body = body[:first_trailer_idx]
@@ -494,26 +512,42 @@ def check_verbose_body(lines: list[str]) -> int:
     return 1
 
 
-def validate(body: str, title: str | None = None) -> None:
+def validate(body: str) -> None:
     block = extract_commit_msg_block(body)
     check_first_line_non_blank(block)
     lines = block_lines(block)
     check_non_empty(lines)
+    check_no_leading_subject_line(lines)
     check_line_width(lines)
     check_no_markdown(lines)
     check_breaking_change_position(lines)
+    # ``check_trailers`` runs before the contiguity / blank-line-before
+    # checks so an unknown-token typo (``Cosed: #1`` for ``Closes: #1``)
+    # surfaces as the more actionable "unknown trailer token" error,
+    # rather than the misleading "no blank line before trailer block"
+    # the layout checks would emit if the typo line failed
+    # ``_is_trailer_shape_line``'s known-token gate.
     check_trailers(lines)
     check_trailer_block_contiguity(lines)
     check_blank_line_before_trailers(lines)
     check_signoff_present(lines)
-    check_first_line_not_subject_dup(lines, title)
     check_fixes_trailer_shape(lines)
+    # Soft warning — runs last so a body that fails any structural
+    # rule above surfaces the actionable error first; the verbose-body
+    # warning is advisory and only useful once the block is otherwise
+    # well-formed. Does NOT raise; returns a count, which the caller's
+    # exit code ignores by design (see CONTRIBUTING.md → "Writing
+    # release-worthy commits" → "Body" → "Lead with why, not what" for
+    # the warning-not-failure rationale).
     check_verbose_body(lines)
 
 
-# Inline self-test cases for title-aware checks. Each tuple is
-# ``(body, title, expect_pass, label)``.
-_TITLE_AWARE_SELF_TEST_CASES: tuple[tuple[str, str, bool, str], ...] = (
+# Inline self-test cases for the leading-subject-line check. Each tuple
+# is ``(body, expect_pass, label)``. Post-#478 the block is body +
+# trailers only, so any first line matching the Conventional-Commit
+# subject shape is rejected — the PR title is the source for the
+# squash commit subject.
+_LEADING_SUBJECT_SELF_TEST_CASES: tuple[tuple[str, bool, str], ...] = (
     (
         "==COMMIT_MSG==\n"
         "Wire the foo into the bar.\n\n"
@@ -521,20 +555,38 @@ _TITLE_AWARE_SELF_TEST_CASES: tuple[tuple[str, str, bool, str], ...] = (
         "Closes #1\n"
         "Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>\n"
         "==COMMIT_MSG==\n",
-        "feature(foo): wire the foo into the bar",
-        False,
-        "failing-first-line-dup",
+        True,
+        "passing-plain-prose-first-line",
     ),
     (
         "==COMMIT_MSG==\n"
-        "Wire the foo into the bar.\n\n"
+        "feature: wire the foo into the bar\n\n"
         "More rationale.\n\n"
         "Closes #1\n"
         "Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>\n"
         "==COMMIT_MSG==\n",
-        "chore(foo): refactor the foo helper",
+        False,
+        "failing-feature-prefix-first-line",
+    ),
+    (
+        "==COMMIT_MSG==\n"
+        "improvement(ci): tighten the validator\n\n"
+        "More rationale.\n\n"
+        "Closes #1\n"
+        "Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>\n"
+        "==COMMIT_MSG==\n",
+        False,
+        "failing-improvement-scope-first-line",
+    ),
+    (
+        "==COMMIT_MSG==\n"
+        "The wheel was extracted before rule 8 landed in the script.\n\n"
+        "More rationale.\n\n"
+        "Closes #1\n"
+        "Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>\n"
+        "==COMMIT_MSG==\n",
         True,
-        "passing-no-dup",
+        "passing-no-cc-shape-first-line",
     ),
 )
 
@@ -544,7 +596,12 @@ def _build_verbose_body(word_count: int, words_per_line: int = 20) -> str:
 
     Each body line carries ``words_per_line`` 1-char placeholder words
     so the body stays under the 72-char line cap as long as
-    ``words_per_line`` ≤ 36.
+    ``words_per_line`` ≤ 36. The synthesized block is body + trailers
+    only (no leading subject line) per #478 — the body region is the
+    placeholder-word block alone, so the line / word counts the
+    boundary cases assert match the sizing exactly. ``w`` is not a
+    CC-shaped prefix, so :func:`check_no_leading_subject_line` doesn't
+    match.
     """
     full_lines = word_count // words_per_line
     leftover = word_count % words_per_line
@@ -554,7 +611,6 @@ def _build_verbose_body(word_count: int, words_per_line: int = 20) -> str:
     body_block = "\n".join(body_lines)
     return (
         "==COMMIT_MSG==\n"
-        "Subject summary placeholder.\n\n"
         f"{body_block}\n\n"
         "Closes #1\n"
         "Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>\n"
@@ -572,7 +628,6 @@ _VERBOSE_BODY_SELF_TEST_CASES: tuple[tuple[str, bool, str], ...] = (
     ),
     (
         "==COMMIT_MSG==\n"
-        "Subject summary placeholder.\n\n"
         "One paragraph of why this change exists. Two short lines is\n"
         "all the body needs because the diff is self-evident.\n\n"
         "Closes #1\n"
@@ -610,9 +665,9 @@ def run_self_test(write: Writer) -> int:
     Returns 0 on full pass, 1 on any failure.
     """
     fail = 0
-    for body, title, expect_pass, label in _TITLE_AWARE_SELF_TEST_CASES:
+    for body, expect_pass, label in _LEADING_SUBJECT_SELF_TEST_CASES:
         try:
-            validate(body, title=title)
+            validate(body)
         except ValidationError as err:
             if expect_pass:
                 write(f"FAIL: {label}: expected pass, got {err}", error=True)
@@ -637,7 +692,7 @@ def run_self_test(write: Writer) -> int:
             actual = "warning" if actually_warned else "no warning"
             write(f"FAIL: {label}: expected {expected}, got {actual}", error=True)
             fail += 1
-    total = len(_TITLE_AWARE_SELF_TEST_CASES) + len(_VERBOSE_BODY_SELF_TEST_CASES)
+    total = len(_LEADING_SUBJECT_SELF_TEST_CASES) + len(_VERBOSE_BODY_SELF_TEST_CASES)
     if fail:
         write(f"{fail} self-test case(s) failed", error=True)
         return 1

--- a/packages/pr-lint-validator/tests/test_commit_msg.py
+++ b/packages/pr-lint-validator/tests/test_commit_msg.py
@@ -4,8 +4,8 @@
 
 """Tests for ``pr_lint_validator.commit_msg``.
 
-The bundled title-aware and verbose-body self-test fixtures are the
-contract surface; the tests below parametrise over both tuples so
+The bundled leading-subject and verbose-body self-test fixtures are
+the contract surface; the tests below parametrise over both tuples so
 each fixture surfaces as its own pytest report line.
 """
 
@@ -20,14 +20,14 @@ def _label_for(case: tuple[object, ...]) -> str:
     return str(case[-1])
 
 
-@pytest.mark.parametrize("case", commit_msg._TITLE_AWARE_SELF_TEST_CASES, ids=_label_for)
-def test_title_aware_self_test_fixture(case: tuple[object, ...]) -> None:
-    body, title_str, expect_pass, _label = case
+@pytest.mark.parametrize("case", commit_msg._LEADING_SUBJECT_SELF_TEST_CASES, ids=_label_for)
+def test_leading_subject_self_test_fixture(case: tuple[object, ...]) -> None:
+    body, expect_pass, _label = case
     if expect_pass:
-        commit_msg.validate(body, title=title_str)  # type: ignore[arg-type]
+        commit_msg.validate(body)  # type: ignore[arg-type]
         return
     with pytest.raises(commit_msg.ValidationError):
-        commit_msg.validate(body, title=title_str)  # type: ignore[arg-type]
+        commit_msg.validate(body)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("case", commit_msg._VERBOSE_BODY_SELF_TEST_CASES, ids=_label_for)

--- a/packages/pr-lint-validator/tests/test_pr_lint_validator_cli.py
+++ b/packages/pr-lint-validator/tests/test_pr_lint_validator_cli.py
@@ -83,6 +83,33 @@ def test_commit_msg_subcommand_validates_passing_body(
     assert "block OK" in out
 
 
+def test_commit_msg_subcommand_rejects_leading_subject_line(
+    tmp_path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A leading CC-shaped first line in the block is rejected (rule 8).
+
+    Post-#478 the block is body + trailers only — the squash commit's
+    subject is rendered from the PR title, so a CC-shaped first line
+    in the block would render twice on ``main``. The CLI's
+    ``commit-msg`` subcommand must surface this as exit code 1 with a
+    fix-it pointer mentioning the body-only convention.
+    """
+    body = tmp_path / "body.md"
+    body.write_text(
+        "==COMMIT_MSG==\n"
+        "improvement(ci): wire the foo into the bar\n\n"
+        "Body paragraph.\n\n"
+        "Closes #1\n"
+        "Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>\n"
+        "==COMMIT_MSG==\n",
+        encoding="utf-8",
+    )
+    rc = cli.main(["commit-msg", str(body)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "leading subject line" in err
+
+
 def test_commit_msg_subcommand_rejects_missing_signoff(
     tmp_path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
==COMMIT_MSG==
The wheel `pr-lint-validator-0.17.0` was extracted before PR #490
added rule 8 (`check_no_leading_subject_line`) to
`scripts/validate-commit-msg-block.py`, so the wheel still ships the
older `check_first_line_not_subject_dup(lines, title)` that accepts a
non-duplicating CC-shaped first line. Mirror the canonical script so
the wheel and the in-tree script agree on rule 8.

Drops the now-unused `title` parameter from the wheel CLI's
`commit-msg` subcommand; the only consumer of the title-aware check
was the deprecated duplication rule.

Closes #499
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

## Review notes

Backports the leading-subject-line check from
`scripts/validate-commit-msg-block.py` (canonical) into the
`pr-lint-validator` wheel, so #477 can pin the wheel without losing
rule 8 coverage. The `--title` plumbing on the wheel CLI's
`commit-msg` subcommand is dropped along with the deprecated rule.

### Test plan

- [ ] `task pr-lint-validator:test` is green (76 unit tests).
- [ ] `task pr-lint-validator:check` (lint + format) is green.
- [ ] `uv run pr-lint-validator commit-msg .github/workflows/tests/pr-lint-fixtures/invalid-leading-subject-line.md` exits non-zero with the leading-subject-line message.
- [ ] `uv run pr-lint-validator commit-msg --self-test` exits 0 across all 10 self-test cases.
- [ ] CI: `pr-lint`, `validator-self-test`, package pytest, changelog-lint all green.