### PR TITLE
fix(ci): drop literal ${{ }} from install-pr-lint-validator description

### DIFF
--- a/.github/actions/install-pr-lint-validator/action.yml
+++ b/.github/actions/install-pr-lint-validator/action.yml
@@ -34,9 +34,12 @@ inputs:
     required: false
     default: "0.17.1"
   github-token:
+    # Don't write `${{ ... }}` here — action.yml metadata only has
+    # the `inputs` context in scope, so `${{ github.token }}` fails
+    # to load with "Unrecognized named-value: 'github'".
     description: >
       GitHub token used to download the wheel asset. Callers
-      typically pass the workflow's `${{ github.token }}`, which
+      typically pass the workflow's `github.token`, which
       has `contents: read` and is sufficient for downloading
       release assets from the same private repository.
     required: true


### PR DESCRIPTION
==COMMIT_MSG==
GitHub Actions evaluates `${{ ... }}` expressions inside action.yml
metadata fields, but only the `inputs` context is in scope at
metadata-load time. The literal `${{ github.token }}` reference in
the `github-token` input description (added by #506) made the
runner reject the manifest with `Unrecognized named-value:
'github'`, breaking every PR-Lint job that consumes the composite
on every PR opened against main since #506 landed (#510 was the
first observed casualty).

#506's own CI did not catch it: pr-lint.yml runs on
`pull_request_target` and explicitly checks out the base ref's
copy of the workflow + composite, so the new file never ran on
the PR that introduced it. The structural gap is tracked in #511.

Drop the `${{ ... }}` braces from the prose so the description is
no longer parsed as an expression. Add a short YAML comment above
the field so future editors do not reintroduce the syntax.

Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

## Review notes

PR Lint failure on main:

- Originating PR: #506 (merged 2026-05-02).
- First observed casualty: #510 — every consumer of the composite (`pr-title-style`, `pr-body-commit-msg`, `validator-self-test`, `pr-title-self-test`, `pr-body-warning-self-test`) failed at the "Install pr-lint-validator from release" step with `Unrecognized named-value: 'github'`. Failed run: https://github.com/aidanns/agent-auth/actions/runs/25242007784.

### Self-validation gap

This PR's own CI **cannot** validate the fix. `.github/workflows/pr-lint.yml` runs on `pull_request_target` and pins `actions/checkout@…` to `${{ github.event.pull_request.base.sha }}`, so the composite resolves against `main` (still broken) rather than the head ref of this PR. Every PR-Lint job here is expected to fail with the same manifest-load error. After this PR merges, main holds the fixed action.yml and subsequent PRs should pass.

The structural gap is tracked separately in #511 — a follow-up will add some form of head-ref-aware lint (actionlint on a `pull_request` trigger, or a unit test that loads each `action.yml` and asserts no `${{ }}` appears in metadata fields) so a future regression of the same shape fails CI in the PR that introduces it.

### Test plan

- [x] CI on this PR: every non-PR-Lint required check still passes (PR-Lint failures are expected — see "Self-validation gap" above). Run: https://github.com/aidanns/agent-auth/pull/512/checks — confirmed 30+ checks green, 5 expected PR-Lint failures, no unexpected failures.
- [ ] After merge: open or rebase any subsequent PR and confirm every PR-Lint job runs to completion (i.e. reaches the actual validator, not the manifest-load error). Acceptable outcomes: validator-pass on a clean PR, or validator-fail on a deliberately bad PR — what matters is that the "Install pr-lint-validator from release" step no longer aborts at manifest load.
