### PR TITLE
chore(ci): order dependency-review after dependency-submission

### DIFF
--- a/.github/workflows/check-security.yml
+++ b/.github/workflows/check-security.yml
@@ -53,6 +53,7 @@ jobs:
     uses: ./.github/workflows/ripsecrets.yml
   check-dependency-review:
     name: Check Dependency Review
+    needs: [check-dependency-submission]
     uses: ./.github/workflows/check-dependency-review.yml
     with:
       event_has_diff_base_head: ${{ inputs.event_has_diff_base_head }}


### PR DESCRIPTION
## Summary

`Check Dependency Review` and `Check Dependency Submission` were
sibling jobs under `check-security.yml` with no `needs:` between
them, so they ran in parallel. When `dependency-review-action`
queried the Dependency Graph before `dependency-submission`'s POST
landed, it found no head-SHA snapshot and emitted a sticky PR
comment ("No snapshots were found for the head SHA ...") that
persisted on every PR. Cancellation churn aggravated the race.

This change adds `needs: [check-dependency-submission]` to the
`check-dependency-review` child so the review waits for the snapshot
upload to complete before scanning.

==COMMIT_MSG==
`Check Dependency Review` and `Check Dependency Submission` were
sibling jobs under `check-security.yml` with no `needs:` between
them, so they ran in parallel. When `dependency-review-action`
queried the Dependency Graph before `dependency-submission`'s POST
landed, it found no head-SHA snapshot and emitted a sticky PR
comment ("No snapshots were found for the head SHA ...") that
persisted on every PR. Cancellation churn aggravated the race —
when a CI run got superseded mid-flight, `submit` could be
cancelled before the POST completed and the snapshot was never
uploaded for that SHA.

Add `needs: [check-dependency-submission]` to the
`check-dependency-review` child so the review waits for the
snapshot upload to complete before scanning. The aggregator's
behaviour at the bottom of the file is unchanged for the success
path — both jobs already sit in its `needs:`. If
`check-dependency-submission` fails, GitHub will mark
`check-dependency-review` as `skipped`, which the aggregator
correctly rejects: a missing snapshot makes the review's verdict
meaningless, so the PR should turn red rather than report a stale
allow.

Considered alternatives: `retry-on-snapshot-warnings: true` on the
action masks the race instead of fixing it and burns CI minutes
on retries; leaving as-is would keep the warning comment on every
PR.

Closes: #555
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

### Test plan

- [ ] Open this PR and confirm a fresh CI run posts the
  dependency-review summary comment without the "No snapshots were
  found for the head SHA" warning.
- [ ] Confirm `Check Dependency Review` runs after
  `Check Dependency Submission` (visible as a `needs:` edge in the
  GitHub Actions run graph for `Check Security`).
- [ ] Confirm `Required checks passed` aggregator under
  `check-security.yml` still rejects a `skipped` result for either
  child (i.e. the ordering does not introduce a green-on-skip hole).