### PR TITLE
chore(docs): expand commit-message rule rationale

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -834,32 +834,39 @@ The rules sit alongside
 rather than superseding it: ADR 0037 defines the prefix allowlist and
 the block structure, this section defines the prose inside.
 
+The terse, machine-applied form of the rules below lives in
+[`.claude/instructions/commit-messages.md`](.claude/instructions/commit-messages.md)
+so every Claude session loads them automatically. This section is the
+human-facing rationale layer — terse rule plus *why* plus
+anti-pattern, the form a reviewer cites when pushing back on a draft.
+
 A subset of the rules below is **CI-enforced**; the rest are
 **convention only** (caught at human review). The split is:
 
-| Rule                                                                             | Enforced by                                                                                                                       |
-| -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| Title prefix in the Palantir allowlist                                           | CI (`pr-title` job, `amannn/action-semantic-pull-request`)                                                                        |
-| Title ≤ 72 chars (after `merge-bot.yml` appends ` (#<n>)`)                       | CI (`pr-title-style` job, `pr-lint-validator title --pr-number`)                                                                  |
-| Title has no trailing period                                                     | CI (`pr-title-style` job)                                                                                                         |
-| Title does not open with a past-tense / participle verb in the closed list       | CI (`pr-title-style` job — list: `Added` / `Fixed` / `Updated` / `Changed` / `Removed` / `Refactored` / `Implemented` / `Bumped`) |
-| Title summary ≤ 50 chars (soft target on the post-prefix summary)                | Convention only                                                                                                                   |
-| Title summary capitalisation (project lowercases post-prefix)                    | Convention only                                                                                                                   |
-| Imperative mood beyond the past-tense closed list                                | Convention only (no clean regex without false positives)                                                                          |
-| Body wraps at ≤ 72 chars                                                         | CI (`pr-body-commit-msg` job, `pr-lint-validator commit-msg`)                                                                     |
-| Body length (soft cap, warning only)                                             | CI (`pr-body-commit-msg` job; warning surfaced in workflow log, does not fail the job)                                            |
-| Body has no markdown headings / task checkboxes / image embeds                   | CI (`pr-body-commit-msg` job — plain `-` / `*` bullets and `1.` numbered lists are permitted)                                     |
-| Body opens non-blank (after PR-template scaffolding)                             | CI (`pr-body-commit-msg` job)                                                                                                     |
-| Body's first line does not duplicate the PR title                                | CI (`pr-body-commit-msg` job, with the title passed in via env var)                                                               |
-| `Fixes: <sha> ("subject")` follows the kernel-style shape when SHA-style is used | CI (`pr-body-commit-msg` job)                                                                                                     |
-| Trailers parse as `Token: value` and use a recognised token                      | CI (`pr-body-commit-msg` job)                                                                                                     |
-| Trailer block is contiguous (no blank lines between trailers)                    | CI (`pr-body-commit-msg` job)                                                                                                     |
-| At least one blank line sits between the body and the trailer block              | CI (`pr-body-commit-msg` job)                                                                                                     |
-| `BREAKING CHANGE:` is the last non-`Signed-off-by:` line                         | CI (`pr-body-commit-msg` job)                                                                                                     |
-| At least one `Signed-off-by:` trailer is present                                 | CI (`pr-body-commit-msg` job; also enforced post-merge by `dco.yml`)                                                              |
-| One logical change per PR                                                        | Convention only (undecidable mechanically)                                                                                        |
-| Body leads with *why*, not *how*                                                 | Convention only (undecidable mechanically)                                                                                        |
-| `fix:` PRs include observable symptoms                                           | Convention only                                                                                                                   |
+| Rule                                                                                                            | Enforced by                                                                                                                       |
+| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Title prefix in the Palantir allowlist                                                                          | CI (`pr-title` job, `amannn/action-semantic-pull-request`)                                                                        |
+| Title ≤ 72 chars (after `merge-bot.yml` appends ` (#<n>)`)                                                      | CI (`pr-title-style` job, `pr-lint-validator title --pr-number`)                                                                  |
+| Title has no trailing period                                                                                    | CI (`pr-title-style` job)                                                                                                         |
+| Title does not open with a past-tense / participle verb in the closed list                                      | CI (`pr-title-style` job — list: `Added` / `Fixed` / `Updated` / `Changed` / `Removed` / `Refactored` / `Implemented` / `Bumped`) |
+| Title summary ≤ 50 chars (soft target on the post-prefix summary)                                               | Convention only                                                                                                                   |
+| Title summary capitalisation (project lowercases post-prefix)                                                   | Convention only                                                                                                                   |
+| Imperative mood beyond the past-tense closed list                                                               | Convention only (no clean regex without false positives)                                                                          |
+| Body wraps at ≤ 72 chars                                                                                        | CI (`pr-body-commit-msg` job, `pr-lint-validator commit-msg`)                                                                     |
+| Body length (soft cap, warning only)                                                                            | CI (`pr-body-commit-msg` job; warning surfaced in workflow log, does not fail the job)                                            |
+| Body has no markdown headings / task checkboxes / image embeds                                                  | CI (`pr-body-commit-msg` job — plain `-` / `*` bullets and `1.` numbered lists are permitted)                                     |
+| Body opens non-blank (after PR-template scaffolding)                                                            | CI (`pr-body-commit-msg` job)                                                                                                     |
+| Body's first line does not duplicate the PR title                                                               | CI (`pr-body-commit-msg` job, with the title passed in via env var)                                                               |
+| `Fixes: <sha> ("subject")` follows the kernel-style shape when SHA-style is used                                | CI (`pr-body-commit-msg` job)                                                                                                     |
+| Trailers parse as `Token: value` and use a recognised token                                                     | CI (`pr-body-commit-msg` job)                                                                                                     |
+| Trailer block is contiguous (no blank lines between trailers)                                                   | CI (`pr-body-commit-msg` job)                                                                                                     |
+| At least one blank line sits between the body and the trailer block                                             | CI (`pr-body-commit-msg` job)                                                                                                     |
+| `BREAKING CHANGE:` is the last non-`Signed-off-by:` line                                                        | CI (`pr-body-commit-msg` job)                                                                                                     |
+| At least one `Signed-off-by:` trailer is present                                                                | CI (`pr-body-commit-msg` job; also enforced post-merge by `dco.yml`)                                                              |
+| One logical change per PR                                                                                       | Convention only (undecidable mechanically)                                                                                        |
+| Body leads with *why*, not *how*                                                                                | Convention only (undecidable mechanically)                                                                                        |
+| `fix:` PRs include observable symptoms                                                                          | Convention only                                                                                                                   |
+| Causal narrative ordering, brevity, bullets-only-for-2+-parallel-sets, arrows-vs-prose, shouty-marker rendering | Convention only (caught at human review; rationale below)                                                                         |
 
 ##### Subject (PR title)
 
@@ -923,6 +930,120 @@ A subset of the rules below is **CI-enforced**; the rest are
   was just an inconsistency tax on contributors. Closes #326."* —
   the file list is in `git show`'s rename detection, not the
   message.
+
+- **Causal narrative ordering — observable behaviour first, setup
+  folded in.** "Lead with *why*" sets the topic; this rule sets the
+  shape. Open the body with the behaviour the reader could have
+  observed (the orthography tax, the redundant aggregator, the
+  sticky comment that wouldn't go away) and fold the setup INTO the
+  mechanism rather than ahead of it. The anti-pattern is opening
+  with "X and Y share Z" before the reader knows why Z matters —
+  the reader has to hold an unexplained relationship in working
+  memory while waiting for its payoff. By the time the payoff
+  arrives the lede has been buried two paragraphs deep and the
+  bisecting reader has moved on.
+
+- **Brevity — default to cutting; explicit KEEP / CUT lists.** Most
+  drafts over-narrate. The default move is *cut*, not polish. Two
+  lists make this concrete:
+
+  **KEEP** —
+
+  1. Exact error strings, log lines, and stack-trace snippets — the
+     bisecting engineer searching `git log --grep` for the same
+     symptom needs them verbatim.
+  2. Non-obvious correctness claims (invariants the reader can't
+     re-derive from the diff in 30 seconds).
+  3. Non-obvious failure modes (timing oracles, race windows,
+     fragile heuristics — same logic as the verbose-body
+     allowlist).
+  4. Rejected alternatives, when the rejection is itself the
+     contribution (audit-trail value).
+
+  **CUT** —
+
+  1. Diff-recap (renamed files, adjusted regexes, new gates — `git show` has them).
+  2. Narrative connectives that add no information ("Additionally,",
+     "It is worth noting that,", "As a follow-up,").
+  3. Success-path confirmations ("the tests pass", "behaviour at
+     the happy path is unchanged"). The CI rollup is the success-
+     path record; the commit body is for the cases where success
+     was *non-obvious*.
+  4. "Behaviour at X is unchanged" sentences in general — silence
+     is the default; an unchanged surface doesn't need a sentence.
+
+- **Bullets only for parallel sets of two-or-more identical-shape
+  items.** Tighter than the industry 3+ convention, deliberately:
+  parallel sets read clearer as bullets even at 2 items —
+  especially file enumerations where exhaustiveness is the point
+  ("the bridge writes to A and B"). Prose for a 2-item parallel
+  reads as a missed structural cue. The flip side is the failure
+  mode: bullets used for a *non-parallel* set turn into a "while
+  we're here" laundry list, which is the surface signal the PR is
+  bundling unrelated changes — see the 8859338 counter-example
+  below. Trigger phrases that should make the author stop and
+  consider splitting the PR before reaching for the bullet
+  character: "Side effects in the same PR:", "Also:", "while
+  we're here".
+
+- **Arrows (`->`) for mechanical sub-step chains; prose with
+  explicit connectives for the primary causal claim.** Arrows
+  compress mechanism: "query before POST -> no snapshot -> sticky
+  comment that won't refresh" is a three-hop chain the reader can
+  walk in one breath. Prose with "so" / "because" / "which" carries
+  the *primary* causal claim — the load-bearing sentence that
+  justifies the change. Mixing them inverts the cue: an arrow
+  chain in the lede reads as decorative, and a prose-walked
+  mechanism in a side-note reads as over-narrated. Pick one per
+  sentence.
+
+- **Backticks (and shouty markers) in body prose.** Backticks in
+  body prose carry visual weight; spend them only where the reader
+  would otherwise read the token as English. Self-identifying
+  tokens stay bare: filenames with extensions
+  (`pr-lint.yml`-style), dotted paths, underscored identifiers,
+  kebab-case identifiers in identifier-shaped contexts. Reword
+  ambiguous bare words ("case statement" not bare `case`).
+  Double-quote literals with spaces or that read as English ("no
+  changelog", "skipped"). **Shouty-cased markers strip wrapper
+  syntax**: write NO_CHANGELOG, not `==NO_CHANGELOG==`. The fenced
+  form is reserved for code blocks (where the marker really is
+  syntax); inside prose the wrapper renders as visual noise and
+  the all-caps token already carries the reader's eye.
+
+- **Worked counter-example —
+  [`8859338`](https://github.com/aidanns/agent-auth/commit/8859338)
+  (the workflow-naming + aggregator-flattening PR).** A useful
+  example of a *partial* failure mode: the opening two paragraphs
+  are well-shaped — they lead with the observable orthography tax
+  (three case conventions for the same artefact, coordinated
+  edits at every consumer) and the redundant aggregator tax
+  (intermediate `required-checks-passed` aggregators that
+  duplicated the workflow_call result GitHub already collapses).
+  Both paragraphs follow "lead with why" and "causal narrative
+  ordering" cleanly.
+
+  The third section ("Side effects in the same PR:" with seven
+  bullets) is the failure mode. Most bullets are diff-recap —
+  the `name:` stripping across non-matrix jobs, `merge-bot.yml`'s
+  `EXPECTED_WORKFLOWS` constant collapse, the doc rewrite of the
+  naming and aggregator sections of `tooling-and-ci.md`, the new
+  workflow-name canary in `verify-standards.sh`. Each is reachable
+  from `git show`. The seven-bullet list is also a "while we're
+  here" laundry list — the surface signal that the PR is bundling
+  several logical changes (naming standardisation, aggregator
+  flattening, helper-script rewrite, comment trim, ADR addition,
+  test golden-file update). The right fix is upstream of the
+  message: split the PR. Once split, each successor's body needs
+  no "Side effects" section — there are no side effects, just the
+  one change.
+
+  The keep-worthy form of 8859338 is the first two paragraphs
+  unchanged, the third section deleted, and the seven bundled
+  changes shipped as separate PRs. The "Coordinated branch-
+  protection rename" footer stays — it carries operational
+  hand-off value (orchestrator-owned action at merge time) that
+  isn't reachable from the diff.
 
 - **When a long body *is* warranted.** Three cases legitimately
   need more than three short paragraphs and explicitly do not trip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -962,7 +962,8 @@ A subset of the rules below is **CI-enforced**; the rest are
 
   **CUT** —
 
-  1. Diff-recap (renamed files, adjusted regexes, new gates — `git show` has them).
+  1. Diff-recap (renamed files, adjusted regexes, new gates —
+     `git show` has them).
   2. Narrative connectives that add no information ("Additionally,",
      "It is worth noting that,", "As a follow-up,").
   3. Success-path confirmations ("the tests pass", "behaviour at

--- a/plans/contributing-md-commit-rationale.md
+++ b/plans/contributing-md-commit-rationale.md
@@ -1,0 +1,148 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# Plan — CONTRIBUTING.md commit-message rule rationale (issue #562)
+
+## Context and scope
+
+Parent meta-tracker #560 splits the new commit-message rules across two
+slices:
+
+- #561 codifies the terse, machine-applied rules in
+  `.claude/instructions/commit-messages.md` so every Claude session
+  loads them automatically.
+- This slice (#562) extends `CONTRIBUTING.md` "Writing release-worthy
+  commits" with the human-facing rationale (rule + WHY + anti-pattern)
+  plus a second worked counter-example. The expanded prose is what a
+  reviewer cites when pushing back on a multi-purpose PR.
+
+The two PRs may merge in either order; a brief broken-link window is
+acceptable while #561 lands.
+
+## What changes
+
+### Five new subsections in `CONTRIBUTING.md` "Writing release-worthy commits"
+
+1. **Causal narrative ordering** — lead with the observable behaviour
+   the reader could have seen; fold setup into the mechanism, not
+   before. Anti-pattern: opening with "X and Y share Z" before the
+   reader knows why Z matters.
+2. **Brevity** — KEEP / CUT lists. KEEP exact error strings
+   (greppable), non-obvious correctness claims, non-obvious failure
+   modes, rejected alternatives. CUT diff-recap, narrative
+   connectives, success-path confirmations, "behaviour at X is
+   unchanged" sentences.
+3. **Shouty-marker rule** — folded into the existing backticks
+   discussion. `==NO_CHANGELOG==` renders in prose as NO_CHANGELOG;
+   the fenced form is reserved for code blocks, not prose, so the
+   marker name reads cleanly inside a sentence.
+4. **Bullet threshold** — bullets only for parallel sets of 2+
+   identical-shape items (tighter than the industry 3+ convention).
+   Rationale: parallel sets read clearer as bullets even at 2 items —
+   especially file enumerations where exhaustiveness is the point —
+   and prose for 2-item parallels reads as a missed structural cue.
+5. **Arrows vs prose** — arrows (`->`) for mechanical sub-step chains
+   ("query before POST -> no snapshot -> sticky comment"); prose with
+   explicit connectives ("so", "because", "which") for the primary
+   causal claim. Mixing them inverts the cue.
+
+Each subsection: terse rule + WHY + anti-pattern + (where short) one
+example. The TLDR rule lives in `.claude/instructions/commit-messages.md`;
+CONTRIBUTING.md is what reviewers cite.
+
+### Second worked counter-example: commit `8859338`
+
+Add alongside (NOT replacing) the existing `7ab4c6a` "Don't restate
+the diff" example. The shape mirrors the existing one so reviewers
+read both at the same level of abstraction.
+
+The 8859338 message is a useful failure mode to dissect because the
+opening two paragraphs are well-shaped — they lead with the
+observable orthography tax and the redundant aggregator tax. The
+failure mode lives in the third section ("Side effects in the same
+PR:") with seven bullets, most of which are diff-recap (the `name:`
+stripping, `merge-bot.yml`'s `EXPECTED_WORKFLOWS` update, the doc
+rewrite, the standards canary).
+
+The right fix is upstream: the bulleted "while we're here" list
+signals the PR is bundling several logical changes. The counter-
+example calls out both the bundling smell and the bullet-as-recap
+smell.
+
+### Cross-references
+
+- One-line forward link from `CONTRIBUTING.md` to
+  `.claude/instructions/commit-messages.md` for the terse rule list,
+  placed near the top of "Writing release-worthy commits" so a
+  reviewer who only wants the rule list (not the rationale) reaches
+  it in one hop.
+- Preserve every existing reference to
+  [ADR 0037](design/decisions/0037-palantir-commit-prefixes-and-commit-msg-block.md).
+  The new prose explicitly sits *alongside* ADR 0037 — ADR 0037 owns
+  the prefix allowlist and `==COMMIT_MSG==` block structure; this
+  section owns the prose inside.
+- The reverse link from `.claude/instructions/commit-messages.md`
+  back to `CONTRIBUTING.md` lands in #561.
+
+## Out of scope
+
+- Changes to the terse rule file (`.claude/instructions/commit-messages.md`)
+  — that's #561.
+- Changes to ADR 0037 itself — the rationale section sits alongside
+  it, not inside it.
+- Changes to the CI-enforcement table — the new rules are
+  convention-only (caught at human review).
+- Re-shooting the existing `7ab4c6a` example — it stays, the new
+  one is added alongside.
+
+## Design and verification
+
+- **Verify implementation against design doc** — N/A. This is a
+  documentation-only change to `CONTRIBUTING.md`; no schema or
+  behaviour to diff.
+- **Threat model** — N/A. No security-relevant surface changes.
+- **Post-incident review (PIR)** — N/A. Not remediating a
+  vulnerability.
+- **Architecture Decision Records** — N/A. The structural decision
+  (prefix allowlist + `==COMMIT_MSG==` block) is already captured in
+  ADR 0037; the prose rules sit alongside it as expanded human
+  guidance, not a new architectural choice.
+- **Cybersecurity standard compliance** — N/A.
+- **QM / SIL compliance** — N/A.
+
+## Post-implementation standards review
+
+- **`coding-standards.md`** — N/A. No code changes.
+- **`service-design.md`** — N/A. No service surface changes.
+- **`release-and-hygiene.md`** — verify that `CONTRIBUTING.md` still
+  parses and renders sensibly under `mdformat` (treefmt) and that
+  the lefthook pre-commit pipeline accepts the diff. The file is
+  required by the project standards and remains intact.
+- **`testing-standards.md`** — N/A. No tests touched.
+- **`tooling-and-ci.md`** — N/A. No CI surface changes; the new
+  prose rules are convention-only and the CI-enforcement table in
+  CONTRIBUTING.md is left as-is.
+
+## Pipeline
+
+1. Branch from latest `main` (already on `aidanns/contributing-md-commit-rationale`).
+2. Edit `CONTRIBUTING.md` "Writing release-worthy commits":
+   - Insert the cross-reference to
+     `.claude/instructions/commit-messages.md` early in the section.
+   - Add the five new rule subsections in the natural reading order
+     (Subject section first if the rule is title-shaped; Body
+     section if it's body-shaped). Causal ordering, brevity, bullet
+     threshold, arrows-vs-prose go under the body rules; the
+     shouty-marker rule goes wherever the existing backticks
+     discussion lives — read the file to decide.
+   - Append the 8859338 worked counter-example after the existing
+     `7ab4c6a` one (same heading shape).
+3. Self-review the diff against the rules being introduced (no
+   diff-recap in the new prose, lead with observable behaviour).
+4. Commit with `git commit -s`, push, open PR with
+   `--label "no changelog"` (chore — not user-visible).
+5. Self-review pass on `git diff main...HEAD`, emit
+   `READY_FOR_REVIEW` heartbeat, await orchestrator dispatch.


### PR DESCRIPTION
## Review notes

Documentation-only change to CONTRIBUTING.md "Writing release-worthy commits" — extends it with the rationale layer for the new commit-message rules being codified for Claude in #561.

### Test plan

- [ ] CONTRIBUTING.md renders cleanly on GitHub (the table reflows after mdformat re-aligned column widths to fit the new convention-row).
- [ ] All five existing ADR 0037 references still resolve to design/decisions/0037-palantir-commit-prefixes-and-commit-msg-block.md.
- [ ] The 7ab4c6a counter-example is preserved verbatim (not replaced by the new 8859338 one).
- [ ] The new cross-link points at `.claude/instructions/commit-messages.md` (created by the parallel #561; brief broken-link window is acceptable per the issue).
- [ ] `scripts/format.sh --check` passes.
- [ ] `scripts/lint.sh` passes.

### Notes for the reviewer

- New subsections sit under the existing Body rules between "Don't restate the diff" (which keeps its 7ab4c6a counter-example) and "When a long body *is* warranted" (which keeps its three-cases list). Reading order is: lead-with-why -> don't-restate-the-diff -> causal-narrative-ordering -> brevity -> bullets -> arrows -> backticks-and-shouty-markers -> 8859338 counter-example -> when-a-long-body-is-warranted.
- The 8859338 example is its own subsection (not folded into one of the new rule bullets) because it demonstrates a different failure mode from 7ab4c6a — bundling and bullet-as-recap, where 7ab4c6a was straight diff-recap. Same structural shape (linked SHA, quoted issue, the keep-worthy form spelled out) so reviewers read both at the same level of abstraction.
- The CI-vs-convention table gets one new row for the five rules collectively; mdformat re-aligned the existing rows to match the new widest row.

==COMMIT_MSG==
The terse, machine-applied rules in
`.claude/instructions/commit-messages.md` (issue #561) tell Claude
what to do; reviewers pushing back on a draft need the WHY and an
anti-pattern they can point at. Extend CONTRIBUTING.md with five
rationale subsections (causal narrative ordering, brevity KEEP /
CUT, bullets-only-for-2+-parallel-sets, arrows-vs-prose, shouty-
marker rendering) and a second worked counter-example built on
commit 8859338, which fails on bundling rather than diff-recap.

The 8859338 example sits alongside the existing 7ab4c6a one —
together they cover the two distinct failure modes the new rules
target. The cross-link from CONTRIBUTING.md to
commit-messages.md lets a reviewer reach the terse rule list in
one hop without re-reading the rationale.

Closes: #562
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==