### PR TITLE
chore(claude): require Closes: + Co-Authored-By trailers

### DIFF
--- a/.claude/instructions/commit-messages.md
+++ b/.claude/instructions/commit-messages.md
@@ -79,20 +79,21 @@ CONTRIBUTING.md and ADR 0037; this file covers the prose inside.
 
 ## Trailers
 
-When Claude authors the PR, the `==COMMIT_MSG==` block must include,
-in this order, immediately above `Signed-off-by:`:
+When Claude authors the PR, the COMMIT_MSG block must include, in
+this order, immediately above the Signed-off-by: trailer:
 
-- `Closes: #N` linking the issue. Use the canonical colon form —
-  never the bare `Closes #N`. The merge bot also accepts the
-  colon-less form, but the canonical form keeps the trailer block
-  uniform and survives the validator tightening tracked separately
-  from this rule.
-- `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`,
+- A Closes: trailer linking the issue, in the canonical colon form
+  `Closes: #N`. Never the bare `Closes #N`. The merge bot accepts
+  the colon-less form too, but the canonical form keeps the trailer
+  block uniform and survives the validator tightening tracked
+  separately from this rule.
+- A Co-Authored-By: trailer in the form
+  `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`,
   with the model+context string set to whatever the authoring agent
-  is actually running as. The literal `noreply@anthropic.com` email
+  is actually running as. The literal noreply@anthropic.com email
   renders the Claude icon next to the co-author chip on GitHub.
 
-The two trailers stack contiguously with `Signed-off-by:` — no blank
+The two trailers stack contiguously with Signed-off-by: — no blank
 lines between them — or `git interpret-trailers --parse` drops them
 out of the trailer set and the merge bot loses the issue link and
 the co-author attribution.

--- a/.claude/instructions/commit-messages.md
+++ b/.claude/instructions/commit-messages.md
@@ -77,6 +77,26 @@ CONTRIBUTING.md and ADR 0037; this file covers the prose inside.
   rather than a mechanical one. Arrows hide the reasoning; prose
   exposes it.
 
+## Trailers
+
+When Claude authors the PR, the `==COMMIT_MSG==` block must include,
+in this order, immediately above `Signed-off-by:`:
+
+- `Closes: #N` linking the issue. Use the canonical colon form —
+  never the bare `Closes #N`. The merge bot also accepts the
+  colon-less form, but the canonical form keeps the trailer block
+  uniform and survives the validator tightening tracked separately
+  from this rule.
+- `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`,
+  with the model+context string set to whatever the authoring agent
+  is actually running as. The literal `noreply@anthropic.com` email
+  renders the Claude icon next to the co-author chip on GitHub.
+
+The two trailers stack contiguously with `Signed-off-by:` — no blank
+lines between them — or `git interpret-trailers --parse` drops them
+out of the trailer set and the merge bot loses the issue link and
+the co-author attribution.
+
 ______________________________________________________________________
 
 See CONTRIBUTING.md -> "Writing release-worthy commits" for the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1158,6 +1158,13 @@ lost on `main` unless the trailer rides into the squash body via this
 block. Position: between `Closes:` and `Signed-off-by:` inside the
 contiguous trailer block.
 
+The session-loaded form of this rule (paired with the canonical
+`Closes:` colon form so they're stated together where every Claude
+session reads them) lives in
+[`.claude/instructions/commit-messages.md`](.claude/instructions/commit-messages.md)
+under "Trailers". Cite that section when pushing back on a draft
+that omits either trailer.
+
 Format:
 
 ```


### PR DESCRIPTION
==COMMIT_MSG==
Two recent on-main commits (e06245a, 46c6fe4) landed without a
Co-Authored-By: Claude trailer, and one used the bare Closes #561
form instead of the canonical Closes: #561. The merge bot pasted
the PR ==COMMIT_MSG== blocks verbatim, so both omissions originated
in the agent that authored the PRs.

The Bash tool's "Committing changes with git" guidance auto-appends
Co-Authored-By: Claude to direct git commit invocations, but the
PR ==COMMIT_MSG== block is hand-authored from a template on a
separate path. CONTRIBUTING.md described the trailer format and
flagged Closes: as canonical, but neither .claude/instructions/
commit-messages.md (#561) nor the PR template stated either as a
hard requirement, so no session-startup-loaded rule existed and
agents drifted.

Add a Trailers section to commit-messages.md that names both rules
together with the exact identity string. The instruction file is
loaded into every Claude session, so it sits strictly upstream of
the validator and the PR template. Cross-link from CONTRIBUTING.md
"Claude attribution trailer" so a reviewer pushing back on a draft
that omits either trailer has a single anchor to cite.

Validator tightening (rejecting the bare Closes #N form so the
canonical form is mechanically enforced) is tracked separately.

Closes: #565
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

Pure docs change — no behaviour or schema change. The validator and
PR template are intentionally untouched (validator tightening
tracked as separate work).

### Test plan

- [ ] CI green (pr-title, pr-body-commit-msg, dco, changelog-lint)
- [ ] "Trailers" section renders cleanly in
      .claude/instructions/commit-messages.md
- [ ] CONTRIBUTING.md cross-link resolves to the new section