### PR TITLE
chore(ci): merge-bot workflow_run includes new CI workflow

### DIFF
--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -107,10 +107,7 @@ on:
   #   - Release Tag (only fires on PR `closed`, well after merge).
   workflow_run:
     workflows:
-      - Test
-      - Check
-      - Typecheck
-      - CodeQL
+      - CI
       - PR Lint
       - DCO
       - Changelog Lint


### PR DESCRIPTION
==COMMIT_MSG==
The `workflow_run` allowlist still names `Test`, `Check`, `Typecheck`,
and `CodeQL` — workflows retired in #491, #509, and #516 (Phase 5
cutover). None of them fire on `main` anymore, so the post-label
`workflow_run.completed` retry never matches the new umbrella `CI`
workflow that replaced them.

Reproduced on PR #524 (2026-05-02): bot fired once on `automerge`
label while CI was still failing, exited with `Refuse to merge`,
then never re-fired once CI turned green. The PR sat with green
checks and `automerge` applied until a maintainer used the
`gh workflow run merge-bot.yml -f pr_number=<N>` break-glass.

Drop the four retired names and add `CI` so the parent workflow's
single `workflow_run.completed` event triggers the retry. CI is
the `workflow_call` aggregator for every gating check shard
(`check-*`, `test-*`, codeql), so its completion already signals
"every PR-gating shard has settled" — no need to enumerate the
shards individually.

Closes #525
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

This is a one-line-area edit to `.github/workflows/merge-bot.yml`
that swaps four retired workflow names (`Test`, `Check`,
`Typecheck`, `CodeQL`) for the new umbrella `CI` workflow in the
`on.workflow_run.workflows` allowlist. No behaviour changes for
the bot itself — only the set of completion events that re-fire
it.

The bot fixing its own auto-retry trigger is exactly the
"applied-label-early-on-failing-CI" recovery path described in
the issue body, so the orchestrator may need the
`gh workflow run merge-bot.yml -f pr_number=<N>` break-glass on
this very PR. That's expected.

### Test plan

- [ ] `git diff origin/main` shows exactly 4 deletions + 1 insertion in `.github/workflows/merge-bot.yml`
- [ ] `pr-lint` check passes (title scope `ci` is in the allowlist; `==COMMIT_MSG==` block well-formed)
- [ ] `no changelog` label present so `check-changelog/exists` passes
- [ ] All CI checks turn green after the empty-commit re-trigger fires `ci.yml` with the label visible
