### PR TITLE
chore(ci): split error-taxonomy contract per package

### DIFF
--- a/packages/agent-auth/tests/test_error_taxonomy.py
+++ b/packages/agent-auth/tests/test_error_taxonomy.py
@@ -2,15 +2,25 @@
 #
 # SPDX-License-Identifier: MIT
 
-"""Contract tests for the error-code taxonomy.
+"""Contract tests for the agent-auth half of the error-code taxonomy.
 
-Every error code documented in ``design/error-codes.md`` is exercised here.
-Each test triggers the precise condition that should produce a given code and
-asserts the response body. Changes to error strings or HTTP statuses will
-fail these tests, which is the intent: the error taxonomy is public API.
+The error taxonomy is split across two packages — agent-auth's response
+codes are exercised here, and things-bridge's response codes are
+exercised in
+``packages/things-bridge/tests/test_things_bridge_error_taxonomy.py``.
+The split keeps each package's unit-test shard self-contained (the
+bridge tests need ``things_client_fake``, which is shipped under
+``packages/things-bridge/tests/`` as a test-only fake and is not on the
+agent-auth shard's pythonpath).
 
-Documented codes
-----------------
+Every error code documented in ``design/error-codes.md`` is exercised by
+exactly one of the two files. Each test triggers the precise condition
+that should produce a given code and asserts the response body. Changes
+to error strings or HTTP statuses will fail these tests, which is the
+intent: the error taxonomy is public API.
+
+Documented codes covered here
+-----------------------------
 agent-auth /v1/validate:
   malformed_request (400), invalid_token (401), token_expired (401),
   token_revoked (401), scope_denied (403).
@@ -28,18 +38,6 @@ agent-auth /metrics (unversioned):
   scope_denied (403).
 agent-auth server-wide:
   not_found (404), rate_limited (429).
-things-bridge /v1/* data endpoints:
-  unauthorized (401), token_expired (401), scope_denied (403),
-  authz_unavailable (502), not_found (404),
-  things_permission_denied (503), things_unavailable (502).
-things-bridge /health (unversioned):
-  unauthorized (401), token_expired (401), scope_denied (403),
-  authz_unavailable (502).
-things-bridge /metrics (unversioned):
-  unauthorized (401), token_expired (401), scope_denied (403),
-  authz_unavailable (502).
-things-bridge server-wide:
-  not_found (404), method_not_allowed (405), rate_limited (429).
 """
 
 import os
@@ -48,7 +46,6 @@ import threading
 from datetime import UTC, datetime, timedelta
 
 import pytest
-from things_client_fake.store import FakeThingsClient, FakeThingsStore
 
 from agent_auth.approval import ApprovalManager
 from agent_auth.approval_client import ApprovalClient
@@ -58,21 +55,7 @@ from agent_auth.metrics import build_registry as build_auth_registry
 from agent_auth.server import AgentAuthServer
 from agent_auth.store import TokenStore
 from agent_auth.tokens import create_token_pair
-from agent_auth_client import (
-    AgentAuthClient,
-    AuthzRateLimitedError,
-    AuthzScopeDeniedError,
-    AuthzTokenExpiredError,
-    AuthzUnavailableError,
-)
 from tests_support.http import get, post
-from things_bridge.config import Config as BridgeConfig
-from things_bridge.errors import (
-    ThingsError,
-    ThingsPermissionError,
-)
-from things_bridge.metrics import build_registry as build_bridge_registry
-from things_bridge.server import ThingsBridgeServer
 
 # -- test infrastructure --
 
@@ -118,74 +101,6 @@ def _extract_token_id(raw_token: str) -> str:
 
 def _bearer(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
-
-
-class _FakeAuthz(AgentAuthClient):
-    def __init__(self) -> None:
-        super().__init__("http://test-fake")
-        self.exc: Exception | None = None
-
-    def validate(self, token: str, required_scope: str, *, description: str | None = None) -> None:
-        if self.exc is not None:
-            raise self.exc
-
-
-class _InjectableThings:
-    """Wraps FakeThingsClient with error-injection for taxonomy tests."""
-
-    exc: Exception | None = None
-
-    def __init__(self, store: FakeThingsStore):
-        self._client = FakeThingsClient(store)
-
-    def list_todos(self, **kwargs):
-        if self.exc is not None:
-            raise self.exc
-        return self._client.list_todos(**kwargs)
-
-    def get_todo(self, todo_id):
-        if self.exc is not None:
-            raise self.exc
-        return self._client.get_todo(todo_id)
-
-    def list_projects(self, **kwargs):
-        if self.exc is not None:
-            raise self.exc
-        return self._client.list_projects(**kwargs)
-
-    def get_project(self, project_id):
-        if self.exc is not None:
-            raise self.exc
-        return self._client.get_project(project_id)
-
-    def list_areas(self):
-        if self.exc is not None:
-            raise self.exc
-        return self._client.list_areas()
-
-    def get_area(self, area_id):
-        if self.exc is not None:
-            raise self.exc
-        return self._client.get_area(area_id)
-
-
-@pytest.fixture
-def bridge_server():
-    config = BridgeConfig(host="127.0.0.1", port=0)
-    authz = _FakeAuthz()
-    store = FakeThingsStore()
-    things = _InjectableThings(store)
-    registry, metrics = build_bridge_registry()
-    server = ThingsBridgeServer(config, things, authz, registry, metrics)
-    port = server.server_address[1]
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        yield authz, things, f"http://127.0.0.1:{port}"
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join(timeout=2)
 
 
 # == agent-auth: POST /agent-auth/v1/validate ==
@@ -471,156 +386,3 @@ def test_agent_auth_rate_limited(tmp_dir, signing_key, encryption_key):
         server.shutdown()
         server.server_close()
         thread.join(timeout=2)
-
-
-# == things-bridge: GET /things-bridge/v1/todos (authorization errors) ==
-
-
-def test_bridge_unauthorized_no_token(bridge_server):
-    _, _, base = bridge_server
-    status, body = get(f"{base}/things-bridge/v1/todos")
-    assert status == 401
-    assert body["error"] == "unauthorized"
-
-
-def test_bridge_token_expired(bridge_server):
-    authz, _, base = bridge_server
-    authz.exc = AuthzTokenExpiredError("expired")
-    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
-    assert status == 401
-    assert body["error"] == "token_expired"
-
-
-def test_bridge_scope_denied(bridge_server):
-    authz, _, base = bridge_server
-    authz.exc = AuthzScopeDeniedError("denied")
-    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
-    assert status == 403
-    assert body["error"] == "scope_denied"
-
-
-def test_bridge_authz_unavailable(bridge_server):
-    authz, _, base = bridge_server
-    authz.exc = AuthzUnavailableError("down")
-    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
-    assert status == 502
-    assert body["error"] == "authz_unavailable"
-
-
-def test_bridge_not_found_unknown_id(bridge_server):
-    _, _, base = bridge_server
-    status, body = get(f"{base}/things-bridge/v1/todos/nonexistent-id", _bearer("tok"))
-    assert status == 404
-    assert body["error"] == "not_found"
-
-
-def test_bridge_things_permission_denied(bridge_server):
-    _, things, base = bridge_server
-    things.exc = ThingsPermissionError("denied")
-    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
-    assert status == 503
-    assert body["error"] == "things_permission_denied"
-
-
-def test_bridge_rate_limited(bridge_server):
-    # Coverage for the 429 passthrough path — agent-auth returns 429,
-    # the bridge maps AuthzRateLimitedError back to 429 with the same
-    # Retry-After (see ADR 0027).
-    authz, _, base = bridge_server
-    authz.exc = AuthzRateLimitedError("rate_limited", retry_after_seconds=3)
-    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
-    assert status == 429
-    assert body["error"] == "rate_limited"
-
-
-def test_bridge_things_unavailable(bridge_server):
-    _, things, base = bridge_server
-    things.exc = ThingsError("subprocess failed")
-    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
-    assert status == 502
-    assert body["error"] == "things_unavailable"
-
-
-# == things-bridge: GET /things-bridge/health (unversioned) ==
-
-
-def test_bridge_health_unauthorized_no_token(bridge_server):
-    _, _, base = bridge_server
-    status, body = get(f"{base}/things-bridge/health")
-    assert status == 401
-    assert body["error"] == "unauthorized"
-
-
-def test_bridge_health_token_expired(bridge_server):
-    authz, _, base = bridge_server
-    authz.exc = AuthzTokenExpiredError("expired")
-    status, body = get(f"{base}/things-bridge/health", _bearer("tok"))
-    assert status == 401
-    assert body["error"] == "token_expired"
-
-
-def test_bridge_health_scope_denied(bridge_server):
-    authz, _, base = bridge_server
-    authz.exc = AuthzScopeDeniedError("denied")
-    status, body = get(f"{base}/things-bridge/health", _bearer("tok"))
-    assert status == 403
-    assert body["error"] == "scope_denied"
-
-
-def test_bridge_health_authz_unavailable(bridge_server):
-    authz, _, base = bridge_server
-    authz.exc = AuthzUnavailableError("down")
-    status, body = get(f"{base}/things-bridge/health", _bearer("tok"))
-    assert status == 502
-    assert body["error"] == "authz_unavailable"
-
-
-# == things-bridge: GET /things-bridge/metrics (unversioned) ==
-
-
-def test_bridge_metrics_unauthorized_no_token(bridge_server):
-    _, _, base = bridge_server
-    status, body = get(f"{base}/things-bridge/metrics")
-    assert status == 401
-    assert body["error"] == "unauthorized"
-
-
-def test_bridge_metrics_token_expired(bridge_server):
-    authz, _, base = bridge_server
-    authz.exc = AuthzTokenExpiredError("expired")
-    status, body = get(f"{base}/things-bridge/metrics", _bearer("tok"))
-    assert status == 401
-    assert body["error"] == "token_expired"
-
-
-def test_bridge_metrics_scope_denied(bridge_server):
-    authz, _, base = bridge_server
-    authz.exc = AuthzScopeDeniedError("denied")
-    status, body = get(f"{base}/things-bridge/metrics", _bearer("tok"))
-    assert status == 403
-    assert body["error"] == "scope_denied"
-
-
-def test_bridge_metrics_authz_unavailable(bridge_server):
-    authz, _, base = bridge_server
-    authz.exc = AuthzUnavailableError("down")
-    status, body = get(f"{base}/things-bridge/metrics", _bearer("tok"))
-    assert status == 502
-    assert body["error"] == "authz_unavailable"
-
-
-# == things-bridge: server-wide ==
-
-
-def test_bridge_not_found_unknown_path(bridge_server):
-    _, _, base = bridge_server
-    status, body = get(f"{base}/things-bridge/v1/does-not-exist", _bearer("tok"))
-    assert status == 404
-    assert body["error"] == "not_found"
-
-
-def test_bridge_method_not_allowed(bridge_server):
-    _, _, base = bridge_server
-    status, body = post(f"{base}/things-bridge/v1/todos", {})
-    assert status == 405
-    assert body["error"] == "method_not_allowed"

--- a/packages/things-bridge/tests/test_things_bridge_error_taxonomy.py
+++ b/packages/things-bridge/tests/test_things_bridge_error_taxonomy.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Contract tests for the things-bridge half of the error-code taxonomy.
+
+The error taxonomy is split across two packages — things-bridge's
+response codes are exercised here, and agent-auth's response codes are
+exercised in
+``packages/agent-auth/tests/test_error_taxonomy.py``. The split keeps
+each package's unit-test shard self-contained: the bridge tests need
+``things_client_fake``, which lives under ``packages/things-bridge/tests/``
+as a test-only fake and is only on the things-bridge shard's pythonpath.
+
+Every error code documented in ``design/error-codes.md`` is exercised by
+exactly one of the two files. Each test triggers the precise condition
+that should produce a given code and asserts the response body. Changes
+to error strings or HTTP statuses will fail these tests, which is the
+intent: the error taxonomy is public API.
+
+Documented codes covered here
+-----------------------------
+things-bridge /v1/* data endpoints:
+  unauthorized (401), token_expired (401), scope_denied (403),
+  authz_unavailable (502), not_found (404),
+  things_permission_denied (503), things_unavailable (502),
+  rate_limited (429).
+things-bridge /health (unversioned):
+  unauthorized (401), token_expired (401), scope_denied (403),
+  authz_unavailable (502).
+things-bridge /metrics (unversioned):
+  unauthorized (401), token_expired (401), scope_denied (403),
+  authz_unavailable (502).
+things-bridge server-wide:
+  not_found (404), method_not_allowed (405).
+"""
+
+import threading
+
+import pytest
+from things_client_fake.store import FakeThingsClient, FakeThingsStore
+
+from agent_auth_client import (
+    AgentAuthClient,
+    AuthzRateLimitedError,
+    AuthzScopeDeniedError,
+    AuthzTokenExpiredError,
+    AuthzUnavailableError,
+)
+from tests_support.http import get, post
+from things_bridge.config import Config as BridgeConfig
+from things_bridge.errors import (
+    ThingsError,
+    ThingsPermissionError,
+)
+from things_bridge.metrics import build_registry as build_bridge_registry
+from things_bridge.server import ThingsBridgeServer
+
+# -- test infrastructure --
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+class _FakeAuthz(AgentAuthClient):
+    def __init__(self) -> None:
+        super().__init__("http://test-fake")
+        self.exc: Exception | None = None
+
+    def validate(self, token: str, required_scope: str, *, description: str | None = None) -> None:
+        if self.exc is not None:
+            raise self.exc
+
+
+class _InjectableThings:
+    """Wraps FakeThingsClient with error-injection for taxonomy tests."""
+
+    exc: Exception | None = None
+
+    def __init__(self, store: FakeThingsStore):
+        self._client = FakeThingsClient(store)
+
+    def list_todos(self, **kwargs):
+        if self.exc is not None:
+            raise self.exc
+        return self._client.list_todos(**kwargs)
+
+    def get_todo(self, todo_id):
+        if self.exc is not None:
+            raise self.exc
+        return self._client.get_todo(todo_id)
+
+    def list_projects(self, **kwargs):
+        if self.exc is not None:
+            raise self.exc
+        return self._client.list_projects(**kwargs)
+
+    def get_project(self, project_id):
+        if self.exc is not None:
+            raise self.exc
+        return self._client.get_project(project_id)
+
+    def list_areas(self):
+        if self.exc is not None:
+            raise self.exc
+        return self._client.list_areas()
+
+    def get_area(self, area_id):
+        if self.exc is not None:
+            raise self.exc
+        return self._client.get_area(area_id)
+
+
+@pytest.fixture
+def bridge_server():
+    config = BridgeConfig(host="127.0.0.1", port=0)
+    authz = _FakeAuthz()
+    store = FakeThingsStore()
+    things = _InjectableThings(store)
+    registry, metrics = build_bridge_registry()
+    server = ThingsBridgeServer(config, things, authz, registry, metrics)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield authz, things, f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+# == things-bridge: GET /things-bridge/v1/todos (authorization errors) ==
+
+
+def test_bridge_unauthorized_no_token(bridge_server):
+    _, _, base = bridge_server
+    status, body = get(f"{base}/things-bridge/v1/todos")
+    assert status == 401
+    assert body["error"] == "unauthorized"
+
+
+def test_bridge_token_expired(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzTokenExpiredError("expired")
+    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
+    assert status == 401
+    assert body["error"] == "token_expired"
+
+
+def test_bridge_scope_denied(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzScopeDeniedError("denied")
+    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
+    assert status == 403
+    assert body["error"] == "scope_denied"
+
+
+def test_bridge_authz_unavailable(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzUnavailableError("down")
+    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
+    assert status == 502
+    assert body["error"] == "authz_unavailable"
+
+
+def test_bridge_not_found_unknown_id(bridge_server):
+    _, _, base = bridge_server
+    status, body = get(f"{base}/things-bridge/v1/todos/nonexistent-id", _bearer("tok"))
+    assert status == 404
+    assert body["error"] == "not_found"
+
+
+def test_bridge_things_permission_denied(bridge_server):
+    _, things, base = bridge_server
+    things.exc = ThingsPermissionError("denied")
+    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
+    assert status == 503
+    assert body["error"] == "things_permission_denied"
+
+
+def test_bridge_rate_limited(bridge_server):
+    # Coverage for the 429 passthrough path — agent-auth returns 429,
+    # the bridge maps AuthzRateLimitedError back to 429 with the same
+    # Retry-After (see ADR 0027).
+    authz, _, base = bridge_server
+    authz.exc = AuthzRateLimitedError("rate_limited", retry_after_seconds=3)
+    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
+    assert status == 429
+    assert body["error"] == "rate_limited"
+
+
+def test_bridge_things_unavailable(bridge_server):
+    _, things, base = bridge_server
+    things.exc = ThingsError("subprocess failed")
+    status, body = get(f"{base}/things-bridge/v1/todos", _bearer("tok"))
+    assert status == 502
+    assert body["error"] == "things_unavailable"
+
+
+# == things-bridge: GET /things-bridge/health (unversioned) ==
+
+
+def test_bridge_health_unauthorized_no_token(bridge_server):
+    _, _, base = bridge_server
+    status, body = get(f"{base}/things-bridge/health")
+    assert status == 401
+    assert body["error"] == "unauthorized"
+
+
+def test_bridge_health_token_expired(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzTokenExpiredError("expired")
+    status, body = get(f"{base}/things-bridge/health", _bearer("tok"))
+    assert status == 401
+    assert body["error"] == "token_expired"
+
+
+def test_bridge_health_scope_denied(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzScopeDeniedError("denied")
+    status, body = get(f"{base}/things-bridge/health", _bearer("tok"))
+    assert status == 403
+    assert body["error"] == "scope_denied"
+
+
+def test_bridge_health_authz_unavailable(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzUnavailableError("down")
+    status, body = get(f"{base}/things-bridge/health", _bearer("tok"))
+    assert status == 502
+    assert body["error"] == "authz_unavailable"
+
+
+# == things-bridge: GET /things-bridge/metrics (unversioned) ==
+
+
+def test_bridge_metrics_unauthorized_no_token(bridge_server):
+    _, _, base = bridge_server
+    status, body = get(f"{base}/things-bridge/metrics")
+    assert status == 401
+    assert body["error"] == "unauthorized"
+
+
+def test_bridge_metrics_token_expired(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzTokenExpiredError("expired")
+    status, body = get(f"{base}/things-bridge/metrics", _bearer("tok"))
+    assert status == 401
+    assert body["error"] == "token_expired"
+
+
+def test_bridge_metrics_scope_denied(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzScopeDeniedError("denied")
+    status, body = get(f"{base}/things-bridge/metrics", _bearer("tok"))
+    assert status == 403
+    assert body["error"] == "scope_denied"
+
+
+def test_bridge_metrics_authz_unavailable(bridge_server):
+    authz, _, base = bridge_server
+    authz.exc = AuthzUnavailableError("down")
+    status, body = get(f"{base}/things-bridge/metrics", _bearer("tok"))
+    assert status == 502
+    assert body["error"] == "authz_unavailable"
+
+
+# == things-bridge: server-wide ==
+
+
+def test_bridge_not_found_unknown_path(bridge_server):
+    _, _, base = bridge_server
+    status, body = get(f"{base}/things-bridge/v1/does-not-exist", _bearer("tok"))
+    assert status == 404
+    assert body["error"] == "not_found"
+
+
+def test_bridge_method_not_allowed(bridge_server):
+    _, _, base = bridge_server
+    status, body = post(f"{base}/things-bridge/v1/todos", {})
+    assert status == 405
+    assert body["error"] == "method_not_allowed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -355,6 +355,7 @@ module = [
     "test_things_applescript_failure",
     "test_things_bridge_cli",
     "test_things_bridge_client",
+    "test_things_bridge_error_taxonomy",
     "test_things_bridge_server",
     "test_things_bridge_shutdown",
     "test_things_bridge_tls",

--- a/scripts/verify-standards.sh
+++ b/scripts/verify-standards.sh
@@ -1885,12 +1885,25 @@ fi
 
 echo "verify-standards: ${audit_schema_file} exists and references all documented audit event kinds."
 
-# Error taxonomy contract tests: tests/test_error_taxonomy.py must exist and
-# reference each documented error code
+# Error taxonomy contract tests: per-package contract files must exist
+# and together reference each documented error code
 # (.claude/instructions/service-design.md — stable error taxonomy).
-error_taxonomy_file="packages/agent-auth/tests/test_error_taxonomy.py"
-if [[ ! -f "${error_taxonomy_file}" ]]; then
-  echo "verify-standards: ${error_taxonomy_file} does not exist." >&2
+# The taxonomy is split across two files so each per-package unit-test
+# shard stays self-contained (issue #519): the agent-auth half does not
+# import the bridge's test-only ``things_client_fake`` module, and the
+# things-bridge half does not import any agent-auth-only test fixtures.
+error_taxonomy_files=(
+  "packages/agent-auth/tests/test_error_taxonomy.py"
+  "packages/things-bridge/tests/test_things_bridge_error_taxonomy.py"
+)
+error_taxonomy_missing_file=0
+for f in "${error_taxonomy_files[@]}"; do
+  if [[ ! -f "${f}" ]]; then
+    echo "verify-standards: ${f} does not exist." >&2
+    error_taxonomy_missing_file=1
+  fi
+done
+if [[ ${error_taxonomy_missing_file} -ne 0 ]]; then
   echo "  Create contract tests for every documented error code in design/error-codes.md." >&2
   exit 1
 fi
@@ -1904,8 +1917,8 @@ error_codes=(
 )
 error_missing=0
 for code in "${error_codes[@]}"; do
-  if ! grep -q "\"${code}\"" "${error_taxonomy_file}"; then
-    echo "verify-standards: error code '${code}' not referenced in ${error_taxonomy_file}." >&2
+  if ! grep -hq "\"${code}\"" "${error_taxonomy_files[@]}"; then
+    echo "verify-standards: error code '${code}' not referenced in any of: ${error_taxonomy_files[*]}." >&2
     error_missing=1
   fi
 done
@@ -1913,7 +1926,7 @@ if [[ ${error_missing} -ne 0 ]]; then
   exit 1
 fi
 
-echo "verify-standards: ${error_taxonomy_file} exists and references all documented error codes."
+echo "verify-standards: ${error_taxonomy_files[*]} exist and together reference all documented error codes."
 
 # OpenAPI specs live alongside the service that owns each surface
 # (packages/agent-auth/openapi/agent-auth.v1.yml,
@@ -1963,10 +1976,11 @@ echo "verify-standards: packages/*/openapi/*.v1.yml exist and ${openapi_contract
 #     response (503 for agent-auth when the store ping fails; 502 for
 #     things-bridge when the authz upstream is unavailable).
 #
-# The check is scoped per-function (not per-file): without that,
-# tests/test_error_taxonomy.py would satisfy the gate for any route
-# because it mentions every route and every status code somewhere in
-# the file.
+# The check is scoped per-function (not per-file): without that, the
+# error-taxonomy contract files (test_error_taxonomy.py /
+# test_things_bridge_error_taxonomy.py) would satisfy the gate for any
+# route because they mention every route and every status code
+# somewhere in the file.
 
 health_drift="$(
   python3 - <<'PY'


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith -->
<!-- SPDX-License-Identifier: MIT -->

==COMMIT_MSG==
The per-package unit-test shards introduced in #491 each run only
against ``packages/<package>/tests/`` with that package's own
``pyproject.toml`` rootdir, so the workspace-wide pythonpath that used
to surface ``things_client_fake`` to every shard no longer applies.
``packages/agent-auth/tests/test_error_taxonomy.py`` therefore failed
the agent-auth shard at collection time once Phase 5 of the test.yml
split (#516) re-enabled CI: the file imported ``things_client_fake``
to drive things-bridge's half of the taxonomy, and that module ships
under ``packages/things-bridge/tests/``.

Split the contract along the same per-package boundary that the
shards already enforce. The agent-auth file keeps the agent-auth half
and loses every cross-package import; a sibling file under
``packages/things-bridge/tests/`` carries the things-bridge half and
keeps the ``things_client_fake`` dependency confined to the package
that already ships it. Each docstring cross-references the other so
future readers see the full taxonomy at a glance, and
``scripts/verify-standards.sh`` now grep-checks both files together
so the workspace-wide guarantee (every documented error code is
exercised) stays intact.

Closes #519
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

### Why split the file (option 1) instead of moving it whole

Both halves of the contract are about each package's own server, so
the natural per-package boundary is per-test-class — not per-file.
Splitting:

- Preserves the per-package test-shard isolation #491 introduced
  (each shard imports only its package's own test fixtures).
- Lets each package's coverage gate measure its own taxonomy
  enforcement (things-bridge keeps its 83% floor; agent-auth keeps
  its 78% floor).
- Avoids forcing one package's shard to depend on the other's
  ``tests/`` tree as a python path — which the issue explicitly
  flagged as a smell that #491's per-package isolation is meant to
  prevent.

The alternative (move the whole file under ``packages/things-bridge/tests/``
or to a workspace-level ``tests/integration/``) would either
re-create the cross-package dependency in the opposite direction
or introduce a new test-tree that nothing else uses.

### Test plan

- [ ] `task check-standards` (verify-standards confirms both contract
      files exist and together reference every documented error code).
- [ ] `uv run --no-sync pytest --no-cov --ignore=packages/agent-auth/tests/integration packages/agent-auth/tests/`
      (replicates the `test-unit / unit-tests (agent-auth)` shard;
      collection no longer fails on the missing
      ``things_client_fake`` import).
- [ ] `uv run --no-sync pytest --no-cov --ignore=packages/things-bridge/tests/integration packages/things-bridge/tests/`
      (things-bridge shard still passes with the new file added).
- [ ] `uv run --no-sync mypy` (no duplicate-module collision between
      the two shards' ``test_*_taxonomy`` modules).
