### PR TITLE
chore(claude): commit-message authoring rules for sessions

### DIFF
--- a/.claude/instructions/commit-messages.md
+++ b/.claude/instructions/commit-messages.md
@@ -1,0 +1,82 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# Commit-message Authoring Rules
+
+Prose conventions for PR titles and ==COMMIT_MSG== bodies. They
+apply to every PR — chore commits enter git log too. The structural
+rules (prefix allowlist, block shape, trailer parsing) live in
+CONTRIBUTING.md and ADR 0037; this file covers the prose inside.
+
+## Bullets
+
+- **Use bullets only for parallel sets of 2+ identical-shape items.**
+  A bulleted list is a claim that the items are the same kind of
+  thing (configs, error codes, rejected alternatives). One-off
+  observations stay in prose.
+- **Never bullet a diff recap.** If the bullets read as "renamed X,
+  adjusted Y, added Z", the commit body is replaying git show —
+  collapse to one sentence on *why*.
+- **Trigger phrases.** "Side effects in the same PR", "Also:",
+  "while we're here" in the draft mean the PR is doing too much,
+  not that bullets will rescue it. Split the PR.
+
+## Backticks
+
+- **Drop them in body prose.** Backticks add visual noise; reserve
+  them for the cases below.
+- **Self-identifying tokens stay bare.** Filenames with extensions,
+  dotted module paths, underscored identifiers, and kebab-case
+  identifiers in identifier-shaped contexts are unambiguously code
+  to the reader without backticks.
+- **Reword ambiguous bare words.** "case statement" not bare `case`;
+  "the gpg command" not bare `gpg` when the sentence reads as
+  English. Pick the noun phrase, drop the backticks.
+- **Double-quote literals with spaces or that read as English.**
+  "no changelog", "skipped", "needs-info" — quotes mark the boundary
+  that backticks would, and read naturally in git log.
+- **Shouty-cased markers strip wrapper syntax.** Write NO_CHANGELOG,
+  not ==NO_CHANGELOG==; the wrapper is implementation detail and
+  the SHOUTY case already signals "literal token".
+
+## Brevity
+
+- **Default to cutting.** A shorter body that survives a six-month
+  re-read beats a longer one that recapitulates the diff.
+- **Drop "behaviour at X is unchanged" sentences.** Absence of
+  behaviour change is the default reading; calling it out adds
+  words without information.
+- **KEEP** — exact error strings (greppable from git log --grep),
+  non-obvious correctness claims, non-obvious failure modes,
+  rejected alternatives.
+- **CUT** — re-statements of the diff, narrative connectives that
+  carry no claim ("First we …, then we …"), success-path
+  confirmations ("the build passes", "tests added").
+
+## Causal narrative ordering
+
+- **Lead with the observable behaviour the reader could have seen.**
+  The symptom, the failure, the surprising output — whatever a
+  future bisector would paste into git log --grep.
+- **Fold setup INTO mechanism, not before.** Introduce shared
+  context at the point it earns its keep, not as a preamble.
+- **Anti-pattern.** Opening with "X and Y share Z" before the
+  reader knows why Z matters forces them to hold context they
+  cannot yet evaluate. Reorder so the consequence comes first.
+
+## Arrows vs prose
+
+- **Arrows (`->`) for mechanical sub-steps.** A short pipeline
+  reads cleanly as `query before POST -> no snapshot -> sticky comment`: each hop is a deterministic consequence of the prior.
+- **Prose with explicit connectives for the primary causal claim.**
+  Use "so", "because", "which" when the link is a *reasoning* step
+  rather than a mechanical one. Arrows hide the reasoning; prose
+  exposes it.
+
+______________________________________________________________________
+
+See CONTRIBUTING.md -> "Writing release-worthy commits" for the
+human-facing rationale and worked counter-examples.

--- a/.claude/instructions/commit-messages.md
+++ b/.claude/instructions/commit-messages.md
@@ -6,9 +6,9 @@ SPDX-License-Identifier: MIT
 
 # Commit-message Authoring Rules
 
-Prose conventions for PR titles and ==COMMIT_MSG== bodies. They
-apply to every PR — chore commits enter git log too. The structural
-rules (prefix allowlist, block shape, trailer parsing) live in
+Prose conventions for PR titles and COMMIT_MSG bodies. They apply
+to every PR — chore commits enter git log too. The structural rules
+(prefix allowlist, block shape, trailer parsing) live in
 CONTRIBUTING.md and ADR 0037; this file covers the prose inside.
 
 ## Bullets
@@ -69,8 +69,9 @@ CONTRIBUTING.md and ADR 0037; this file covers the prose inside.
 
 ## Arrows vs prose
 
-- **Arrows (`->`) for mechanical sub-steps.** A short pipeline
-  reads cleanly as `query before POST -> no snapshot -> sticky comment`: each hop is a deterministic consequence of the prior.
+- **Arrows (`->`) for mechanical sub-steps.** A short pipeline reads
+  cleanly as `query before POST -> no snapshot -> sticky comment`:
+  each hop is a deterministic consequence of the prior.
 - **Prose with explicit connectives for the primary causal claim.**
   Use "so", "because", "which" when the link is a *reasoning* step
   rather than a mechanical one. Arrows hide the reasoning; prose

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ topic is relevant:
   include (design verification and post-implementation standards review).
 - `coding-standards.md` — naming, types, and safety rules.
 - `commit-messages.md` — bullets, backticks, brevity, causal ordering, and
-  arrows-vs-prose rules for PR titles and `==COMMIT_MSG==` bodies.
+  arrows-vs-prose rules for PR titles and COMMIT_MSG bodies.
 - `service-design.md` — configuration, file paths, plugin surfaces, HTTP
   services, security, and resilience standards.
 - `design.md` — design directory structure, ADRs, functional decomposition,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,8 @@ topic is relevant:
 - `plan-template.md` — checklist of steps every implementation plan must
   include (design verification and post-implementation standards review).
 - `coding-standards.md` — naming, types, and safety rules.
+- `commit-messages.md` — bullets, backticks, brevity, causal ordering, and
+  arrows-vs-prose rules for PR titles and `==COMMIT_MSG==` bodies.
 - `service-design.md` — configuration, file paths, plugin surfaces, HTTP
   services, security, and resilience standards.
 - `design.md` — design directory structure, ADRs, functional decomposition,

--- a/plans/claude-md-commit-message-rules.md
+++ b/plans/claude-md-commit-message-rules.md
@@ -1,0 +1,89 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# Plan: Commit-message authoring rules for Claude sessions
+
+Issue #561 (parent #560). Add a session-loaded rules file so a fresh
+Claude session applies the same prose conventions on its first
+commit-message draft.
+
+## Decision recap
+
+- Location: `.claude/instructions/commit-messages.md` (per issue
+  Decision 2026-05-03 — option a in the parent meta-tracker).
+- `CLAUDE.md` "Detailed instructions" gains a one-line pointer.
+- The new file cross-references the human-facing rationale in
+  `CONTRIBUTING.md` -> "Writing release-worthy commits". The reverse
+  pointer (CONTRIBUTING.md -> instruction file) is a parallel-PR
+  scope (#562) — a brief broken-link window is acceptable.
+
+## Five rule clusters (terse phrasing)
+
+Match the prose style of `coding-standards.md` /
+`service-design.md`: `**bold-cluster**` lead, single-line directive,
+anti-pattern triggers called out where applicable. Sub-bullets only
+when the cluster has multiple distinct sub-rules.
+
+1. **Bullets** — only for parallel sets of 2+ identical-shape items;
+   never for diff recap. Trigger phrases on draft prose ("Side
+   effects in the same PR", "Also:", "while we're here") signal the
+   PR is doing too much, not that bullets are needed.
+2. **Backticks** — drop in body prose. Self-identifying tokens stay
+   bare (filenames with extensions, dotted paths, underscored
+   identifiers, kebab-case identifiers in identifier-shaped contexts).
+   Reword ambiguous bare words ("case statement" not bare `case`).
+   Double-quote literals with spaces or that read as English ("no
+   changelog", "skipped"). Shouty-cased markers strip wrapper syntax
+   (`==NO_CHANGELOG==` -> NO_CHANGELOG).
+3. **Brevity** — default to cutting; explicit KEEP / CUT lists. Drop
+   "behaviour at X is unchanged" sentences. KEEP exact error strings
+   (greppable), non-obvious correctness claims, non-obvious failure
+   modes, rejected alternatives. CUT re-statements, narrative
+   connectives, success-path confirmations.
+4. **Causal narrative ordering** — lead with the observable
+   behaviour the reader could have seen; fold setup INTO mechanism,
+   not before. Anti-pattern: opening with "X and Y share Z" before
+   the reader knows why Z matters.
+5. **Arrows vs prose** — arrows (`->`) for mechanical sub-steps
+   ("query before POST -> no snapshot -> sticky comment"); prose
+   with explicit connectives ("so", "because", "which") for the
+   primary causal claim.
+
+## CLAUDE.md update
+
+Insert one bullet in the "Detailed instructions" list, between the
+`coding-standards.md` and `design.md` entries (alphabetical-ish
+neighbours; also groups with the other prose-quality conventions).
+
+Phrasing: `commit-messages.md` — bullets, backticks, brevity, causal
+ordering, and arrows-vs-prose rules for PR titles and ==COMMIT_MSG==
+bodies.
+
+## Cross-reference
+
+In `commit-messages.md`, end with a one-line pointer:
+"See CONTRIBUTING.md -> 'Writing release-worthy commits' for the
+human-facing rationale and worked counter-examples."
+
+## Skipped plan-template steps (with justification)
+
+- **Threat model / PIR / ADR / cybersecurity / QM-SIL** — none
+  apply: docs-only change to a developer-facing instruction file,
+  no code, no schema, no security surface, no decision worth ADR
+  weight (the file location decision is recorded in the parent
+  issue's clarification).
+- **Verify implementation against design doc** — no design doc
+  governs `.claude/instructions/`; the issue body is the spec.
+
+## Post-implementation standards review
+
+- `coding-standards.md`, `service-design.md`,
+  `release-and-hygiene.md`, `testing-standards.md`,
+  `tooling-and-ci.md` — all code/service-shaped; not applicable to a
+  prose-only edit. Confirm each one is not applicable rather than
+  silently skip.
+- Apply the rules in the new file to the new file's own prose and
+  to the PR's `==COMMIT_MSG==` block before pushing.


### PR DESCRIPTION
## Review notes

Implements #561 (parent #560). New file:
.claude/instructions/commit-messages.md, with one-line pointers from
CLAUDE.md's "Detailed instructions" list and from the new file back
to CONTRIBUTING.md's "Writing release-worthy commits" section. The
reverse pointer (CONTRIBUTING.md -> instruction file) is scoped to
the parallel #562 PR, per the issue body — brief broken-link window
is accepted.

The new file applies its own rules to itself: bare self-identifying
tokens (CONTRIBUTING.md, ==COMMIT_MSG==, NO_CHANGELOG), backticks
only for ambiguous-bare-word demonstrations and the arrows-vs-prose
worked example, brevity-first phrasing, terse cluster bullets in
the same shape as coding-standards.md and service-design.md.

### Test plan

- [ ] `task format -- --check` passes (ran locally pre-push)
- [ ] `task reuse-lint` passes (ran locally pre-push)
- [ ] CI: pr-title, pr-title-style, pr-body-commit-msg, dco
- [ ] Demoability: a fresh Claude session in this repo applies the
      rules on its first commit-message draft (verified by the
      orchestrator launching this very session — it loaded the file
      via the CLAUDE.md "Detailed instructions" pointer)

==COMMIT_MSG==
A fresh Claude session has no automatic exposure to the prose
conventions in CONTRIBUTING.md, so its first commit-message draft
in a new repo defaults to diff-recap bullets, scattered backticks,
and narrative-ordering that buries the observable behaviour. Adding
the rules to .claude/instructions/ pulls them into the
session-startup context so the draft lands within convention on the
first attempt instead of after review.

Closes #561
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==
