### PR TITLE
chore(ci): aggregator gates on test-* shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
     # branch-protection ruleset switch from per-workflow required
     # checks to this one aggregator is tracked under #5.2.
     name: Required checks passed
-    needs: [plan, check-docs, check-changelog, check-publish, check-pull-request, check-lint, check-standards, build, check-release, check-security, check-fmt]
+    needs: [plan, check-docs, check-changelog, check-publish, check-pull-request, check-lint, check-standards, build, check-release, check-security, check-fmt, test-unit, test-integration, test-smoke, test-system]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
==COMMIT_MSG==
The required-checks-passed job in ci.yml aggregated only the
non-test workflow_call children (plan, check-*, build); the four
test-* siblings landed in #491 (test-unit, test-integration,
test-smoke, test-system) were never added to its needs: list. Per
the #441 contract ("fails on any failed/skipped/timed-out
result"), missing children silently bypass the gate, so a red
test shard would still leave Required checks passed green and
unblock merge under the post-#5.2 branch-protection ruleset.

Extend the list to cover all four shards so the aggregator
faithfully reflects every PR-time CI signal.

Closes #518
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

### Test plan

- [ ] CI on this PR shows the four `test-*` children listed under the `Required checks passed` aggregator's `needs:` (visible by inspecting the job graph).
- [ ] `Required checks passed` succeeds only when every test shard is `success` (verified implicitly by this PR's own green run).
