### PR TITLE
chore(claude): scaffold engineering skill config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,3 +160,17 @@ topic is relevant:
 - `bash.md` — Bash-specific linting and formatting.
 - `release-and-hygiene.md` — required project files (CONTRIBUTING, CHANGELOG,
   LICENSE, SECURITY), release process, and repo metadata.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub issues at `aidanns/agent-auth`, managed via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`); the four non-`wontfix` labels are created on first use. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — `CONTEXT.md` at the repo root, ADRs at `design/decisions/` (non-default path). See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,4 +173,4 @@ Canonical vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-fo
 
 ### Domain docs
 
-Single-context — `CONTEXT.md` at the repo root, ADRs at `design/decisions/` (non-default path). See `docs/agents/domain.md`.
+Glossary at `CONTEXT.md` (repo root); ADRs at `design/decisions/` (non-default path — i.e. not the `docs/adr/` location the engineering skills default to). See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,4 +12,4 @@ Domain language for the agent-auth project. Populate as terms get resolved (typi
 
 <!-- TODO(aidanns): populate as the project's vocabulary stabilises. Each entry: a noun phrase, a one-paragraph definition, and (optional) "synonyms to avoid". -->
 
-For broader project documentation (architecture, ADRs, assurance), see `docs/agents/domain.md`.
+For broader project documentation (architecture, ADRs, assurance), see `design/` — `DESIGN.md` (architecture), `design/decisions/` (ADRs), `ASSURANCE.md` / `ASVS.md` / `SSDF.md` (assurance and security framework mappings). The agent-skill index of how to consume those docs lives at `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,15 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# CONTEXT
+
+Domain language for the agent-auth project. Populate as terms get resolved (typically via `/grill-with-docs`).
+
+## Glossary
+
+<!-- TODO(aidanns): populate as the project's vocabulary stabilises. Each entry: a noun phrase, a one-paragraph definition, and (optional) "synonyms to avoid". -->
+
+For broader project documentation (architecture, ADRs, assurance), see `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -12,7 +12,7 @@ How the engineering skills should consume this repo's domain documentation when 
 
 - **`CONTEXT.md`** at the repo root — domain glossary.
 - **`design/decisions/`** — ADRs that touch the area you're about to work in. ADRs live at `design/decisions/`, not the default `docs/adr/`.
-- **`design/`** — broader documentation: `DESIGN.md` (architecture), `THINGS.md` (Things 3 integration), `functional_decomposition.*`, `product_breakdown.*`, and assurance docs (`ASSURANCE.md`, `ASVS.md`, `SSDF.md`, `SELF_ASSESSMENT.md`). Consult when the topic is broader than a single ADR.
+- **`design/`** — broader documentation: `DESIGN.md` (architecture), `THINGS.md` (Things 3 AppleScript API reference — third-party surface, not this project's integration architecture; for the integration see `DESIGN.md` and ADR-0013), `functional_decomposition.*`, `product_breakdown.*`, and assurance docs (`ASSURANCE.md`, `ASVS.md`, `SSDF.md`, `SELF_ASSESSMENT.md`). Consult when the topic is broader than a single ADR.
 
 The canonical layout of `design/` is documented in `.claude/instructions/design.md`.
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,31 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — domain glossary.
+- **`design/decisions/`** — ADRs that touch the area you're about to work in. ADRs live at `design/decisions/`, not the default `docs/adr/`.
+- **`design/`** — broader documentation: `DESIGN.md` (architecture), `THINGS.md` (Things 3 integration), `functional_decomposition.*`, `product_breakdown.*`, and assurance docs (`ASSURANCE.md`, `ASVS.md`, `SSDF.md`, `SELF_ASSESSMENT.md`). Consult when the topic is broader than a single ADR.
+
+The canonical layout of `design/` is documented in `.claude/instructions/design.md`.
+
+If `CONTEXT.md` doesn't exist, **proceed silently**. Don't flag its absence; don't suggest creating it upfront. The producer skill (`/grill-with-docs`) populates it lazily when terms get resolved.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (SQLite field-level encryption) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -12,7 +12,7 @@ Issues and PRDs for this repo live as GitHub issues at `aidanns/agent-auth`. Use
 
 - **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
 - **Read an issue**: `gh issue view <number> --comments`.
-- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **List issues**: `gh issue list --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`
 - **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
 - **Close**: `gh issue close <number> --comment "..."`

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,28 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues at `aidanns/agent-auth`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -19,3 +19,5 @@ When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the 
 `wontfix` already exists in this repo. The other four are created on first use via `gh label create <name>`.
 
 These labels describe **triage state**. They are orthogonal to the existing **execution-state** labels (`scheduled`, `in-progress`, `paused`, `blocked`, `needs fix`) — those track an active Claude Code session's progress and can coexist on the same issue.
+
+`needs-info` and `blocked` look similar but apply at different stages: `needs-info` means the issue is awaiting clarification from an external reporter *before* triage is complete (no Claude Code session has picked it up), while `blocked` means a Claude Code session is mid-execution and has parked the issue awaiting an answer it captured as a `Claude: Blocked — <question>` comment. If both states ever apply, the execution-state `blocked` is the active one — drop the `needs-info` label when an agent picks up the issue.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,21 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# Triage Labels
+
+The skills speak in terms of five canonical triage labels. This repo uses the canonical names verbatim:
+
+- `needs-triage` — maintainer needs to evaluate this issue
+- `needs-info` — waiting on reporter for more information
+- `ready-for-agent` — fully specified, ready for an AFK agent
+- `ready-for-human` — requires human implementation
+- `wontfix` — will not be actioned
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the matching label string above.
+
+`wontfix` already exists in this repo. The other four are created on first use via `gh label create <name>`.
+
+These labels describe **triage state**. They are orthogonal to the existing **execution-state** labels (`scheduled`, `in-progress`, `paused`, `blocked`, `needs fix`) — those track an active Claude Code session's progress and can coexist on the same issue.


### PR DESCRIPTION
==COMMIT_MSG==
Wire the engineering skills (triage, refine-issues, to-prd, to-issues,
diagnose, tdd, improve-codebase-architecture, grill-with-docs) so they
read the right paths and label vocabulary for this repo. Generated by
the engineering:setup skill.

- Append `## Agent skills` block to CLAUDE.md pointing at three new
  per-skill config files under docs/agents/.
- Add docs/agents/issue-tracker.md (GitHub via gh CLI).
- Add docs/agents/triage-labels.md mapping the five canonical roles
  to verbatim label names; the four non-`wontfix` labels are created
  on first use.
- Add docs/agents/domain.md noting the non-default ADR location at
  design/decisions/ and pointing at .claude/instructions/design.md
  for the canonical design/ layout.
- Seed CONTEXT.md as a glossary stub at the repo root for future
  /grill-with-docs sessions.

No user-visible behaviour change; pure agent-tooling configuration.

Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

This PR is the output of running the \`engineering:setup\` skill. It
scaffolds the per-repo configuration the engineering skills assume
(issue tracker, triage label vocabulary, domain-doc layout) without
changing any product behaviour.

### Test plan

- [ ] Confirm \`treefmt\` passes locally (\`task fmt:check\` or
      equivalent) — pre-commit lefthook ran cleanly.
- [ ] Read \`CLAUDE.md\` § "Agent skills" and follow each
      \`docs/agents/*.md\` link to verify the three docs render and
      cross-reference correctly.
- [ ] Verify SPDX/REUSE compliance: \`reuse lint\` (or whichever
      task target wraps it) reports zero new uncovered files.
