### PR TITLE
chore(ci): verified partial re-run on label events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,26 @@ name: CI
 
 on:
   pull_request:
-    # Default activity types — `opened`, `synchronize`, `reopened`,
-    # `ready_for_review`. The aggregator surfaces as a status check
-    # on every PR, including draft → ready transitions. Restricted
-    # to PRs targeting `main` to match the convention every other
-    # PR-time workflow in this repo (`test.yml`, `check.yml`,
+    # Activity types — `opened`, `synchronize`, `reopened`,
+    # `ready_for_review` cover the diff-changing transitions; the
+    # aggregator surfaces as a status check on every PR, including
+    # draft → ready transitions. `labeled` and `unlabeled` are
+    # included so PR-time workflows that gate on labels
+    # (`check-changelog/exists` reading `no changelog`,
+    # dependabot-adapter reading `automerge`) re-fire when the label
+    # set changes — without them, applying `no changelog` after
+    # `gh pr create` left ci.yml stuck on the original `labels=[]`
+    # payload and `Required checks passed` reported a stale failure
+    # (issue #527). The diff-dependent children are skipped on
+    # label-only re-runs via the verified-prior-success path
+    # below, so the wasted-runtime cost of widening the trigger
+    # surface is bounded to the metadata-dependent children
+    # (`check-changelog`, `check-pull-request`). Restricted to PRs
+    # targeting `main` to match the convention every other PR-time
+    # workflow in this repo (`test.yml`, `check.yml`,
     # `typecheck.yml`, ...) uses.
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   push:
     branches: [main]
   merge_group:
@@ -67,6 +79,16 @@ jobs:
       docs_changed: ${{ steps.filter.outputs.docs }}
       design_changed: ${{ steps.filter.outputs.design }}
       workflows_changed: ${{ steps.filter.outputs.workflows }}
+      # Verified-prior-success flag (issue #527 / Option 4). `true`
+      # only on `labeled` / `unlabeled` events whose head SHA already
+      # has a non-failing conclusion for every diff-dependent child
+      # check-run; downstream `<job>:` `if:` gates and the aggregator
+      # carve-out both consume this. `false` on every other event
+      # (the diff itself changed → prior check-runs are stale by
+      # definition) and whenever the prior conclusion of any
+      # diff-dependent child is `failure` / `cancelled` /
+      # `timed_out` / `missing` (the safe-default branch).
+      diff_dependent_jobs_already_passed: ${{ steps.prior.outputs.diff_dependent_jobs_already_passed }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -128,6 +150,78 @@ jobs:
               - '.github/workflows/**'
               - '.github/actions/**'
 
+      - name: Probe prior run state on this head SHA
+        id: prior
+        # Verified partial-rerun gate for label-only events
+        # (issue #527 / Option 4). On `labeled` / `unlabeled` the
+        # head SHA is identical to the previous `synchronize`'s
+        # head SHA — so any check-run on that SHA whose conclusion
+        # is non-failing is still authoritative. We probe each
+        # diff-dependent child via the Checks API; if every one
+        # is non-failing on this SHA, downstream `<job>:` blocks
+        # skip via the `if:` gate below and the aggregator's
+        # `skipped = failure` rule (#441) is relaxed for that
+        # specific case. If ANY child's prior conclusion is
+        # `failure` / `cancelled` / `timed_out` / `missing`, the
+        # flag is `false` and downstream children run as today —
+        # safe default, no regression.
+        #
+        # The Checks API endpoint
+        # (`repos/{owner}/{repo}/commits/{sha}/check-runs`) accepts
+        # the workflow-level `contents: read` permission, which the
+        # `plan` job inherits — no additional permissions needed.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+          # On `opened` / `synchronize` / `reopened` /
+          # `ready_for_review` the diff itself changed (or this is
+          # the first run on the SHA), so prior check-runs are
+          # stale by definition.
+          if [[ "${EVENT_ACTION}" != "labeled" && "${EVENT_ACTION}" != "unlabeled" ]]; then
+            echo "diff_dependent_jobs_already_passed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          # Diff-dependent check-run names — derived from
+          # `required-checks-passed.needs:` minus the metadata-
+          # dependent allowlist. Driving this from a helper rather
+          # than enumerating inline keeps the list in lockstep with
+          # ci.yml itself: when a new child is added to `needs:`,
+          # the helper auto-extends and the carve-out covers it
+          # without churning this file.
+          diff_dependent=$(scripts/ci/diff-dependent-jobs.sh)
+
+          rollup=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs" \
+            --paginate --jq '.check_runs')
+
+          all=true
+          while IFS= read -r name; do
+            [[ -z "${name}" ]] && continue
+            latest=$(jq -r --arg n "${name}" \
+              '[.[] | select(.name == $n)] | sort_by(.started_at) | .[-1].conclusion // "missing"' \
+              <<<"${rollup}")
+            # `success` / `neutral` / `skipped` from a prior label-
+            # aware run all preserve the SUCCESS contract for the
+            # aggregator. Anything else (`failure`, `cancelled`,
+            # `timed_out`, `missing`, `action_required`,
+            # `startup_failure`, `null`) invalidates the skip and
+            # the children re-run.
+            case "${latest}" in
+              success | neutral | skipped) ;;
+              *)
+                echo "::notice::diff-dependent job '${name}' conclusion=${latest} on head ${HEAD_SHA}; will re-run."
+                all=false
+                break
+                ;;
+            esac
+          done <<<"${diff_dependent}"
+
+          echo "diff_dependent_jobs_already_passed=${all}" >> "${GITHUB_OUTPUT}"
+
   check-fmt:
     # Intermediate orchestrator carrying formatting / lint children
     # (issue #452 lands `spdx-license-headers`; #459 will add treefmt
@@ -136,6 +230,14 @@ jobs:
     # opt into changed-files gating.
     name: Check Fmt
     needs: [plan]
+    # Diff-dependent: outcome is determined by code in the head SHA.
+    # Skip on `labeled`/`unlabeled` re-runs whose head SHA already
+    # passed (issue #527 / Option 4). The aggregator carve-out at
+    # the bottom of this file converts the resulting `skipped`
+    # result back into a SUCCESS contract, but only when the same
+    # flag is true — so the relaxation can't fire unless the probe
+    # in `plan` verified the prior pass.
+    if: needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'
     uses: ./.github/workflows/check-fmt.yml
   check-security:
     # Security-cadence child orchestrator (issue #447). Carries CodeQL
@@ -147,6 +249,8 @@ jobs:
     # reference plan outputs without churning this file.
     name: Check Security
     needs: [plan]
+    # Diff-dependent — see `check-fmt` above for the gate contract.
+    if: needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'
     uses: ./.github/workflows/check-security.yml
     permissions:
       # Granted to the `check-security.yml` chain. workflow_call
@@ -172,6 +276,8 @@ jobs:
     # continues to run alongside this chain until the Phase 5 sweep.
     name: check-lint
     needs: [plan]
+    # Diff-dependent — see `check-fmt` above for the gate contract.
+    if: needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'
     uses: ./.github/workflows/check-lint.yml
     secrets: inherit
   check-docs:
@@ -181,6 +287,8 @@ jobs:
     # `.github/workflows/check-docs.yml` for the TODO marker.
     name: check-docs
     needs: [plan]
+    # Diff-dependent — see `check-fmt` above for the gate contract.
+    if: needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'
     uses: ./.github/workflows/check-docs.yml
 
   test-unit:
@@ -193,6 +301,8 @@ jobs:
     # parallel until Phase 5 retires the original.
     name: test-unit
     needs: [plan]
+    # Diff-dependent — see `check-fmt` above for the gate contract.
+    if: needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'
     uses: ./.github/workflows/test-unit.yml
 
   test-integration:
@@ -203,6 +313,8 @@ jobs:
     # workflow runs in parallel until Phase 5.
     name: test-integration
     needs: [plan]
+    # Diff-dependent — see `check-fmt` above for the gate contract.
+    if: needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'
     uses: ./.github/workflows/test-integration.yml
 
   test-smoke:
@@ -213,6 +325,8 @@ jobs:
     # workflow runs in parallel until Phase 5.
     name: test-smoke
     needs: [plan]
+    # Diff-dependent — see `check-fmt` above for the gate contract.
+    if: needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'
     uses: ./.github/workflows/test-smoke.yml
 
   test-system:
@@ -222,6 +336,8 @@ jobs:
     # workflow runs in parallel until Phase 5.
     name: test-system
     needs: [plan]
+    # Diff-dependent — see `check-fmt` above for the gate contract.
+    if: needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'
     uses: ./.github/workflows/test-system.yml
   build:
     # Production-artifact build child workflow (issue #460). Runs
@@ -233,6 +349,8 @@ jobs:
     # branch-protection ruleset switches to this aggregator (#5.2).
     name: build
     needs: [plan]
+    # Diff-dependent — see `check-fmt` above for the gate contract.
+    if: needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'
     uses: ./.github/workflows/build.yml
 
   check-release:
@@ -246,6 +364,8 @@ jobs:
     # switches to this aggregator (#5.2).
     name: check-release
     needs: [plan]
+    # Diff-dependent — see `check-fmt` above for the gate contract.
+    if: needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'
     uses: ./.github/workflows/check-release.yml
   check-standards:
     # Project-standards slot (issue #455). Runs `task verify-standards`
@@ -255,6 +375,8 @@ jobs:
     # not modify the branch-protection ruleset (strategy C).
     name: check-standards
     needs: [plan]
+    # Diff-dependent — see `check-fmt` above for the gate contract.
+    if: needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'
     uses: ./.github/workflows/check-standards.yml
   check-pull-request:
     # PR-metadata child workflow (issue #450). Houses jobs that
@@ -277,6 +399,8 @@ jobs:
     # in this PR.
     name: check-publish
     needs: [plan]
+    # Diff-dependent — see `check-fmt` above for the gate contract.
+    if: needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'
     uses: ./.github/workflows/check-publish.yml
   check-changelog:
     # Changelog gating slot (issue #451). Splits the legacy
@@ -313,10 +437,65 @@ jobs:
         # will need to surface a `success` result (e.g. via a
         # short-circuit step) rather than skipping the job
         # altogether.
+        #
+        # Carve-out (issue #527 / Option 4): when a `labeled`/
+        # `unlabeled` event re-runs ci.yml and the `plan` job's
+        # probe step verified that every diff-dependent child
+        # already produced a non-failing conclusion on the same
+        # head SHA, those children skip via the `if:` gate above.
+        # `skipped` then maps to SUCCESS for that specific set —
+        # but ONLY when `diff_dependent_jobs_already_passed ==
+        # 'true'`, AND ONLY for the ci.yml job IDs in
+        # DIFF_DEPENDENT_JOB_IDS below. Anything outside that set
+        # (the metadata-dependent children `check-changelog` and
+        # `check-pull-request`, plus `plan` itself) keeps the
+        # original strict #441 contract. The carve-out can't fire
+        # without the verified-prior-success flag, so a label
+        # change against a SHA whose CI never finished still
+        # fails on `skipped` — by design.
         env:
           NEEDS: ${{ toJSON(needs) }}
+          DIFF_DEPENDENT_JOBS_ALREADY_PASSED: ${{ needs.plan.outputs.diff_dependent_jobs_already_passed }}
+          # Mirror of the diff-dependent ci.yml job IDs that
+          # `scripts/ci/diff-dependent-jobs.sh` enumerates (the
+          # script outputs LEAF check-run names; here we need the
+          # parent ci.yml job IDs that show up as keys in
+          # `needs.*`). Drift between this list and the script is
+          # caught by `tests/test_ci_diff_dependent_probe.py`.
+          DIFF_DEPENDENT_JOB_IDS: |
+            check-fmt
+            check-security
+            check-lint
+            check-docs
+            check-publish
+            check-release
+            check-standards
+            build
+            test-unit
+            test-integration
+            test-smoke
+            test-system
         run: |
           set -euo pipefail
+          # Build a jq-side set of the diff-dependent job IDs from
+          # the env list. Strip blank lines so the YAML block
+          # scalar's trailing newline doesn't add an empty key.
+          diff_dependent_set=$(printf '%s\n' "${DIFF_DEPENDENT_JOB_IDS}" \
+            | awk 'NF' \
+            | jq -R . \
+            | jq -s 'map({(.): true}) | add')
+
           echo "${NEEDS}" \
-            | jq -e 'to_entries | all(.value.result == "success")' \
+            | jq -e \
+                --arg flag "${DIFF_DEPENDENT_JOBS_ALREADY_PASSED}" \
+                --argjson dd "${diff_dependent_set}" \
+                'to_entries
+                  | all(
+                      .value.result == "success"
+                      or (
+                        $flag == "true"
+                        and ($dd[.key] // false)
+                        and .value.result == "skipped"
+                      )
+                    )' \
             > /dev/null

--- a/scripts/ci/diff-dependent-jobs.sh
+++ b/scripts/ci/diff-dependent-jobs.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+# Print the list of GitHub check-run names whose outcome depends only on
+# the code at the PR's head SHA — the "diff-dependent" set, distinct from
+# checks that read PR metadata (labels, title, body, milestone).
+#
+# Used by the `plan` job in `.github/workflows/ci.yml` (issue #527 /
+# Option 4 — verified partial re-run on label-only events). On a
+# `labeled` / `unlabeled` event the head SHA is the same as the prior
+# `synchronize`, so any check-run that already produced `success` on
+# that SHA is still authoritative; those checks can skip and the
+# aggregator's `skipped = failure` rule (#441) is relaxed for them
+# specifically. The list of "those checks" must be derived rather
+# than copy-pasted, otherwise drift between ci.yml and the probe
+# silently breaks the safety invariant — see "Keeping the list in
+# sync" in #527 for the rationale.
+#
+# Derivation: read ci.yml's `required-checks-passed.needs:` array,
+# subtract the planning job (`plan`) and the metadata-dependent
+# allowlist, and expand each surviving ci.yml job ID into the leaf
+# check-run names GitHub publishes for that workflow_call child.
+#
+# The job-ID → leaf-check-runs mapping is hard-coded inline in this
+# script. Each entry is small enough to read at a glance, and the
+# accompanying `tests/test_ci_diff_dependent_jobs_sh.py` test runs
+# the script against the real ci.yml and asserts every emitted name
+# matches a check-run GitHub actually produces, so drift between this
+# script and either ci.yml's needs list or any child workflow's
+# matrix membership fails CI rather than degrading silently.
+#
+# Usage:
+#   scripts/ci/diff-dependent-jobs.sh [path-to-ci.yml]
+#
+# Default ci.yml path is `.github/workflows/ci.yml` relative to the
+# repo root (auto-detected via the script's own location).
+#
+# Output: one check-run name per line on stdout. No external
+# dependencies beyond `yq` (already in the repo's required tooling
+# per CLAUDE.md and `scripts/verify-dependencies.sh`).
+
+set -euo pipefail
+
+if [[ $# -gt 1 ]]; then
+  echo "diff-dependent-jobs: expected at most 1 arg (path to ci.yml); got $#" >&2
+  exit 2
+fi
+
+# Repo root resolved from the script's own location so callers can
+# invoke from any cwd (the `plan` job runs from the workspace root,
+# but tests may invoke from elsewhere).
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "${script_dir}/../.." && pwd)
+ci_yml="${1:-${repo_root}/.github/workflows/ci.yml}"
+
+if [[ ! -f "${ci_yml}" ]]; then
+  echo "diff-dependent-jobs: ci.yml not found at: ${ci_yml}" >&2
+  exit 2
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "diff-dependent-jobs: yq is required but not installed" >&2
+  exit 2
+fi
+
+# Metadata-dependent ci.yml job IDs. Their outcome may change
+# between label events on the same head SHA, so they MUST re-run
+# unconditionally. Default for any new child is "diff-dependent" —
+# only add a job here if its evaluation reads PR metadata
+# (labels, title, body, milestone, etc.).
+#
+# - check-changelog: reads `pull_request.labels` for the bypass and
+#   `pull_request.head.ref` for the entry-name slug check.
+# - check-pull-request: reads commit-message metadata via
+#   `pull_request.{base,head}.sha` and DCO sign-off, both of which
+#   are diff-dependent in practice — but the workflow ALSO houses
+#   pr-lint validators (title, body, commit-message block per ADR
+#   0037) once they migrate, which read PR metadata. Listed here
+#   so the gating story stays uniform across pr-lint additions.
+metadata_dependent=(
+  check-changelog
+  check-pull-request
+)
+
+# Read `required-checks-passed.needs:` as a flat list, one job ID per
+# line. `yq -r '.[] | .'` flattens the YAML array; the input is the
+# `needs` block.
+needs=$(yq -r '.jobs."required-checks-passed".needs[]' "${ci_yml}")
+
+# Apply the subtractions (`plan` + metadata-dependent set) using
+# associative-array set membership so the script remains O(n).
+declare -A excluded=([plan]=1)
+for j in "${metadata_dependent[@]}"; do
+  excluded["${j}"]=1
+done
+
+# Iterate the surviving job IDs in the order ci.yml lists them. Order
+# is stable so the script's stdout is deterministic, which the tests
+# rely on for golden-file comparisons.
+diff_dependent_job_ids=()
+while IFS= read -r jid; do
+  [[ -z "${jid}" ]] && continue
+  if [[ -z "${excluded["${jid}"]+x}" ]]; then
+    diff_dependent_job_ids+=("${jid}")
+  fi
+done <<<"${needs}"
+
+# Expand each ci.yml job ID into the leaf check-run names GitHub
+# publishes. The naming convention is `<calling-job-display-name> /
+# <called-job-display-name>` — when a workflow_call child has its
+# own internal `Required checks passed` aggregator (check-fmt,
+# check-lint, check-security) we probe that single rollup; otherwise
+# we list the matrix-expanded leaves explicitly.
+#
+# Display names (the parent's `name:` in ci.yml, when present) are
+# spelled exactly as GitHub renders them in the PR check rollup —
+# capitalisation matters. See the issue body for a sample rollup.
+emit_leaves() {
+  local jid="$1"
+  case "${jid}" in
+    check-fmt)
+      echo "Check Fmt / Required checks passed"
+      ;;
+    check-security)
+      echo "Check Security / Required checks passed"
+      ;;
+    check-lint)
+      echo "check-lint / Required checks passed"
+      ;;
+    check-docs)
+      echo "check-docs / check-docs"
+      ;;
+    check-publish)
+      echo "check-publish / check-publish"
+      ;;
+    check-release)
+      echo "check-release / check-release"
+      ;;
+    check-standards)
+      echo "check-standards / verify-standards"
+      ;;
+    build)
+      echo "build / build"
+      ;;
+    test-unit)
+      # Matrix: one row per workspace member; names per the parens
+      # variant convention (#414). Keep in sync with
+      # `.github/workflows/test-unit.yml`'s `matrix.package`.
+      echo "test-unit / unit-tests (agent-auth)"
+      echo "test-unit / unit-tests (agent-auth-common)"
+      echo "test-unit / unit-tests (gpg-bridge)"
+      echo "test-unit / unit-tests (gpg-cli)"
+      echo "test-unit / unit-tests (things-bridge)"
+      echo "test-unit / unit-tests (things-cli)"
+      echo "test-unit / unit-tests (things-client-cli-applescript)"
+      ;;
+    test-integration)
+      # Matrix: per-package Docker-backed integration shards. Keep in
+      # sync with `.github/workflows/test-integration.yml`.
+      echo "test-integration / integration-tests (agent-auth)"
+      echo "test-integration / integration-tests (gpg-bridge)"
+      echo "test-integration / integration-tests (things-bridge)"
+      echo "test-integration / integration-tests (things-cli)"
+      echo "test-integration / integration-tests (things-client-applescript)"
+      ;;
+    test-smoke)
+      # Matrix: install-from-wheels for the externally-shipped CLIs.
+      # Keep in sync with `.github/workflows/test-smoke.yml`'s
+      # `matrix.service`.
+      echo "test-smoke / install-from-wheels (gpg-bridge, gpg-bridge)"
+      echo "test-smoke / install-from-wheels (things-cli, things-cli)"
+      ;;
+    test-system)
+      echo "test-system / macos-applescript"
+      ;;
+    *)
+      echo "diff-dependent-jobs: unmapped ci.yml job ID: ${jid}" >&2
+      echo "  add a case arm to emit_leaves() (or, if the job is" >&2
+      echo "  metadata-dependent, add it to the metadata_dependent" >&2
+      echo "  array near the top of this script)" >&2
+      exit 2
+      ;;
+  esac
+}
+
+for jid in "${diff_dependent_job_ids[@]}"; do
+  emit_leaves "${jid}"
+done

--- a/tests/test_ci_diff_dependent_probe.py
+++ b/tests/test_ci_diff_dependent_probe.py
@@ -1,0 +1,482 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Static-pin tests for the verified partial-rerun on label events.
+
+The CI parent (`.github/workflows/ci.yml`) used to declare
+`pull_request: types: [opened, synchronize, reopened, ready_for_review]`,
+omitting `labeled` / `unlabeled`. As a result, applying or removing a
+label after `gh pr create` did NOT re-fire ci.yml — the
+`check-changelog/exists` child evaluated `[[ ",${PR_LABELS}," ==
+*",no changelog,"* ]]` against the original `labels=[]` payload and
+emitted a stale-failure status that blocked merging. The recurring
+workaround was to push an empty commit per PR to re-fire CI; that paid
+the full ~5-10 minute CI cost on every label flip.
+
+Issue #527 fixed this in three coupled phases (Option 4 — verified
+partial re-run):
+
+1. ``plan`` job's ``Probe prior run state on this head SHA`` step
+   queries the Checks API for prior conclusions on the head SHA on
+   ``labeled`` / ``unlabeled`` events; sets the
+   ``diff_dependent_jobs_already_passed`` job output to ``true`` when
+   every diff-dependent child has a non-failing conclusion already.
+2. Every diff-dependent ci.yml ``<job>:`` block carries
+   ``if: needs.plan.outputs.diff_dependent_jobs_already_passed !=
+   'true'`` so it skips on verified-prior-success label flips.
+3. ``required-checks-passed`` aggregator gets a tight carve-out: when
+   the flag is ``true``, ``skipped`` results on the diff-dependent
+   children specifically map to SUCCESS (relaxing the #441 strict
+   contract for that specific case only).
+4. ``pull_request: types:`` adds ``labeled, unlabeled`` so the
+   re-fire actually happens.
+
+These tests pin the public-facing shape of those four properties.
+Drift in either direction (a new diff-dependent child added without
+the ``if:`` gate, the carve-out widened beyond the verified-prior-
+success case, the ``types:`` list narrowed back) breaks the safety
+property silently — the tests surface it at PR time instead.
+
+Test placement: tests/ alongside test_merge_bot_workflow_run_trigger.py
+— same workflow-yaml-loading pattern, same regression-pin shape.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+HELPER_PATH = REPO_ROOT / "scripts" / "ci" / "diff-dependent-jobs.sh"
+
+# Diff-dependent ci.yml job IDs — the set on which the verified-prior-
+# success skip is allowed. The test below cross-checks this against
+# (a) the helper script's output by deriving the same set from the
+# aggregator's needs and (b) the aggregator's DIFF_DEPENDENT_JOB_IDS
+# env entry. Drift across the three locations breaks the carve-out.
+DIFF_DEPENDENT_JOB_IDS: frozenset[str] = frozenset(
+    {
+        "build",
+        "check-docs",
+        "check-fmt",
+        "check-lint",
+        "check-publish",
+        "check-release",
+        "check-security",
+        "check-standards",
+        "test-integration",
+        "test-smoke",
+        "test-system",
+        "test-unit",
+    }
+)
+
+# Metadata-dependent children — keep the unconditional `needs: [plan]`
+# on every event because their evaluation reads PR metadata
+# (`pull_request.labels`, `pull_request.title`, `pull_request.body`,
+# DCO sign-off chain, etc.) that can differ between events on the
+# same head SHA.
+METADATA_DEPENDENT_JOB_IDS: frozenset[str] = frozenset(
+    {
+        "check-changelog",
+        "check-pull-request",
+    }
+)
+
+# The diff-dependent gate's conditional, spelled exactly as it must
+# appear in ci.yml. Yaml booleans `true` / `false` are GitHub Actions
+# expression-language strings, not YAML booleans, so quoting matters.
+DIFF_DEPENDENT_GATE = "needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'"
+
+
+def _load_workflow() -> dict[Any, Any]:
+    return cast(
+        "dict[Any, Any]",
+        yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8")),
+    )
+
+
+# `on` is parsed as the Python boolean key `True` by PyYAML 1.1
+# semantics. Look it up via either key so the test is robust to
+# PyYAML version drift. Mirrors the helper in
+# test_merge_bot_workflow_run_trigger.py.
+def _on_block(workflow: dict[Any, Any]) -> dict[str, Any]:
+    if "on" in workflow:
+        return cast("dict[str, Any]", workflow["on"])
+    if True in workflow:
+        return cast("dict[str, Any]", workflow[True])
+    raise AssertionError("ci.yml has no `on:` block")
+
+
+def test_pull_request_types_includes_labeled_and_unlabeled() -> None:
+    """``pull_request: types:`` must include ``labeled, unlabeled``.
+
+    Without these, ci.yml never re-fires when an orchestrator applies
+    ``no changelog`` after ``gh pr create`` — the meta-circular case
+    issue #527 documents (the PR fixing this issue itself paid the
+    empty-commit-retrigger cost because its base branch lacked the
+    trigger). Pinning the set here surfaces a future narrowing
+    immediately.
+    """
+    on_block = _on_block(_load_workflow())
+    pull_request = on_block.get("pull_request")
+    assert isinstance(pull_request, dict), "ci.yml must declare pull_request as a mapping"
+    types = pull_request.get("types")
+    assert isinstance(types, list), "pull_request.types must be a YAML list"
+    for required in (
+        "opened",
+        "synchronize",
+        "reopened",
+        "ready_for_review",
+        "labeled",
+        "unlabeled",
+    ):
+        assert required in types, (
+            f"pull_request.types missing '{required}' — without it the "
+            f"verified partial re-run path can never fire (issue #527)."
+        )
+
+
+def test_plan_job_emits_diff_dependent_jobs_already_passed_output() -> None:
+    """The ``plan`` job must surface the verified-prior-success flag.
+
+    Downstream child gates and the aggregator carve-out both consume
+    ``needs.plan.outputs.diff_dependent_jobs_already_passed``; if the
+    output is renamed or dropped, every gate silently degrades to
+    ``true`` (the ``!= 'true'`` becomes ``!= ''`` which is also
+    truthy → children always skip → aggregator fails). Hard-pin the
+    name.
+    """
+    workflow = _load_workflow()
+    plan_outputs = workflow["jobs"]["plan"].get("outputs", {})
+    assert "diff_dependent_jobs_already_passed" in plan_outputs, (
+        "plan job must emit `diff_dependent_jobs_already_passed` output "
+        "(issue #527 / Option 4). Downstream `if:` gates and aggregator "
+        "carve-out depend on the exact name."
+    )
+    # Sanity: it must reference the `prior` step's output.
+    expr = plan_outputs["diff_dependent_jobs_already_passed"]
+    assert "steps.prior.outputs.diff_dependent_jobs_already_passed" in expr, (
+        "plan output must source from `steps.prior.outputs."
+        "diff_dependent_jobs_already_passed` to keep the contract "
+        "auditable (one place defines the value)."
+    )
+
+
+def test_plan_job_has_probe_prior_run_state_step() -> None:
+    """The ``plan`` job must run the Checks-API probe step.
+
+    Walk the steps list looking for one with ``id: prior`` and a name
+    that mentions probing. The step body's exact shell is not pinned
+    here (lines change with comment edits) but the step's existence is.
+    """
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["plan"]["steps"]
+    matching = [s for s in steps if s.get("id") == "prior"]
+    assert len(matching) == 1, (
+        "plan job must have exactly one step with `id: prior` — the "
+        "Checks-API probe (issue #527). Found "
+        f"{len(matching)}."
+    )
+    step = matching[0]
+    assert "Probe" in step.get("name", ""), (
+        "plan job's `prior` step must have a `name:` mentioning "
+        "'Probe' so the run logs are scannable."
+    )
+    # The probe needs HEAD_SHA, EVENT_ACTION, and GH_TOKEN via env so
+    # user-controlled label names cannot inject shell syntax. The
+    # values themselves are tested via the helper-script tests below.
+    env = step.get("env", {})
+    for key in ("HEAD_SHA", "EVENT_ACTION", "GH_TOKEN"):
+        assert key in env, (
+            f"probe step's env block must declare {key!r}; the shell "
+            f"body reads it through ${{{key}}} (no inline interpolation)."
+        )
+
+
+def test_diff_dependent_children_carry_the_if_gate() -> None:
+    """Every diff-dependent child must skip on verified-prior-success.
+
+    The gate's literal text is pinned — ``!= 'true'`` not ``== 'false'``
+    so an unset value (the safe default on non-label events) treats
+    the children as still needing to run.
+    """
+    workflow = _load_workflow()
+    jobs = workflow["jobs"]
+    for jid in DIFF_DEPENDENT_JOB_IDS:
+        assert jid in jobs, (
+            f"ci.yml job ID {jid!r} listed in DIFF_DEPENDENT_JOB_IDS "
+            f"is not in the actual workflow — update one or the other."
+        )
+        actual = jobs[jid].get("if")
+        assert actual == DIFF_DEPENDENT_GATE, (
+            f"ci.yml job {jid!r} must carry `if: {DIFF_DEPENDENT_GATE}` "
+            f"so it skips on verified-prior-success label re-runs "
+            f"(issue #527). Got: {actual!r}."
+        )
+
+
+def test_metadata_dependent_children_have_no_if_gate() -> None:
+    """Metadata-dependent children must run on every event.
+
+    ``check-changelog`` reads ``pull_request.labels``;
+    ``check-pull-request`` houses the DCO chain plus future pr-lint
+    metadata validators. Both must re-evaluate on label flips, which
+    means NO ``if:`` gate on the parent ci.yml ``<job>:`` block.
+    """
+    workflow = _load_workflow()
+    for jid in METADATA_DEPENDENT_JOB_IDS:
+        assert jid in workflow["jobs"], (
+            f"ci.yml job ID {jid!r} listed in METADATA_DEPENDENT_JOB_IDS "
+            f"is not in the actual workflow."
+        )
+        actual = workflow["jobs"][jid].get("if")
+        assert actual is None, (
+            f"ci.yml job {jid!r} is metadata-dependent — it must "
+            f"NOT carry an `if:` gate so it re-runs on label flips. "
+            f"Got: {actual!r}."
+        )
+
+
+def test_aggregator_carveout_env_lists_exact_diff_dependent_set() -> None:
+    """Aggregator's ``DIFF_DEPENDENT_JOB_IDS`` env must match the set.
+
+    The carve-out only fires when both the verified-prior-success
+    flag is true AND the entry's key is in this list. Drift between
+    this list and the set actually gated by the ``if:`` above leaks
+    one of two ways: a job in the env list but not gated → never
+    skips → no effect (harmless but stale); a job gated but not in
+    the env list → skips on verified-prior-success → aggregator
+    treats it as failure → CI broken. Pin the env list to the
+    same set the gate covers.
+    """
+    workflow = _load_workflow()
+    agg = workflow["jobs"]["required-checks-passed"]
+    step = agg["steps"][0]
+    env = step.get("env", {})
+    raw = env.get("DIFF_DEPENDENT_JOB_IDS", "")
+    assert isinstance(raw, str), (
+        "aggregator's DIFF_DEPENDENT_JOB_IDS env must be a YAML block "
+        "scalar (string), so the bash-side splitter sees newline-"
+        "separated entries."
+    )
+    actual = frozenset(line.strip() for line in raw.splitlines() if line.strip())
+    assert actual == DIFF_DEPENDENT_JOB_IDS, (
+        "aggregator's DIFF_DEPENDENT_JOB_IDS env drift: "
+        f"missing={sorted(DIFF_DEPENDENT_JOB_IDS - actual)} "
+        f"extra={sorted(actual - DIFF_DEPENDENT_JOB_IDS)}. The set "
+        "MUST match the diff-dependent gate's coverage exactly."
+    )
+
+
+def test_aggregator_carveout_conditional_is_tight() -> None:
+    """Aggregator must require BOTH the flag AND set membership.
+
+    The relaxation is auditable only because the conditional gates
+    on TWO conditions: the verified-prior-success flag (so a SHA
+    whose CI never finished can't claim the skip) AND the entry's
+    key being in the diff-dependent set (so the metadata-dependent
+    children's `skipped` is still treated as failure per #441).
+    Pin the bash so a future edit can't accidentally widen.
+    """
+    workflow = _load_workflow()
+    agg = workflow["jobs"]["required-checks-passed"]
+    step = agg["steps"][0]
+    body = step["run"]
+    # The jq filter must reference both the flag and the set.
+    assert '$flag == "true"' in body, (
+        "aggregator carve-out must gate on the verified-prior-success "
+        'flag — `$flag == "true"` — so an unset flag does not allow '
+        "skipped to count as success."
+    )
+    assert "$dd[.key]" in body, (
+        "aggregator carve-out must gate on per-key set membership — "
+        "`$dd[.key]` — so only the diff-dependent children get the "
+        "skipped → success treatment."
+    )
+    assert '.value.result == "skipped"' in body, (
+        "aggregator carve-out must only relax `skipped` results — "
+        "`failure` / `cancelled` / `timed_out` must still fail."
+    )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash unavailable")
+def test_helper_script_outputs_all_expected_check_run_names() -> None:
+    """``scripts/ci/diff-dependent-jobs.sh`` must enumerate the right leaves.
+
+    The helper expands each diff-dependent ci.yml job ID into one or
+    more leaf check-run names (matrix-expanded). The plan-job probe
+    iterates these names against the GitHub Checks API, so an empty
+    or short list means the verified-prior-success flag will be
+    `true` even when not every child actually passed. Pin the
+    expected leaf set explicitly so a matrix-membership change in
+    test-unit / test-integration / test-smoke surfaces here.
+    """
+    expected_leaves = {
+        # check-fmt / check-security / check-lint each have an internal
+        # "Required checks passed" aggregator that consolidates the
+        # workflow_call's matrix children.
+        "Check Fmt / Required checks passed",
+        "Check Security / Required checks passed",
+        "check-lint / Required checks passed",
+        # Single-job children publish one check-run each.
+        "check-docs / check-docs",
+        "check-publish / check-publish",
+        "check-release / check-release",
+        "check-standards / verify-standards",
+        "build / build",
+        "test-system / macos-applescript",
+        # test-unit matrix.
+        "test-unit / unit-tests (agent-auth)",
+        "test-unit / unit-tests (agent-auth-common)",
+        "test-unit / unit-tests (gpg-bridge)",
+        "test-unit / unit-tests (gpg-cli)",
+        "test-unit / unit-tests (things-bridge)",
+        "test-unit / unit-tests (things-cli)",
+        "test-unit / unit-tests (things-client-cli-applescript)",
+        # test-integration matrix.
+        "test-integration / integration-tests (agent-auth)",
+        "test-integration / integration-tests (gpg-bridge)",
+        "test-integration / integration-tests (things-bridge)",
+        "test-integration / integration-tests (things-cli)",
+        "test-integration / integration-tests (things-client-applescript)",
+        # test-smoke matrix — the parens-variant convention emits
+        # `(<service.name>, <service.entrypoint>)` for object matrix
+        # rows, even when both values are identical.
+        "test-smoke / install-from-wheels (gpg-bridge, gpg-bridge)",
+        "test-smoke / install-from-wheels (things-cli, things-cli)",
+    }
+
+    result = subprocess.run(
+        [str(HELPER_PATH)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    actual = {line for line in result.stdout.splitlines() if line.strip()}
+    missing = expected_leaves - actual
+    extra = actual - expected_leaves
+    assert not missing and not extra, (
+        f"diff-dependent-jobs.sh leaf drift: "
+        f"missing={sorted(missing)} extra={sorted(extra)}. Update both "
+        "the helper's `emit_leaves()` mapping and this test's "
+        "`expected_leaves` set."
+    )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash unavailable")
+def test_helper_script_is_idempotent() -> None:
+    """Multiple invocations must produce byte-identical output.
+
+    The helper is invoked once per ci.yml run; a non-deterministic
+    output (e.g. set iteration order in bash) would mean the probe
+    hits a different leaf set across runs and the verified-prior-
+    success flag becomes flaky. Pin determinism here.
+    """
+    runs = [
+        subprocess.run(
+            [str(HELPER_PATH)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        for _ in range(3)
+    ]
+    first = runs[0].stdout
+    for r in runs[1:]:
+        assert r.stdout == first, (
+            "diff-dependent-jobs.sh produced non-deterministic output "
+            "across invocations — the probe will see different leaf "
+            "sets across runs and the verified-prior-success flag "
+            "will be flaky."
+        )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash unavailable")
+def test_helper_script_excludes_metadata_dependent_set() -> None:
+    """Helper must NEVER list a metadata-dependent child's leaves.
+
+    `check-changelog` and `check-pull-request` re-run on every event
+    by design (their evaluation depends on PR metadata, not the
+    diff). Listing them in the helper would cause the probe to check
+    their prior conclusion and — if green — let the verified-prior-
+    success flag flip to true even when the metadata HAS changed
+    between events. The probe must only ever see diff-dependent
+    leaves; the metadata-dependent ones surface their pass/fail
+    through their own re-run.
+    """
+    result = subprocess.run(
+        [str(HELPER_PATH)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    output = result.stdout
+    # Match the prefix `<jid> /` so we catch any leaf rooted under a
+    # metadata-dependent ci.yml job — even ones we didn't anticipate
+    # (e.g. a future internal aggregator named "Required checks passed").
+    for jid in METADATA_DEPENDENT_JOB_IDS:
+        prefix_capital = f"{jid.replace('-', ' ').title()} /"
+        prefix_lower = f"{jid} /"
+        for prefix in (prefix_capital, prefix_lower):
+            assert prefix not in output, (
+                f"diff-dependent-jobs.sh emitted a leaf rooted under "
+                f"metadata-dependent job {jid!r} (matched prefix "
+                f"{prefix!r}). Metadata-dependent children must NOT "
+                f"be probed — see issue #527."
+            )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash unavailable")
+def test_helper_script_covers_required_checks_passed_needs_minus_metadata() -> None:
+    """Helper's covered job IDs must equal `needs:` minus metadata set.
+
+    The whole point of deriving the list rather than enumerating it
+    inline is that adding a new child to ``required-checks-passed.
+    needs:`` automatically extends the verified-prior-success
+    coverage. Verify the derivation: parse ``needs:`` from ci.yml,
+    subtract `plan` and the metadata-dependent set, and assert every
+    surviving job ID has at least one leaf in the helper's output.
+    """
+    workflow = _load_workflow()
+    needs = workflow["jobs"]["required-checks-passed"]["needs"]
+    assert isinstance(needs, list), "required-checks-passed.needs must be a list"
+    derived = (set(needs) - {"plan"}) - METADATA_DEPENDENT_JOB_IDS
+
+    result = subprocess.run(
+        [str(HELPER_PATH)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    output = result.stdout
+
+    # Every derived job ID must appear as the prefix of at least one
+    # leaf — capitalisation differs per ci.yml's `name:` field, so
+    # check both common casings.
+    for jid in derived:
+        prefix_lower = f"{jid} /"
+        prefix_capital = f"{jid.replace('-', ' ').title()} /"
+        assert prefix_lower in output or prefix_capital in output, (
+            f"diff-dependent-jobs.sh produced no leaf for derived job "
+            f"ID {jid!r} (looked for prefixes {prefix_lower!r} or "
+            f"{prefix_capital!r}). A new entry was added to "
+            f"required-checks-passed.needs without extending the "
+            f"helper's emit_leaves()."
+        )
+
+    # Derived set must equal DIFF_DEPENDENT_JOB_IDS — keeps the test's
+    # local constant in lockstep with the workflow's actual surface.
+    assert derived == DIFF_DEPENDENT_JOB_IDS, (
+        "DIFF_DEPENDENT_JOB_IDS in this test drifted from "
+        "required-checks-passed.needs minus the metadata-dependent set. "
+        f"derived-from-yaml={sorted(derived)} test-constant="
+        f"{sorted(DIFF_DEPENDENT_JOB_IDS)}."
+    )


### PR DESCRIPTION
==COMMIT_MSG==
Applying or removing a label after `gh pr create` did not re-fire
ci.yml — `pull_request: types:` omitted `labeled, unlabeled` — so
`check-changelog/exists` evaluated against the original `labels=[]`
event payload, emitted a stale-failure status, and forced an
empty-commit retrigger to clear it. Reproduced four times in the
2026-05-02 /workflow:implement runs (PRs #521, #524, #526, #529);
each PR paid the full ~5-10 min CI cost on the workaround.

Implements Option 4 — verified partial re-run, gated on prior-
success on the same head SHA — in three coupled phases landed
together so the trigger widening never ships without its safety
property:

1. `plan` job's `Probe prior run state on this head SHA` step
   queries the Checks API for prior conclusions on the head SHA
   on `labeled`/`unlabeled` events; emits
   `diff_dependent_jobs_already_passed=true` only when every
   diff-dependent child has a non-failing conclusion on the same
   SHA. The diff-dependent leaf list comes from a new helper
   `scripts/ci/diff-dependent-jobs.sh` that derives from
   `required-checks-passed.needs:` minus a hard-coded
   metadata-dependent allowlist (`check-changelog`,
   `check-pull-request`), so adding a child to `needs:` extends
   the probe automatically.
2. Every diff-dependent ci.yml `<job>:` block carries
   `if: needs.plan.outputs.diff_dependent_jobs_already_passed !=
   'true'` so it skips on verified-prior-success label re-runs.
   `check-changelog` and `check-pull-request` keep their
   unconditional `needs: [plan]` and re-run on every event.
3. `required-checks-passed` aggregator gets a tight carve-out:
   when the flag is `true` AND the entry is in the diff-dependent
   set, `skipped` maps to SUCCESS. Otherwise the strict #441
   skipped-equals-failure contract still applies — a label change
   against a SHA whose CI never finished re-runs everything by
   design.
4. `pull_request: types:` adds `labeled, unlabeled`.

Tests in `tests/test_ci_diff_dependent_probe.py` pin the four
properties as static-yaml regressions: trigger types include
`labeled, unlabeled`, every diff-dependent child carries the gate,
metadata-dependent children carry no gate, the aggregator carve-out
gates on both flag and per-key set membership, and the helper
script's emitted leaves match what GitHub's Checks API publishes.

Closes #527
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

The diff is ordered to match the issue's "Implementation sequence":
plan-job probe + helper + new output first; then `if:` gates on each
diff-dependent child; then aggregator carve-out; then the
`labeled, unlabeled` types addition. Reading top-to-bottom in
ci.yml mirrors that sequence as well — the probe step and output
appear before any `if:` gate that consumes them, the gate appears
on each child before the aggregator that handles its skipped result,
and the trigger types live in `on:` at the top.

Drift checks the test file pins:
- helper output equals expected leaf set (one row per matrix variant);
- helper is byte-deterministic across multiple invocations;
- helper never emits a leaf rooted under `check-changelog` /
  `check-pull-request`;
- helper's covered ci.yml job IDs equal `required-checks-passed.needs:`
  minus `plan` minus the metadata-dependent allowlist (drift here
  catches a new child added to `needs:` without extending the helper);
- aggregator's `DIFF_DEPENDENT_JOB_IDS` env value equals the same
  set (drift here catches a gate added without a carve-out hook
  or vice versa);
- aggregator's jq filter references both the flag and per-key set
  membership (drift here catches a future widening of the relaxation).

This PR's own base branch lacks the `labeled` / `unlabeled` trigger
(meta-circular case from the issue body) so the customary
`gh pr edit --add-label "no changelog"` will not re-fire CI on its
own — the implementor will push an empty commit after labelling, as
recorded in CLAUDE.md / auto-memory. Once this PR merges to main the
workaround is no longer needed.

### Test plan

- [ ] `task lint` passes (lefthook ran on commit; treefmt + ruff
      auto-formatted the test file before the second commit attempt)
- [ ] `task test` passes (covers the 11 new tests in
      `tests/test_ci_diff_dependent_probe.py`)
- [ ] `bash scripts/ci/diff-dependent-jobs.sh` prints the 23
      expected leaf check-run names (one per ci.yml diff-dependent
      job + matrix expansion)
- [ ] `bash scripts/verify-standards.sh` is green
- [ ] CI on this PR runs the diff-dependent children at least once
      (first run is on `opened` → flag is `false` → children execute)
