### PR TITLE
chore(ci): centralize event-kind gating in plan

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -39,6 +39,19 @@ name: Check Changelog
 # inspect.
 on:
   workflow_call:
+    inputs:
+      # Centralised event-kind gate from `ci.yml`'s `plan` job
+      # (issue #530). The `exists` and `format` jobs both need PR
+      # context (the diff and labels) and short-circuit on non-PR
+      # events. The release-PR head-ref skip below is retained
+      # alongside this gate — it's a content-specific changelog rule
+      # rather than event-kind policy and stays local.
+      event_is_pull_request:
+        description: >-
+          True iff the originating event is a pull_request (the
+          changelog checks need PR diff + labels).
+        required: true
+        type: boolean
 
 permissions:
   contents: read
@@ -65,9 +78,10 @@ jobs:
         id: skip
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          EVENT_IS_PULL_REQUEST: ${{ inputs.event_is_pull_request }}
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+          if [[ "${EVENT_IS_PULL_REQUEST}" != "true" ]]; then
             echo "no PR context — skipping changelog presence check"
             echo "skip=true" >> "${GITHUB_OUTPUT}"
             exit 0
@@ -129,9 +143,10 @@ jobs:
         id: skip
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          EVENT_IS_PULL_REQUEST: ${{ inputs.event_is_pull_request }}
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+          if [[ "${EVENT_IS_PULL_REQUEST}" != "true" ]]; then
             echo "no PR context — skipping changelog format check"
             echo "skip=true" >> "${GITHUB_OUTPUT}"
             exit 0

--- a/.github/workflows/check-dependency-review.yml
+++ b/.github/workflows/check-dependency-review.yml
@@ -27,6 +27,21 @@ name: Check Dependency Review
 # each.
 on:
   workflow_call:
+    inputs:
+      # Centralised event-kind gate from `ci.yml`'s `plan` job
+      # (issue #530). `actions/dependency-review-action` only supports
+      # `pull_request`, `pull_request_target`, and `merge_group` — on
+      # `push` / `workflow_dispatch` it has no base/head pair to scan
+      # and exits non-zero. Gate the steps (not the whole job) so the
+      # job's result stays `success` and `check-security.yml`'s
+      # `Required checks passed` aggregator (which rejects `skipped`)
+      # stays green.
+      event_has_diff_base_head:
+        description: >-
+          True iff the originating event carries a base/head diff
+          (`pull_request`, `pull_request_target`, `merge_group`).
+        required: true
+        type: boolean
 
 permissions:
   # Read-only access to the Dependency Graph diff — this is the scanner input.
@@ -40,11 +55,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - if: ${{ inputs.event_has_diff_base_head }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: dependency-check
+        if: ${{ inputs.event_has_diff_base_head }}
         uses: actions/dependency-review-action@v4
         with:
           # HIGH/CRITICAL is the industry-standard gating bar and matches

--- a/.github/workflows/check-dependency-submission.yml
+++ b/.github/workflows/check-dependency-submission.yml
@@ -23,6 +23,22 @@ name: Check Dependency Submission
 # receive a read-only `GITHUB_TOKEN`, so the snapshot POST would 403.
 on:
   workflow_call:
+    inputs:
+      # Centralised fork-PR gate from `ci.yml`'s `plan` job
+      # (issue #530). Replaces the previous in-job `fork-check` step
+      # that recomputed `IS_FORK` from `github.event_name` and
+      # `head.repo.full_name`. The semantic is identical: fork PRs
+      # receive a read-only `GITHUB_TOKEN` so the snapshot POST would
+      # 403, and we short-circuit to `success` rather than
+      # `if:`-skipping the job (the parent aggregator rejects
+      # `skipped`). Push / cron-equivalent / `workflow_dispatch` /
+      # `merge_group` / internal PRs all submit normally.
+      event_from_external_repo:
+        description: >-
+          True iff this is a `pull_request` event from a fork (head
+          repo differs from the workflow repo).
+        required: true
+        type: boolean
 
 permissions:
   # Required to POST to /repos/{owner}/{repo}/dependency-graph/snapshots.
@@ -33,32 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Skip on fork PR
-        # GITHUB_TOKEN is read-only on fork PRs, so the snapshot POST
-        # would 403. Surfacing a `success` result here (rather than
-        # `if:`-skipping the whole job) keeps the parent
-        # `check-security.yml` aggregator green — its `Required checks
-        # passed` step rejects `skipped` alongside `failure` /
-        # `cancelled` / `timed_out`. Push / cron / workflow_dispatch
-        # always run in the main repo context and fall through to the
-        # snapshot submission below.
-        id: fork-check
-        env:
-          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-        run: |
-          set -euo pipefail
-          if [[ "${IS_FORK}" == "true" ]]; then
-            echo "skip=true" >> "${GITHUB_OUTPUT}"
-            echo "Fork PR detected — skipping snapshot submission."
-          else
-            echo "skip=false" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - if: steps.fork-check.outputs.skip != 'true'
+      - if: ${{ !inputs.event_from_external_repo }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build and submit snapshot
-        if: steps.fork-check.outputs.skip != 'true'
+        if: ${{ !inputs.event_from_external_repo }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MANIFEST_PATH: .github/tool-versions.yml

--- a/.github/workflows/check-security.yml
+++ b/.github/workflows/check-security.yml
@@ -14,6 +14,27 @@ name: Check Security
 # the aggregator's `needs:` list.
 on:
   workflow_call:
+    inputs:
+      # Centralised event-kind gating from `ci.yml`'s `plan` job
+      # (issue #530). Forwarded to leaf children whose actions
+      # require a base/head diff (`check-dependency-review`) or whose
+      # write-token POSTs would 403 on fork PRs
+      # (`check-dependency-submission`).
+      event_has_diff_base_head:
+        description: >-
+          True for events that carry a base/head diff
+          (`pull_request`, `pull_request_target`, `merge_group`) — the
+          set the GitHub `actions/dependency-review-action` supports.
+        required: true
+        type: boolean
+      event_from_external_repo:
+        description: >-
+          True for `pull_request` events whose head repo differs from
+          the workflow repo (i.e. fork PRs). Fork PRs receive a
+          read-only `GITHUB_TOKEN`, so any check that POSTs to
+          `/repos/.../dependency-graph/snapshots` etc. must short-circuit.
+        required: true
+        type: boolean
 
 permissions:
   contents: read
@@ -33,12 +54,16 @@ jobs:
   check-dependency-review:
     name: Check Dependency Review
     uses: ./.github/workflows/check-dependency-review.yml
+    with:
+      event_has_diff_base_head: ${{ inputs.event_has_diff_base_head }}
     permissions:
       contents: read
       pull-requests: write
   check-dependency-submission:
     name: Check Dependency Submission
     uses: ./.github/workflows/check-dependency-submission.yml
+    with:
+      event_from_external_repo: ${{ inputs.event_from_external_repo }}
     permissions:
       contents: write
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,61 @@ jobs:
       docs_changed: ${{ steps.filter.outputs.docs }}
       design_changed: ${{ steps.filter.outputs.design }}
       workflows_changed: ${{ steps.filter.outputs.workflows }}
+      event_is_pull_request: ${{ steps.event.outputs.event_is_pull_request }}
+      event_has_diff_base_head: ${{ steps.event.outputs.event_has_diff_base_head }}
+      event_from_external_repo: ${{ steps.event.outputs.event_from_external_repo }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Compute event-kind gating booleans
+        id: event
+        # Centralise the event-kind decisions that downstream child
+        # workflows need to gate steps on (issue #530), so individual
+        # children don't replicate `github.event_name` /
+        # `head.repo.full_name` checks. Three booleans because the
+        # downstream gates are not identical:
+        #   - `event_is_pull_request`: PR-only context (changelog
+        #     presence/format depend on the PR diff and PR labels).
+        #   - `event_has_diff_base_head`: events that carry a base/head
+        #     diff (`pull_request`, `pull_request_target`, `merge_group`)
+        #     — required by `actions/dependency-review-action`.
+        #   - `event_from_external_repo`: PR from a fork. Used by checks
+        #     whose write-token POSTs would 403 under the read-only
+        #     fork-PR `GITHUB_TOKEN` (dependency-submission).
+        # User-controlled metadata (`head.repo.full_name`) is routed
+        # through env vars rather than inlined `${{ ... }}` expressions
+        # inside `run:` so a maliciously-named fork repository cannot
+        # inject shell syntax — same convention as the
+        # `Compute label-driven gating booleans` step above.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            event_is_pull_request=true
+          else
+            event_is_pull_request=false
+          fi
+          if [[ "${EVENT_NAME}" == "pull_request" \
+              || "${EVENT_NAME}" == "pull_request_target" \
+              || "${EVENT_NAME}" == "merge_group" ]]; then
+            event_has_diff_base_head=true
+          else
+            event_has_diff_base_head=false
+          fi
+          if [[ "${EVENT_NAME}" == "pull_request" \
+              && "${HEAD_REPO_FULL_NAME}" != "${REPOSITORY}" ]]; then
+            event_from_external_repo=true
+          else
+            event_from_external_repo=false
+          fi
+          {
+            echo "event_is_pull_request=${event_is_pull_request}"
+            echo "event_has_diff_base_head=${event_has_diff_base_head}"
+            echo "event_from_external_repo=${event_from_external_repo}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Compute label-driven gating booleans
         id: labels
@@ -148,6 +201,9 @@ jobs:
     name: Check Security
     needs: [plan]
     uses: ./.github/workflows/check-security.yml
+    with:
+      event_has_diff_base_head: ${{ needs.plan.outputs.event_has_diff_base_head == 'true' }}
+      event_from_external_repo: ${{ needs.plan.outputs.event_from_external_repo == 'true' }}
     permissions:
       # Granted to the `check-security.yml` chain. workflow_call
       # permissions are intersected at every layer — the parent must
@@ -287,6 +343,8 @@ jobs:
     name: check-changelog
     needs: [plan]
     uses: ./.github/workflows/check-changelog.yml
+    with:
+      event_is_pull_request: ${{ needs.plan.outputs.event_is_pull_request == 'true' }}
 
   required-checks-passed:
     # Repo-wide aggregator (#440 "Decisions (locked in)"): a single


### PR DESCRIPTION
==COMMIT_MSG==
Every push to main currently leaves CI red on the merge commit because
check-dependency-review's underlying actions/dependency-review-action
only supports pull_request / pull_request_target / merge_group events
and exits non-zero on push / workflow_dispatch (no base/head pair to
scan). The check-security.yml aggregator treats any non-success result
as failure, so the failure propagates to "Required checks passed".

Centralise event-kind decisions in ci.yml's plan job and thread three
booleans through workflow_call inputs to leaf children:

- event_is_pull_request: PR-only context for changelog checks.
- event_has_diff_base_head: events the dependency-review action
  supports (pull_request, pull_request_target, merge_group).
- event_from_external_repo: fork PRs whose read-only GITHUB_TOKEN
  would 403 the dependency-snapshot POST.

Leaf children (check-dependency-review, check-dependency-submission,
check-changelog) declare the relevant inputs and gate steps on them
at step level (not job level) so jobs surface success rather than
skipped — the aggregator rejects skipped per #441.

check-dependency-submission's previous in-job fork-check step is
removed in favour of the centralised input. check-changelog's two
inline github.event_name checks are replaced; the release-PR
head-ref skip stays local because it's content-specific to changelog
rules, not event-kind policy.

User-controlled metadata (head.repo.full_name) is routed through env
vars rather than inlined ${{ ... }} expressions inside run:, matching
the convention the existing label-gating step uses, so a maliciously-
named fork repository cannot inject shell syntax.

Closes #530
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

### Test plan

- [ ] CI on this PR is green (in particular `Check Security / Check Dependency Review / dependency-review` succeeds via step-level skip on `pull_request`).
- [ ] After merge: the resulting `push (main)` run of `CI` is fully green — `check-dependency-review` short-circuits to `success` (no base/head error), `check-changelog/{exists,format}` short-circuit to `success`, `check-dependency-submission` falls through and submits, and `Required checks passed` aggregates clean.
- [ ] Inspect a fork PR (existing or contrived) and confirm `check-dependency-submission` short-circuits without 403.
