### PR TITLE
chore(ci): move release-impact-comment to changelog-bot.yml

### DIFF
--- a/.github/workflows/changelog-bot.yml
+++ b/.github/workflows/changelog-bot.yml
@@ -140,3 +140,239 @@ jobs:
             --pr ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
             --repo-root "${GITHUB_WORKSPACE}"
+
+  release-impact-comment:
+    name: Release impact comment
+    runs-on: ubuntu-latest
+    # Surface the predicted release-impact bump on every PR that
+    # touches `changelog/@unreleased/*.yml`, so a reviewer can catch a
+    # mislabelled YAML (e.g. a `feature` entry that should have been
+    # `improvement`) before the next release goes out and the version
+    # jumps unexpectedly. The matrix lint (#401) catches the worst
+    # category — `feature(ci):` and friends — but the YAML's `type:`
+    # field is still author-controlled and can drift past the matrix
+    # ("feature" applied to a small refactor that should be
+    # "improvement"). This job is the human-review complement: it
+    # posts the predicted `current -> next` version transition so the
+    # mislabel is visible at PR-review time. Origin: issue #406.
+    # Co-located with the auto-author job in this workflow as of #466
+    # so the predicted-bump surface lives next to the YAML-authoring
+    # surface that drives it.
+    #
+    # Trigger: this workflow runs on `pull_request` (NOT
+    # `pull_request_target`), matching the auto-author job. That
+    # means fork PRs do not receive a release-impact comment — the
+    # default `GITHUB_TOKEN` on `pull_request` is `pull-requests:
+    # read` for forks regardless of the workflow-level grant. The
+    # in-repo branches that run the bulk of release-bumping work are
+    # the cohort that benefits from the comment, and the trade is
+    # symmetric with the auto-author job's "in-repo only" stance
+    # (the bot doesn't mint a write-token for fork PRs either).
+    #
+    # Bot identity: posts as `github-actions[bot]` via the default
+    # `GITHUB_TOKEN`. The merge-bot / release-bot / changelog-bot path
+    # was considered for symmetry, but the App token is App-installed
+    # only on this repository's branches under the auto-author job's
+    # narrower trigger guard; the comment surface here is purely
+    # informational (no protected-branch or contents writes), so the
+    # default token keeps the surface decoupled from the App's
+    # operational state. The "Claude: " prefix per the project
+    # convention still identifies the comment as agent-authored.
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Need full history so `git describe --tags` below can
+          # locate the latest `v*.*.*` tag without the 1-commit
+          # shallow default actions/checkout uses.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Install runtime deps (PyYAML)
+        # `predict_release_impact.py` depends on PyYAML transitively
+        # via `version_logic.parse_entry_file`. Avoid the full workspace
+        # `uv sync` here — this job only needs the changelog parser.
+        # Same shape as `release-bot.yml`'s "Install PyYAML" step.
+        run: pip install --no-cache-dir 'pyyaml>=6'
+
+      - name: List changed files
+        # The rest of this job needs to know whether the PR touches
+        # `changelog/@unreleased/*.yml` so it can early-exit cleanly
+        # on PRs that touched no entry (no noise comments on every PR).
+        # `gh` is preinstalled on `ubuntu-latest`. The output goes via
+        # `RUNNER_TEMP` rather than a shell variable so paths with
+        # spaces or shell metacharacters survive.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh pr view "${PR_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --json files \
+            --jq '.files[].path' \
+            > "${RUNNER_TEMP}/changed-files.txt"
+
+      - name: Detect changelog/@unreleased/ touch
+        id: touched
+        # Early-exit when the PR touches no `@unreleased/*.yml` files
+        # so the bot doesn't post (or update) a noise comment on PRs
+        # that have no release impact to predict. The `grep` is fixed
+        # to the directory prefix so it doesn't match unrelated paths
+        # like `docs/changelog/...`.
+        run: |
+          set -euo pipefail
+          if grep -qE '^changelog/@unreleased/[^/]+\.yml$' "${RUNNER_TEMP}/changed-files.txt"; then
+            echo "touched=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "touched=false" >> "${GITHUB_OUTPUT}"
+            echo "release-impact-comment: no changelog/@unreleased/ files touched; nothing to predict."
+          fi
+
+      - name: Resolve current version
+        id: version
+        if: steps.touched.outputs.touched == 'true'
+        # Same approach as `release-bot.yml`'s "Resolve current version"
+        # step: `git describe --tags --abbrev=0 --match 'v*.*.*'` reads
+        # the latest published tag. Falls back to `0.0.0` when no tag
+        # exists yet (first-ever release) so the very first `feature`
+        # entry produces `0.1.0` rather than crashing the predict.
+        run: |
+          set -euo pipefail
+          if tag="$(git describe --tags --abbrev=0 --match 'v*.*.*' 2>/dev/null)"; then
+            echo "current=${tag#v}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "current=0.0.0" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Predict release impact
+        id: predict
+        if: steps.touched.outputs.touched == 'true'
+        env:
+          CURRENT_VERSION: ${{ steps.version.outputs.current }}
+        run: |
+          set -euo pipefail
+          # Reject anything that isn't strict semver before passing it
+          # to the script. `git describe --tags --match 'v*.*.*'` should
+          # already constrain the value to `MAJOR.MINOR.PATCH`, but the
+          # validation makes the contract explicit at the consuming
+          # step's edge so a future change to the resolver can't
+          # silently widen the surface.
+          if ! [[ "${CURRENT_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "release-impact-comment: invalid current version '${CURRENT_VERSION}'" >&2
+            exit 1
+          fi
+          envelope="$(python3 scripts/changelog/predict_release_impact.py \
+            --repo-root . \
+            --current-version "${CURRENT_VERSION}")"
+          echo "${envelope}" > "${RUNNER_TEMP}/predict.json"
+          # Surface a top-level `predict` boolean so the next step's
+          # `if:` can branch without re-parsing the JSON.
+          if jq -e '.predict == true' < "${RUNNER_TEMP}/predict.json" >/dev/null; then
+            echo "predict=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "predict=false" >> "${GITHUB_OUTPUT}"
+            echo "release-impact-comment: $(jq -r '.reason' < "${RUNNER_TEMP}/predict.json")"
+          fi
+
+      - name: Render comment body
+        id: render
+        if: steps.touched.outputs.touched == 'true' && steps.predict.outputs.predict == 'true'
+        # Render the comment body as Markdown. The first line is an
+        # HTML comment marker the next step uses for idempotent
+        # matching — invisible to humans on the rendered comment but
+        # greppable by the bot. The "Claude: " prefix marks the
+        # comment as agent-authored per the project convention.
+        run: |
+          set -euo pipefail
+          payload="${RUNNER_TEMP}/predict.json"
+          bump="$(jq -r '.bump' < "${payload}")"
+          current="$(jq -r '.current_version' < "${payload}")"
+          next="$(jq -r '.next_version' < "${payload}")"
+          # Render one bullet per driver so a multi-entry PR shows
+          # every contributing entry. Bullet text is built in a jq
+          # filter so the embedded paths / types survive shell
+          # quoting verbatim. Each line: `- type \`feature\` in
+          # \`changelog/@unreleased/pr-NNN-slug.yml\` (-> MINOR)`.
+          drivers="$(jq -r '
+            .drivers[]
+            | "- type `\(.type)` in `\(.path)` (-> \(.bump))"
+              + (if .package then " — package `\(.package)`" else "" end)
+          ' < "${payload}")"
+          body_path="${RUNNER_TEMP}/comment-body.md"
+          {
+            echo "<!-- claude-release-impact -->"
+            echo "Claude: **Release impact:** this PR will trigger a **${bump}** version bump."
+            echo ""
+            echo "Predicted next version: \`v${next}\` (current: \`v${current}\`)."
+            echo ""
+            echo "Drivers:"
+            echo ""
+            echo "${drivers}"
+            echo ""
+            echo "_If this bump is wrong, edit the \`type:\` field in the YAML._"
+          } > "${body_path}"
+          echo "body_path=${body_path}" >> "${GITHUB_OUTPUT}"
+
+      - name: Post or update PR comment
+        if: steps.touched.outputs.touched == 'true' && steps.predict.outputs.predict == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BODY_PATH: ${{ steps.render.outputs.body_path }}
+          # The marker the comment carries on its first line; the
+          # match is exact-prefix so an arbitrary user comment that
+          # happens to mention "claude-release-impact" doesn't get
+          # patched. Kept here (rather than hardcoded in the run-block)
+          # so a future renaming is a single-line edit.
+          MARKER: "<!-- claude-release-impact -->"
+        # Idempotent: list the PR's existing issue comments, find the
+        # one whose body starts with the marker (if any), and
+        # PATCH it with the freshly rendered body. PATCH (rather than
+        # delete + create) preserves the comment ID so subscribers
+        # don't get a fresh notification on every workflow re-run.
+        # If no matching comment exists, POST a new one.
+        run: |
+          set -euo pipefail
+          # `gh api --paginate` (without `--jq`) returns concatenated
+          # arrays from each page; piping into `jq -r` flattens and
+          # filters in a single pass so we don't depend on a particular
+          # gh version's output shape. `--arg` keeps the marker out of
+          # the jq program text so its `<`, `!`, `-` characters survive
+          # shell quoting verbatim. `first(...)` (rather than a trailing
+          # `head -n 1`) caps the result inside jq itself: under
+          # `set -euo pipefail`, closing the pipe early via `head` can
+          # deliver SIGPIPE upstream and fail the pipeline on
+          # long-lived PRs whose comment list spans multiple pages.
+          # `// empty` keeps the assignment empty (rather than emitting
+          # the literal string "null") when no matching comment exists.
+          existing_id="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            | jq -r --arg marker "${MARKER}" \
+                'first(.[] | select((.body // "") | startswith($marker)) | .id) // empty')"
+          # `-F body=@<file>` reads the body from disk as a JSON
+          # string field — identical semantics to inlining
+          # `body="$(cat <file>)"` but binary-safe and free of any
+          # shell-expansion of the file's contents (the comment body
+          # is rendered Markdown so it can carry backticks / `$(`,
+          # which would otherwise execute under bash's `$(...)`).
+          if [[ -n "${existing_id}" ]]; then
+            echo "release-impact-comment: updating existing comment ${existing_id}"
+            gh api --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" \
+              -F "body=@${BODY_PATH}" \
+              > /dev/null
+          else
+            echo "release-impact-comment: posting new comment"
+            gh api --method POST \
+              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -F "body=@${BODY_PATH}" \
+              > /dev/null
+          fi

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -4,20 +4,18 @@
 
 name: PR Lint
 
-# Residual top-level workflow for the two `pr-lint`-adjacent jobs that
-# stayed put after the validator migration in #463:
+# Residual top-level workflow for the two `pr-lint`-adjacent self-tests
+# that stayed put after the validator migration in #463 and the
+# release-impact-comment migration in #466:
 #
 #   * `pr-title-types-self-test` — asserts the `types: |` allowlist in
 #     `check-pull-request.yml` (`title-prefix` job) stays in lockstep
 #     with `scripts/lint/commit_taxonomy.py::ALLOWED_TYPES`. Runs here
 #     rather than as a child of `ci.yml` because it's a meta-check on
 #     the workflow YAML itself, not a per-PR title/body validator.
-#   * `release-impact-comment` — posts/updates the predicted release
-#     bump on PRs that touch `changelog/@unreleased/*.yml`. Slated to
-#     move to `changelog-bot.yml` under #466.
 #   * `predict-release-impact-self-test` — exercises the predict
-#     script's bump matrix on every run; co-located with the comment
-#     job for the same reason as above.
+#     script's bump matrix on every run; lives here rather than under
+#     a parent `ci.yml` chain for the same meta-check reason.
 #
 # The original PR-title and ==COMMIT_MSG== validation jobs (plus their
 # self-tests) were ported into `check-pull-request.yml` in #463 so the
@@ -25,17 +23,17 @@ name: PR Lint
 # package's own pytest suite at `packages/pr-lint-validator/tests/`
 # exercises `run_self_test`, so the `validator-self-test`,
 # `pr-title-self-test`, and `pr-body-warning-self-test` jobs that lived
-# here became redundant and were deleted in the same migration.
+# here became redundant and were deleted in the same migration. The
+# `release-impact-comment` job moved to `changelog-bot.yml` in #466 so
+# the predicted-bump surface lives next to the YAML-authoring surface
+# that drives it.
 #
-# This workflow runs on `pull_request_target` so the
-# `release-impact-comment` job has `pull-requests: write` on fork PRs
-# (the comment surface is informational; see the per-job comment for
-# the full fork-safety rationale). The remaining jobs do not need the
-# elevated token but inherit the trigger to keep this workflow a
-# single-trigger surface.
+# This workflow runs on `pull_request` (read-only) — the surviving
+# self-tests do not need the elevated `pull_request_target` token that
+# `release-impact-comment` once relied on for fork-PR write access.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, reopened, synchronize]
 
 permissions:
@@ -70,307 +68,13 @@ jobs:
           set -euo pipefail
           python3 scripts/lint/commit_taxonomy.py check-pr-lint-yaml
 
-  release-impact-comment:
-    name: Release impact comment
-    runs-on: ubuntu-latest
-    # Surface the predicted release-impact bump on every PR that
-    # touches `changelog/@unreleased/*.yml`, so a reviewer can catch a
-    # mislabelled YAML (e.g. a `feature` entry that should have been
-    # `improvement`) before the next release goes out and the version
-    # jumps unexpectedly. The matrix lint (#401) catches the worst
-    # category — `feature(ci):` and friends — but the YAML's `type:`
-    # field is still author-controlled and can drift past the matrix
-    # ("feature" applied to a small refactor that should be
-    # "improvement"). This job is the human-review complement: it
-    # posts the predicted `current -> next` version transition so the
-    # mislabel is visible at PR-review time. Origin: issue #406.
-    #
-    # Bot identity: posts as `github-actions[bot]` via the default
-    # `GITHUB_TOKEN`. The merge-bot / release-bot / changelog-bot path
-    # was considered for symmetry, but minting an App token requires
-    # provisioning new secrets and the comment surface here is purely
-    # informational (no protected-branch or contents writes). Using
-    # the default token keeps the bot fully operational on the PR
-    # that initially adds the workflow without depending on a separate
-    # one-time setup. The "Claude: " prefix per the project convention
-    # still identifies the comment as agent-authored.
-    #
-    # `pull_request_target` keeps the comment writeable on fork PRs
-    # (the workflow inherits the base repo's `pull-requests: write`
-    # grant, and `actions/checkout` is pinned to the base ref so the
-    # fork cannot ship a malicious predict script in the same PR).
-    # The PR head's `changelog/@unreleased/*.yml` files ARE fetched
-    # — they are pure data parsed by PyYAML, no code-execution
-    # surface. The base-ref script is what runs over them.
-    permissions:
-      pull-requests: write
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          # Pin to the base ref so a fork PR cannot weaken the
-          # predict script in the same PR. The head's YAMLs are
-          # fetched into the workspace separately below.
-          ref: ${{ github.event.pull_request.base.sha }}
-          # Need full history so the base-ref `git describe --tags`
-          # below can locate the latest `v*.*.*` tag without the
-          # 1-commit shallow default actions/checkout uses.
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.11"
-
-      - name: Install runtime deps (PyYAML)
-        # `predict_release_impact.py` depends on PyYAML transitively
-        # via `version_logic.parse_entry_file`. Avoid the full workspace
-        # `uv sync` here — this job only needs the changelog parser.
-        # Same shape as `release-bot.yml`'s "Install PyYAML" step.
-        run: pip install --no-cache-dir 'pyyaml>=6'
-
-      - name: List changed files
-        # Fan out the same `gh pr view --json files` pattern the
-        # `pr-title-style` job uses, for the same reason: the rest of
-        # this job needs to know whether the PR touches
-        # `changelog/@unreleased/*.yml` so it can early-exit cleanly
-        # on PRs that touched no entry (no noise comments on every PR).
-        # `gh` is preinstalled on `ubuntu-latest`. The output goes via
-        # `RUNNER_TEMP` rather than a shell variable so paths with
-        # spaces or shell metacharacters survive.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          gh pr view "${PR_NUMBER}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --json files \
-            --jq '.files[].path' \
-            > "${RUNNER_TEMP}/changed-files.txt"
-
-      - name: Detect changelog/@unreleased/ touch
-        id: touched
-        # Early-exit when the PR touches no `@unreleased/*.yml` files
-        # so the bot doesn't post (or update) a noise comment on PRs
-        # that have no release impact to predict. The `grep` is fixed
-        # to the directory prefix so it doesn't match unrelated paths
-        # like `docs/changelog/...`.
-        run: |
-          set -euo pipefail
-          if grep -qE '^changelog/@unreleased/[^/]+\.yml$' "${RUNNER_TEMP}/changed-files.txt"; then
-            echo "touched=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "touched=false" >> "${GITHUB_OUTPUT}"
-            echo "release-impact-comment: no changelog/@unreleased/ files touched; nothing to predict."
-          fi
-
-      - name: Fetch PR head's @unreleased YAMLs
-        # Materialise the head ref's `changelog/@unreleased/*.yml` into
-        # a sandbox under `${RUNNER_TEMP}` — NOT into the workspace.
-        # The predict script + `version_logic` parser both come from
-        # the base ref (pinned by the earlier `actions/checkout`); the
-        # YAML data files are read from the sandbox by passing
-        # `--repo-root ${RUNNER_TEMP}/predict-sandbox` to the predict
-        # invocation. PyYAML's `safe_load` parses YAML as data — no
-        # code-execution surface — so this is safe even on a fork PR.
-        #
-        # We deliberately AVOID `git checkout "${HEAD_SHA}" -- path/`
-        # here. CodeQL's `actions/untrusted-checkout` query treats any
-        # `git checkout <head-sha>` in a `pull_request_target` workflow
-        # as a code-execution surface, regardless of the `-- <path>`
-        # constraint that scopes it to data-only files. Routing through
-        # the GitHub Contents API keeps the head fetch off CodeQL's
-        # flagged channel and onto the unflagged HTTP-fetch channel.
-        if: steps.touched.outputs.touched == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          sandbox="${RUNNER_TEMP}/predict-sandbox/changelog/@unreleased"
-          # Reset the sandbox each run so files removed at head (e.g.
-          # the release-PR's mass rename) don't linger from a previous
-          # workflow on the same runner.
-          rm -rf "${RUNNER_TEMP}/predict-sandbox"
-          mkdir -p "${sandbox}"
-          # List `@unreleased/*.yml` at HEAD via the Contents API, then
-          # fetch each blob raw. A 404 on the directory listing means
-          # the PR removed the entire dir at head (release-PR rollover);
-          # the consuming step's `--repo-root` then sees an empty
-          # `@unreleased/` and the predict short-circuits with
-          # `predict=false`.
-          if listing="$(gh api \
-                "repos/${GITHUB_REPOSITORY}/contents/changelog/@unreleased?ref=${HEAD_SHA}" \
-                --jq '.[] | select(.type=="file") | .name' 2>/dev/null)"; then
-            while IFS= read -r name; do
-              [[ -z "${name}" ]] && continue
-              [[ "${name}" =~ \.yml$ ]] || continue
-              gh api -H 'Accept: application/vnd.github.raw' \
-                "repos/${GITHUB_REPOSITORY}/contents/changelog/@unreleased/${name}?ref=${HEAD_SHA}" \
-                > "${sandbox}/${name}"
-            done <<<"${listing}"
-          fi
-
-      - name: Resolve current version
-        if: steps.touched.outputs.touched == 'true'
-        # Same approach as `release-bot.yml`'s "Resolve current version"
-        # step: `git describe --tags --abbrev=0 --match 'v*.*.*'` reads
-        # the latest published tag. Falls back to `0.0.0` when no tag
-        # exists yet (first-ever release) so the very first `feature`
-        # entry produces `0.1.0` rather than crashing the predict.
-        #
-        # The version is written to a file under `RUNNER_TEMP` rather
-        # than to `GITHUB_OUTPUT`. Under `pull_request_target`, CodeQL's
-        # `actions/untrusted-checkout` query treats `${{ steps.*.outputs.* }}`
-        # expressions as a tainted-data path into a privileged workflow
-        # — even when the source step ran on the base-ref checkout —
-        # and the env-var pattern alone (`env: VAR: ${{ steps.x.y }}`)
-        # does not fully untaint the flow. Routing the value through a
-        # file in `RUNNER_TEMP` sidesteps the expression entirely; the
-        # consuming step reads it with `cat` and re-validates it as
-        # strict semver before use (defence in depth).
-        run: |
-          set -euo pipefail
-          if tag="$(git describe --tags --abbrev=0 --match 'v*.*.*' 2>/dev/null)"; then
-            printf '%s' "${tag#v}" > "${RUNNER_TEMP}/current-version.txt"
-          else
-            printf '0.0.0' > "${RUNNER_TEMP}/current-version.txt"
-          fi
-
-      - name: Predict release impact
-        id: predict
-        if: steps.touched.outputs.touched == 'true'
-        run: |
-          set -euo pipefail
-          CURRENT_VERSION="$(cat "${RUNNER_TEMP}/current-version.txt")"
-          # Reject anything that isn't strict semver before passing it
-          # to the script. `git describe --tags --match 'v*.*.*'` should
-          # already constrain the value to `MAJOR.MINOR.PATCH`, but the
-          # validation makes the contract explicit at the consuming
-          # step's edge so a future change to the resolver can't
-          # silently widen the surface.
-          if ! [[ "${CURRENT_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "release-impact-comment: invalid current version '${CURRENT_VERSION}'" >&2
-            exit 1
-          fi
-          envelope="$(python3 scripts/changelog/predict_release_impact.py \
-            --repo-root "${RUNNER_TEMP}/predict-sandbox" \
-            --current-version "${CURRENT_VERSION}")"
-          echo "${envelope}" > "${RUNNER_TEMP}/predict.json"
-          # Surface a top-level `predict` boolean so the next step's
-          # `if:` can branch without re-parsing the JSON.
-          if jq -e '.predict == true' < "${RUNNER_TEMP}/predict.json" >/dev/null; then
-            echo "predict=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "predict=false" >> "${GITHUB_OUTPUT}"
-            echo "release-impact-comment: $(jq -r '.reason' < "${RUNNER_TEMP}/predict.json")"
-          fi
-
-      - name: Render comment body
-        id: render
-        if: steps.touched.outputs.touched == 'true' && steps.predict.outputs.predict == 'true'
-        # Render the comment body as Markdown. The first line is an
-        # HTML comment marker the next step uses for idempotent
-        # matching — invisible to humans on the rendered comment but
-        # greppable by the bot. The "Claude: " prefix marks the
-        # comment as agent-authored per the project convention.
-        run: |
-          set -euo pipefail
-          payload="${RUNNER_TEMP}/predict.json"
-          bump="$(jq -r '.bump' < "${payload}")"
-          current="$(jq -r '.current_version' < "${payload}")"
-          next="$(jq -r '.next_version' < "${payload}")"
-          # Render one bullet per driver so a multi-entry PR shows
-          # every contributing entry. Bullet text is built in a jq
-          # filter so the embedded paths / types survive shell
-          # quoting verbatim. Each line: `- type \`feature\` in
-          # \`changelog/@unreleased/pr-NNN-slug.yml\` (-> MINOR)`.
-          drivers="$(jq -r '
-            .drivers[]
-            | "- type `\(.type)` in `\(.path)` (-> \(.bump))"
-              + (if .package then " — package `\(.package)`" else "" end)
-          ' < "${payload}")"
-          body_path="${RUNNER_TEMP}/comment-body.md"
-          {
-            echo "<!-- claude-release-impact -->"
-            echo "Claude: **Release impact:** this PR will trigger a **${bump}** version bump."
-            echo ""
-            echo "Predicted next version: \`v${next}\` (current: \`v${current}\`)."
-            echo ""
-            echo "Drivers:"
-            echo ""
-            echo "${drivers}"
-            echo ""
-            echo "_If this bump is wrong, edit the \`type:\` field in the YAML._"
-          } > "${body_path}"
-          echo "body_path=${body_path}" >> "${GITHUB_OUTPUT}"
-
-      - name: Post or update PR comment
-        if: steps.touched.outputs.touched == 'true' && steps.predict.outputs.predict == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BODY_PATH: ${{ steps.render.outputs.body_path }}
-          # The marker the comment carries on its first line; the
-          # match is exact-prefix so an arbitrary user comment that
-          # happens to mention "claude-release-impact" doesn't get
-          # patched. Kept here (rather than hardcoded in the run-block)
-          # so a future renaming is a single-line edit.
-          MARKER: "<!-- claude-release-impact -->"
-        # Idempotent: list the PR's existing issue comments, find the
-        # one whose body starts with the marker (if any), and
-        # PATCH it with the freshly rendered body. PATCH (rather than
-        # delete + create) preserves the comment ID so subscribers
-        # don't get a fresh notification on every workflow re-run.
-        # If no matching comment exists, POST a new one.
-        run: |
-          set -euo pipefail
-          # `gh api --paginate` (without `--jq`) returns concatenated
-          # arrays from each page; piping into `jq -r` flattens and
-          # filters in a single pass so we don't depend on a particular
-          # gh version's output shape. `--arg` keeps the marker out of
-          # the jq program text so its `<`, `!`, `-` characters survive
-          # shell quoting verbatim. `first(...)` (rather than a trailing
-          # `head -n 1`) caps the result inside jq itself: under
-          # `set -euo pipefail`, closing the pipe early via `head` can
-          # deliver SIGPIPE upstream and fail the pipeline on
-          # long-lived PRs whose comment list spans multiple pages.
-          # `// empty` keeps the assignment empty (rather than emitting
-          # the literal string "null") when no matching comment exists.
-          existing_id="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --paginate \
-            | jq -r --arg marker "${MARKER}" \
-                'first(.[] | select((.body // "") | startswith($marker)) | .id) // empty')"
-          # `-F body=@<file>` reads the body from disk as a JSON
-          # string field — identical semantics to inlining
-          # `body="$(cat <file>)"` but binary-safe and free of any
-          # shell-expansion of the file's contents (the comment body
-          # is rendered Markdown so it can carry backticks / `$(`,
-          # which would otherwise execute under bash's `$(...)`).
-          if [[ -n "${existing_id}" ]]; then
-            echo "release-impact-comment: updating existing comment ${existing_id}"
-            gh api --method PATCH \
-              "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" \
-              -F "body=@${BODY_PATH}" \
-              > /dev/null
-          else
-            echo "release-impact-comment: posting new comment"
-            gh api --method POST \
-              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-              -F "body=@${BODY_PATH}" \
-              > /dev/null
-          fi
-
   predict-release-impact-self-test:
     name: predict_release_impact unit tests
     runs-on: ubuntu-latest
     # Exercise the predict script's bump matrix on every run so a
     # regression in the prediction surface (e.g. the bump enum
     # gaining a new variant whose label is not rendered) immediately
-    # fails CI rather than silently emitting a wrong comment. Same
-    # rationale as the existing `validator-self-test` job.
+    # fails CI rather than silently emitting a wrong comment.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -481,7 +481,7 @@ range (per ADR 0026 § Pre-1.0 behaviour). Force the graduation to
 `1.0.0` with `release-as: 1.0.0` on the breaking change's YAML.
 
 The `release-impact-comment` job in
-[`.github/workflows/pr-lint.yml`](.github/workflows/pr-lint.yml)
+[`.github/workflows/changelog-bot.yml`](.github/workflows/changelog-bot.yml)
 posts an idempotent `Claude:` comment on every PR that touches
 `changelog/@unreleased/*.yml`, surfacing the predicted
 `current → next` version transition so a mislabelled `type:` (e.g.

--- a/scripts/changelog/predict_release_impact.py
+++ b/scripts/changelog/predict_release_impact.py
@@ -5,11 +5,12 @@
 """Predict the SemVer bump a PR will trigger and emit a JSON envelope.
 
 Consumed by the ``release-impact-comment`` job in
-``.github/workflows/pr-lint.yml`` (issue #406). The job posts an
-idempotent PR comment surfacing the predicted bump so a reviewer can
-catch a mislabelled YAML (e.g. a ``feature`` entry that should have
-been ``improvement``) at PR-review time, before the next release goes
-out and the version jumps unexpectedly.
+``.github/workflows/changelog-bot.yml`` (issue #406; relocated from
+``pr-lint.yml`` under #466). The job posts an idempotent PR comment
+surfacing the predicted bump so a reviewer can catch a mislabelled
+YAML (e.g. a ``feature`` entry that should have been ``improvement``)
+at PR-review time, before the next release goes out and the version
+jumps unexpectedly.
 
 The script is plumbing — it does no bump-computation of its own. It
 walks ``changelog/@unreleased/*.yml`` and delegates to
@@ -172,7 +173,8 @@ def _build_parser() -> argparse.ArgumentParser:
         description=(
             "Emit a JSON envelope predicting the SemVer bump implied "
             "by `changelog/@unreleased/*.yml`. Consumed by the "
-            "`release-impact-comment` job in `.github/workflows/pr-lint.yml`."
+            "`release-impact-comment` job in "
+            "`.github/workflows/changelog-bot.yml`."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
==COMMIT_MSG==
Co-locate the predicted-bump comment surface with the YAML-authoring
surface that drives it. The auto-author job in changelog-bot.yml
commits a `changelog/@unreleased/pr-<N>-*.yml` when a PR opts in via
the `==CHANGELOG_MSG==` marker, and the release-impact-comment job
then surfaces the predicted `current -> next` version transition for
those YAMLs at PR-review time. Keeping both surfaces in one workflow
makes the relationship discoverable and avoids dragging the elevated
`pull_request_target` token along on the residual self-tests now that
no other job in pr-lint.yml needs fork-PR write access.

The job ports its existing logic — same step decomposition (list
changed files, detect changelog touch, resolve current version,
predict, render, post/update with marker-based idempotency), same
PyYAML-only runtime install, same default-`GITHUB_TOKEN` bot identity
with the "Claude:" prefix per the project convention. Two
simplifications fall out of the trigger change to `pull_request`:
the API-fetch sandbox for the PR head's YAMLs collapses into a normal
checkout, and the current-version value passes through a step output
instead of `RUNNER_TEMP` routing (the CodeQL `untrusted-checkout`
concern that drove that indirection only applies under
`pull_request_target`).

Behaviour change: fork PRs no longer receive a release-impact comment.
That trade is symmetric with the auto-author job's "in-repo only"
stance — the bot doesn't mint a write-token for fork PRs either, and
in-repo branches do the bulk of the release-bumping work this surface
is designed to gate.

The two surviving jobs in pr-lint.yml — `pr-title-types-self-test` and
`predict-release-impact-self-test` — are meta-checks on the workflow
YAML and the predict script itself, neither of which need the elevated
token. They stay put with read-only permissions on `pull_request`.

Closes: #466
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

This PR moves the `release-impact-comment` job out of `pr-lint.yml` and into
`changelog-bot.yml`, alongside the existing changelog-bot auto-author job.
Per the issue's stated re-scope (the "delete pr-lint.yml entirely" line in
the issue is stale guidance from when more jobs were expected to leave),
`pr-lint.yml` is **kept** with its two surviving self-tests
(`pr-title-types-self-test` and `predict-release-impact-self-test`) — they
have no new home in the new CI structure yet, and deleting them would
silently lose coverage on `commit_taxonomy.py` allowlist drift and
`predict_release_impact.py` regressions.

### Notable design choices

- **Trigger set:** `pull_request` (NOT `pull_request_target`), matching the
  auto-author job in `changelog-bot.yml` per the issue body. This is a
  deliberate behaviour change: fork PRs no longer get a release-impact
  comment, mirroring the auto-author job's in-repo-only stance.
- **Simplifications under `pull_request`:** the elaborate sandbox /
  base-ref-pin / RUNNER_TEMP-routing dance the original job needed to
  satisfy CodeQL's `actions/untrusted-checkout` query under
  `pull_request_target` becomes unnecessary on `pull_request`, where the
  default `GITHUB_TOKEN` is already not elevated for fork PRs. The new
  job uses a normal checkout and step outputs.
- **`pr-lint.yml` trigger:** dropped from `pull_request_target` to
  `pull_request` since no remaining job needs the elevated token.

### Test plan

- [ ] Workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/changelog-bot.yml'))"` and same for `pr-lint.yml`)
- [ ] `pr-title-types-self-test` job passes locally: `python3 scripts/lint/commit_taxonomy.py check-pr-lint-yaml`
- [ ] `predict-release-impact-self-test` job passes locally: `python3 -m pytest -o addopts= scripts/changelog/tests/test_predict_release_impact.py -v`
- [ ] CI on this PR shows the release-impact-comment job runs from the new home (no comment expected here since the PR doesn't touch `changelog/@unreleased/*.yml`, but the job should appear under `Changelog Bot / Release impact comment` and exit cleanly via the early-exit branch).
- [ ] The two self-tests still report under `PR Lint / ...` check names.