### PR TITLE
chore(ci): add ci/check-security/dependency-submission

### DIFF
--- a/.github/workflows/check-dependency-submission.yml
+++ b/.github/workflows/check-dependency-submission.yml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+name: Check Dependency Submission
+
+# `workflow_call` child of `check-security.yml`, itself a child of
+# `ci.yml` (parent issue #440). Carries the tool-versions Dependency
+# Graph snapshot job that previously lived in the standalone
+# `dependency-submission.yml`. Per the Strategy C migration plan
+# agreed on the parent issue, this workflow runs alongside the
+# original `dependency-submission.yml` until Phase 5 cuts branch
+# protection over to the `Required checks passed` aggregator and the
+# original is deleted. Both produce a check context named `submit`;
+# GitHub disambiguates them by `workflowName`, so existing
+# branch-protection rules on the original continue to fire
+# identically while the new chain runs in parallel.
+#
+# The push / weekly-cron / workflow_dispatch triggers stay on
+# `dependency-submission.yml` for the duration of the migration; this
+# child only runs on `workflow_call` (i.e. on `pull_request` via the
+# `ci.yml` chain). The fork-PR skip is preserved verbatim — fork PRs
+# receive a read-only `GITHUB_TOKEN`, so the snapshot POST would 403.
+on:
+  workflow_call:
+
+permissions:
+  # Required to POST to /repos/{owner}/{repo}/dependency-graph/snapshots.
+  contents: write
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Skip on fork PR
+        # GITHUB_TOKEN is read-only on fork PRs, so the snapshot POST
+        # would 403. Surfacing a `success` result here (rather than
+        # `if:`-skipping the whole job) keeps the parent
+        # `check-security.yml` aggregator green — its `Required checks
+        # passed` step rejects `skipped` alongside `failure` /
+        # `cancelled` / `timed_out`. Push / cron / workflow_dispatch
+        # always run in the main repo context and fall through to the
+        # snapshot submission below.
+        id: fork-check
+        env:
+          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          set -euo pipefail
+          if [[ "${IS_FORK}" == "true" ]]; then
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+            echo "Fork PR detected — skipping snapshot submission."
+          else
+            echo "skip=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - if: steps.fork-check.outputs.skip != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Build and submit snapshot
+        if: steps.fork-check.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MANIFEST_PATH: .github/tool-versions.yml
+        run: bash scripts/ci/submit-dependency-snapshot.sh

--- a/.github/workflows/check-security.yml
+++ b/.github/workflows/check-security.yml
@@ -26,6 +26,12 @@ jobs:
       contents: read
       security-events: write
 
+  check-dependency-submission:
+    name: Check Dependency Submission
+    uses: ./.github/workflows/check-dependency-submission.yml
+    permissions:
+      contents: write
+
   required-checks-passed:
     # Per-parent aggregator (#440 "Decisions (locked in)"): each
     # parent orchestrator carries its own `Required checks passed`
@@ -34,7 +40,7 @@ jobs:
     # one in turn. Subsequent migration issues add each new child
     # workflow's job name to `needs:` here.
     name: Required checks passed
-    needs: [codeql-analyse]
+    needs: [codeql-analyse, check-dependency-submission]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Add ``check-dependency-submission.yml`` (workflow_call) and wire it into ``check-security.yml`` so the tool-versions Dependency Graph snapshot job runs under the new uv-style nested CI shell (#440).
- Strategy C: original ``dependency-submission.yml`` is left in place and continues to run on push / weekly cron / workflow_dispatch / pull_request, in parallel with the new chain, until Phase 5 retires the originals.
- Fork-PR skip preserved via a short-circuit step so the job surfaces ``success`` rather than ``skipped`` and the parent's ``Required checks passed`` aggregator stays green.

## Review notes

### Test plan
- [ ] check-security.yml syntactically valid.
- [ ] ``Required checks passed`` (CI) runs and is green.
- [ ] Both old ``submit`` (from dependency-submission.yml) and the new chain fire.
- [ ] Fork-PR skip behavior preserved on the new chain.

==COMMIT_MSG==
Migrate the tool-versions Dependency Graph snapshot job under the
new ``check-security.yml`` workflow_call shell as
``check-dependency-submission.yml`` (parent issue #440, this issue
#449). Wire it into the parent's ``required-checks-passed``
aggregator alongside ``codeql-analyse``.

Strategy C from #440: the original ``dependency-submission.yml``
stays in place and continues to run on push / weekly cron /
workflow_dispatch / pull_request, in parallel with this new chain,
until Phase 5 cuts branch protection over to the
``Required checks passed`` aggregator and retires the originals.
The new workflow file is named ``check-dependency-submission.yml``
to coexist with the original on disk for the duration of the
migration.

The fork-PR skip is preserved as a short-circuit step (rather than
the original job-level ``if:``) so the job surfaces ``success``
rather than ``skipped`` on fork PRs — the parent shell's
``Required checks passed`` step rejects ``skipped`` alongside
``failure`` per the convention documented in
``check-security.yml``.

Closes #449
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==