### PR TITLE
chore(ci): add ci/check-security/dependency-review

### DIFF
--- a/.github/workflows/check-dependency-review.yml
+++ b/.github/workflows/check-dependency-review.yml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+name: Check Dependency Review
+
+# `workflow_call` child of `check-security.yml`, itself a child of
+# `ci.yml` (parent issue #440). Carries the GitHub Dependency Review
+# action that previously lived in the standalone
+# `dependency-review.yml`. Per the Strategy C migration plan agreed on
+# the parent issue, this workflow runs alongside the original
+# `dependency-review.yml` until Phase 5 cuts branch protection over to
+# the `Required checks passed` aggregator and the original is deleted.
+# Both produce a check context named `dependency-review`; GitHub
+# disambiguates them by `workflowName`, so the existing branch-
+# protection rule on the original continues to fire identically while
+# the new chain runs in parallel.
+#
+# The filename is `check-dependency-review.yml` (not
+# `dependency-review.yml`) so the new workflow_call child can coexist
+# on disk with the original `dependency-review.yml` for the duration
+# of the parallel-run migration.
+#
+# Action SHA, permissions, and inputs (`fail-on-severity: high`,
+# `comment-summary-in-pr: always`) are carried over byte-for-byte
+# from the original — see `dependency-review.yml` for the rationale on
+# each.
+on:
+  workflow_call:
+
+permissions:
+  # Read-only access to the Dependency Graph diff — this is the scanner input.
+  contents: read
+  # Required by comment-summary-in-pr so the action can post the inline
+  # findings summary on the PR conversation.
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: dependency-check
+        uses: actions/dependency-review-action@v4
+        with:
+          # HIGH/CRITICAL is the industry-standard gating bar and matches
+          # what Dependabot alerts prioritise for notification. Dropping to
+          # moderate produces a false-positive treadmill on transitive
+          # deps for a solo-maintained project — can be revisited if the
+          # noise/value trade flips.
+          fail-on-severity: high
+          # Post a human-readable summary on the PR so the action's
+          # findings are visible without clicking through to the check
+          # details page.
+          comment-summary-in-pr: always

--- a/.github/workflows/check-security.yml
+++ b/.github/workflows/check-security.yml
@@ -7,8 +7,9 @@ name: Check Security
 # `workflow_call` parent shell for security-cadence checks under the
 # uv-style nested workflow_call CI structure (parent issue #440).
 # Currently carries the CodeQL analyse child (`codeql-analyse.yml`,
-# issue #447); subsequent migration issues add `dependency-review`
-# (#448), `dependency-submission` (#449), and `ripsecrets` (#459)
+# issue #447) and the Dependency Review child
+# (`check-dependency-review.yml`, issue #448); subsequent migration
+# issues add `dependency-submission` (#449) and `ripsecrets` (#459)
 # under here as further `workflow_call` children, each one extending
 # the aggregator's `needs:` list.
 on:
@@ -26,6 +27,13 @@ jobs:
       contents: read
       security-events: write
 
+  check-dependency-review:
+    name: Check Dependency Review
+    uses: ./.github/workflows/check-dependency-review.yml
+    permissions:
+      contents: read
+      pull-requests: write
+
   required-checks-passed:
     # Per-parent aggregator (#440 "Decisions (locked in)"): each
     # parent orchestrator carries its own `Required checks passed`
@@ -34,7 +42,7 @@ jobs:
     # one in turn. Subsequent migration issues add each new child
     # workflow's job name to `needs:` here.
     name: Required checks passed
-    needs: [codeql-analyse]
+    needs: [codeql-analyse, check-dependency-review]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/check-dependency-review.yml` as a `workflow_call` child of `check-security.yml`, exposing the GitHub Dependency Review action as a `dependency-check` step (issue #448, parent #440).
- Wires it as a sibling to `codeql-analyse` inside `check-security.yml`, extending `required-checks-passed.needs` with the new job.
- Strategy C: original `.github/workflows/dependency-review.yml` is unmodified and runs in parallel until Phase 5; the new file is named `check-dependency-review.yml` to coexist with the original on disk.

## Review notes

### Test plan

- [ ] `check-security.yml` syntactically valid (CI parses without error).
- [ ] `Required checks passed` (CI) runs and is green.
- [ ] Both old `review` (from `dependency-review.yml`) and the new `ci / check-security / check-dependency-review / dependency-review` chain fire and pass on this PR.

==COMMIT_MSG==
Wire the GitHub Dependency Review action under the new
check-security workflow_call shell (issue #440) as a sibling
to codeql-analyse, so the new "Required checks passed"
aggregator gets a dependency-CVE signal alongside CodeQL.

Per Strategy C the original dependency-review.yml stays
unmodified and runs in parallel until Phase 5 cuts branch
protection over to the aggregator. The new file is named
check-dependency-review.yml (not dependency-review.yml) so it
can coexist with the original on disk.

Action SHA, permissions, and inputs (fail-on-severity: high,
comment-summary-in-pr: always) are carried over byte-for-byte
from the original.

Closes #448
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==