### PR TITLE
chore(ci): collapse merge-bot workflow_run listener to just CI

### DIFF
--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -16,10 +16,12 @@ name: Merge Bot
 #
 # Triggers:
 #   - pull_request: labeled — proceed when the new label == `automerge`.
-#   - workflow_run: completed — sticky-label retry once the last
-#     watched CI workflow completes AFTER the label was set. We list
-#     every PR-gating workflow by name so each one's completion fires
-#     the bot. `workflow_run` is used here (not `check_suite`) because
+#   - workflow_run: completed — sticky-label retry once `CI`
+#     completes AFTER the label was set. The listener is scoped to
+#     `CI` only because its `Required checks passed` aggregator is
+#     the single branch-protection-required check, so a green CI
+#     run means every gate passed (issue #467). `workflow_run` is
+#     used here (not `check_suite`) because
 #     `check_suite` events are suppressed by GitHub's anti-recursion
 #     rule when the upstream workflow runs under the default
 #     `GITHUB_TOKEN` — every CI workflow in this repo does, so
@@ -119,32 +121,17 @@ name: Merge Bot
 on:
   pull_request:
     types: [labeled]
-  # Every PR-gating workflow listed by name so each completion fires
-  # the bot. Adding a new required-check workflow requires updating
-  # this list — that's intentional. Excludes:
-  #   - Merge Bot itself (anti-recursion).
-  #   - Release / publish / scorecard / mutation / benchmark workflows
-  #     that don't run on PRs.
-  #   - Dependency Submission, which now runs on PRs (issue #412) but
-  #     intentionally skips on fork PRs (read-only GITHUB_TOKEN), so
-  #     it can't be a required gate without blocking external
-  #     contributions; PR-time CVE gating is enforced by Dependency
-  #     Review against the head-SHA snapshot it produces.
-  #   - Release Tag (only fires on PR `closed`, well after merge).
+  # Listen on `CI` only — that workflow's `Required checks passed`
+  # aggregator is the single branch-protection-required check, so a
+  # green CI completion is the one signal that means "every gate
+  # passed and the bot should re-evaluate" (issue #467). The
+  # previous per-workflow enumeration was redundant once the
+  # aggregator landed, and `CI` itself is naturally excluded from
+  # an anti-recursion list because Merge Bot does not author
+  # commits — there is no recursion to break.
   workflow_run:
     workflows:
       - CI
-      - PR Lint
-      - DCO
-      - Changelog Lint
-      - REUSE
-      - Dependency Review
-      - Verify Design
-      - Verify Function Tests
-      - Verify Standards
-      - Verify Token CLI / HTTP Parity
-      - Changelog Bot
-      - Release Dryrun
     types: [completed]
   pull_request_review:
     types: [submitted, dismissed]


### PR DESCRIPTION
==COMMIT_MSG==
The listener used to enumerate every PR-gating workflow by name so
each completion would fire the bot. After #466 landed the
`Required checks passed` aggregator inside ci.yml, branch
protection is gated on that single check — so any non-CI workflow
completion is no longer a meaningful re-evaluate signal for the
bot. Several entries in the old list also referenced workflows
that have already been deleted in earlier migrations and were
silently ignored by GitHub Actions.

Scope the listener to `CI` only and refresh the surrounding
prose — the per-workflow exclusion enumeration is no longer
relevant, and `CI` does not need an anti-recursion exclusion
because Merge Bot authors no commits. The `pull_request: labeled`
primary trigger, the `pull_request_review` re-fire trigger, the
`push: main` sweep trigger, and the `workflow_dispatch`
break-glass entry point are all unchanged.

Closes: #467
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

Pure CI workflow tuning — no user-visible change. The merge bot's
evaluation logic, merge logic, sweep job, and label-needs-fix job
are all unchanged; only the `on.workflow_run.workflows` listener
list and its accompanying prose move. The listener's collapse to
`["CI"]` will be exercised end-to-end when this PR is merged via
the merge bot itself.

### Test plan

- [ ] CI is green on this branch.
- [ ] `pr-lint.yml` passes (the `==COMMIT_MSG==` block carries
  contiguous `Closes:` + `Signed-off-by:` trailers and no leading
  subject line).
- [ ] Once `automerge` is applied, the merge bot fires correctly
  on this PR — that is the intended live verification of the
  collapsed listener.