### PR TITLE
chore(ci): cap merge-bot sweep fan-out + needs fix gate

### DIFF
--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -1148,37 +1148,156 @@ jobs:
       group: merge-bot-sweep
       cancel-in-progress: true
     steps:
-      - name: List open automerge PRs and dispatch merge-bot per PR
+      - name: List, filter, partition, cap, and dispatch merge-bot per PR
         env:
           GH_TOKEN: ${{ github.token }}
+          # Per-sweep dispatch cap. Sourced from a repo variable so
+          # the cap can be tuned without a workflow edit; defaults
+          # to 3 when the repo variable is unset. See issue #498.
+          SWEEP_MAX: ${{ vars.MERGE_BOT_SWEEP_MAX || '3' }}
         run: |
           set -euo pipefail
-          # `gh pr list --json number` returns a JSON array of
-          # `{number: <int>}`; `--jq '.[].number'` flattens it to
-          # one number per line. Empty output means no PRs to
-          # dispatch — exit 0 cleanly. Bind through `mapfile` so
-          # the per-PR loop body sees one number at a time and
-          # the dispatch call quotes `${pr}` rather than splitting
-          # on whitespace.
-          mapfile -t prs < <(gh pr list \
+          # Sweep cap rationale (issue #498): firing
+          # `workflow_dispatch` against every open `automerge` PR on
+          # every `push:main` advance produces a thundering-herd of
+          # `update-branch` calls (each pushes a merge commit, which
+          # restarts CI on the PR head). When N PRs are simultaneously
+          # BEHIND and `main` advances repeatedly during a CI cycle,
+          # this multiplies into N parallel CI cascades and saturates
+          # the runner queue. Capping the per-sweep fan-out to the
+          # oldest N *eligible* PRs drains the queue at a sustainable
+          # rate; PRs not picked this sweep get picked on the next
+          # `push:main` (which fires when one of the dispatched N
+          # actually merges, advancing main). The per-PR
+          # `merge-bot-<n>` concurrency group already serialises
+          # per-PR work — this cap is purely about across-PR fan-out.
+
+          # Stage 1 — list open `automerge` PRs with the metadata
+          # needed for eligibility, partition, and sort. Capture
+          # number, headRefName, title, and labels in a single
+          # `gh pr list` call so downstream filters operate on a
+          # frozen snapshot.
+          all_prs="$(gh pr list \
             --repo "${GITHUB_REPOSITORY}" \
             --state open \
             --label automerge \
-            --json number \
-            --jq '.[].number')
-          if [[ "${#prs[@]}" -eq 0 ]]; then
-            echo "merge-bot sweep: no open automerge PRs; nothing to dispatch."
+            --json number,headRefName,title,labels \
+            --jq '[.[] | {number, headRefName, title, labels: [.labels[].name]}]')"
+          total_open="$(jq 'length' <<<"${all_prs}")"
+          if [[ "${total_open}" -eq 0 ]]; then
+            echo "merge-bot sweep: total=0 eligible=0 needs-fix-excluded=0 dispatched=0 (no open automerge PRs)."
             exit 0
           fi
-          echo "merge-bot sweep: dispatching merge-bot for PRs: ${prs[*]}"
+
+          # Stage 2 — eligibility filter.
+          #
+          # A PR is eligible iff:
+          #   (a) any commit on the PR has ever had a
+          #       `statusCheckRollup.state == "SUCCESS"` rollup
+          #       (the "ever-been-green" check), AND
+          #   (b) it does NOT carry the `needs fix` label.
+          #
+          # The ever-green check uses the GraphQL
+          # `pullRequest.commits(last: 100).nodes.commit.statusCheckRollup.state`
+          # walk — a structurally-independent GitHub-native signal.
+          # Comment-text or commit-author heuristics are explicitly
+          # rejected because they depend on the bot's own prior
+          # outputs and create circular dependencies. The
+          # `needs fix` exclusion is the PR-level park gate that
+          # the `label-needs-fix` job (#503 / #515) maintains in
+          # response to `workflow_run.completed`; combined with the
+          # ever-green check it lets the sweep skip both
+          # never-been-green PRs and known-failing PRs.
+          #
+          # `commits(last: 100)` cap is acceptable; PRs with deeper
+          # histories that have ever been green will surface as a
+          # current-rollup hit on a near-future sweep anyway.
+          eligible_numbers=()
+          needs_fix_excluded=0
+          while IFS= read -r pr_json; do
+            pr_number="$(jq -r '.number' <<<"${pr_json}")"
+            has_needs_fix="$(jq -r '[.labels[] | select(. == "needs fix")] | length > 0' <<<"${pr_json}")"
+            if [[ "${has_needs_fix}" == "true" ]]; then
+              needs_fix_excluded=$((needs_fix_excluded + 1))
+              echo "merge-bot sweep: PR #${pr_number} excluded (carries 'needs fix' label)."
+              continue
+            fi
+            rollup_states="$(gh api graphql \
+              -F owner="${GITHUB_REPOSITORY%%/*}" \
+              -F repo="${GITHUB_REPOSITORY#*/}" \
+              -F number="${pr_number}" \
+              -f query='
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      commits(last: 100) {
+                        nodes { commit { oid statusCheckRollup { state } } }
+                      }
+                    }
+                  }
+                }
+              ' \
+              --jq '[.data.repository.pullRequest.commits.nodes[].commit.statusCheckRollup.state] | map(select(. != null))')"
+            ever_green="$(jq 'any(. == "SUCCESS")' <<<"${rollup_states}")"
+            if [[ "${ever_green}" == "true" ]]; then
+              eligible_numbers+=("${pr_number}")
+            else
+              echo "merge-bot sweep: PR #${pr_number} excluded (no commit on the PR has ever had statusCheckRollup=SUCCESS)."
+            fi
+          done < <(jq -c '.[]' <<<"${all_prs}")
+          eligible_count="${#eligible_numbers[@]}"
+
+          if [[ "${eligible_count}" -eq 0 ]]; then
+            echo "merge-bot sweep: total=${total_open} eligible=0 needs-fix-excluded=${needs_fix_excluded} dispatched=0 (nothing eligible to dispatch)."
+            exit 0
+          fi
+
+          # Stage 3 — partition, sort, head.
+          #
+          # Release PRs (head ref `^release/X.Y.Z$` AND title
+          # `^chore\(release\): X.Y.Z$`) are dispatched first to
+          # unblock the next tag-and-publish; other PRs follow.
+          # Within each group, FIFO (ascending PR number).
+          # Concatenate, then head at SWEEP_MAX. `jq -n` builds the
+          # number-only output from the metadata snapshot keyed on
+          # the eligible-list bash array.
+          eligible_json="$(printf '%s\n' "${eligible_numbers[@]}" | jq -R 'tonumber' | jq -s '.')"
+          dispatch_numbers="$(jq -n \
+            --argjson all "${all_prs}" \
+            --argjson eligible "${eligible_json}" \
+            --argjson cap "${SWEEP_MAX}" '
+              ($all | map(select(.number as $n | $eligible | index($n)))) as $picked
+              | ($picked | map(select(
+                  (.headRefName | test("^release/[0-9]+\\.[0-9]+\\.[0-9]+$"))
+                  and (.title | test("^chore\\(release\\): [0-9]+\\.[0-9]+\\.[0-9]+$"))
+                ))) as $release
+              | ($picked | map(select(
+                  ((.headRefName | test("^release/[0-9]+\\.[0-9]+\\.[0-9]+$")) | not)
+                  or ((.title | test("^chore\\(release\\): [0-9]+\\.[0-9]+\\.[0-9]+$")) | not)
+                ))) as $other
+              | (($release | sort_by(.number)) + ($other | sort_by(.number)))
+              | .[0:$cap]
+              | map(.number)
+            ')"
+
+          mapfile -t prs < <(jq -r '.[]' <<<"${dispatch_numbers}")
+          dispatched_count="${#prs[@]}"
+          echo "merge-bot sweep: total=${total_open} eligible=${eligible_count} needs-fix-excluded=${needs_fix_excluded} cap=${SWEEP_MAX} dispatched=${dispatched_count} numbers=[${prs[*]:-}]"
+
+          if [[ "${dispatched_count}" -eq 0 ]]; then
+            exit 0
+          fi
+
+          # Stage 4 — dispatch.
+          #
+          # `gh workflow run` posts to
+          # `POST /repos/.../actions/workflows/{id}/dispatches`,
+          # which fires a `workflow_dispatch` event. Each dispatched
+          # run hits the existing per-PR `merge-bot-<n>`
+          # concurrency group on the `merge` job, so a
+          # sweep-triggered dispatch for a PR already being
+          # processed by another trigger queues cleanly.
           for pr in "${prs[@]}"; do
-            # `gh workflow run` posts to
-            # `POST /repos/.../actions/workflows/{id}/dispatches`,
-            # which fires a `workflow_dispatch` event. Each
-            # dispatched run hits the existing per-PR
-            # `merge-bot-<n>` concurrency group on the `merge`
-            # job, so a sweep-triggered dispatch for a PR already
-            # being processed by another trigger queues cleanly.
             gh workflow run merge-bot.yml \
               --repo "${GITHUB_REPOSITORY}" \
               --ref main \


### PR DESCRIPTION
## Review notes

Caps the merge-bot `push:main` sweep at `N = vars.MERGE_BOT_SWEEP_MAX` (default 3) eligible PRs per main-advance event, eliminating the thundering-herd of CI re-runs that saturated the runner queue during the 2026-05-01 #440 milestone push.

### What changed

The sweep job's single bash step is rewritten to:

1. List open `automerge` PRs with `number,headRefName,title,labels` in one `gh pr list` call (frozen snapshot for downstream filters).
2. For each PR: skip if it carries the `needs fix` label (the PR-level park gate that `label-needs-fix` (#503/#515) maintains in response to `workflow_run.completed`); otherwise issue a single `gh api graphql` query that walks `pullRequest.commits(last: 100).nodes.commit.statusCheckRollup.state` and treats the PR as eligible iff any commit's rollup has ever been `SUCCESS`.
3. Partition the eligible set into release PRs (head ref `^release/X.Y.Z$` AND title `^chore(release): X.Y.Z$`, both required) and other PRs; sort each ascending by PR number; concatenate release-first; head at `${{ vars.MERGE_BOT_SWEEP_MAX || '3' }}`.
4. Log `total / eligible / needs-fix-excluded / cap / dispatched / numbers` so the sweep decision is observable.
5. Dispatch `gh workflow run` for the head-N PRs (existing behaviour, just narrower).

### Eligibility decision principle

The eligibility filter reads only GitHub-native data — never the bot's own prior outputs. Comment-text / commit-author heuristics are explicitly rejected because they create circular dependencies with the bot's implementation drift. The GraphQL `statusCheckRollup` walk is a structurally-independent signal, and the `needs fix` label is maintained by an orthogonal job (#503/#515) on `workflow_run.completed` — not by this sweep job.

### What this does NOT change

- The per-PR `merge-bot-<n>` concurrency group on the `merge` job (the source of truth for *per-PR* serialisation) is untouched — this cap is purely about *across-PR* fan-out.
- No trigger surface change: `pull_request: labeled`, `workflow_run: completed`, `pull_request_review`, and `workflow_dispatch` all behave identically. The cap applies only to the `push:main` sweep.
- The `label-needs-fix` job's logic and trigger surface are untouched.

### Implementation choices

- `commits(last: 100)` cap is acceptable per the issue body — PRs with deeper histories that have ever been green will surface as a current-rollup hit on a near-future sweep.
- `${{ vars.MERGE_BOT_SWEEP_MAX || '3' }}` defaults to 3 when the repo variable is unset, so the workflow ships safely without a repo-var change.
- `set -euo pipefail` plus the early-return when `eligible_count == 0` keeps the empty-array `printf` path under `set -u` from firing.
- The "release PR" predicate requires both signals (head ref AND title) to match. PRs where only one matches partition into the "other" group, matching the issue body's specification.

### Test plan

- [ ] `task verify-standards` passes locally.
- [ ] `actionlint` (or the project's equivalent) passes on `.github/workflows/merge-bot.yml`.
- [ ] CI is green on the PR (no syntactic / lint failures from the new `run` block).
- [ ] On merge: confirm the next sweep on `main` advance logs `merge-bot sweep: total=... eligible=... needs-fix-excluded=... cap=3 dispatched=... numbers=[...]`.

==COMMIT_MSG==
Each `push:main` previously dispatched merge-bot for every open
`automerge` PR, with no cap. When N PRs were simultaneously BEHIND
and main advanced, every dispatched run called
`PUT /pulls/{n}/update-branch`, which pushed a merge commit per PR
and restarted CI on N heads in parallel. On busy days where main
moved several times during a single CI cycle, this multiplied into a
thundering-herd of CI re-runs across the whole automerge queue.

Cap the sweep fan-out to the oldest N eligible PRs per main-advance
event, where `N = vars.MERGE_BOT_SWEEP_MAX` (default 3, no repo var
required). A PR is eligible iff (a) any commit on the PR has ever
had a `statusCheckRollup.state == "SUCCESS"` rollup via the
`pullRequest.commits(last: 100)` GraphQL walk — a structurally
independent GitHub-native signal, not derived from the bot's own
prior outputs — AND (b) it does not carry the `needs fix` label
that the `label-needs-fix` job (#503 / #515) maintains for
known-failing PRs. Eligible PRs are partitioned into release PRs
(head ref `^release/X.Y.Z$` AND title `^chore(release): X.Y.Z$`,
both signals required) and other PRs, sorted ascending by PR number
within each group, concatenated release-first, then headed at the
cap. PRs not picked this sweep get picked on the next push:main
when one of the dispatched N actually merges.

The per-PR `merge-bot-<n>` concurrency group is unchanged — this
cap is purely about across-PR fan-out. No trigger surface change:
the cap applies only to the `push:main` sweep job. Logs the
total / eligible / needs-fix-excluded / dispatched counts and the
dispatched PR numbers so the sweep decision is observable.

Closes: #498
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==