### PR TITLE
feature: merge-bot @-mention `update` command

### DIFF
--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -54,6 +54,17 @@ name: merge-bot
 #   - workflow_dispatch — maintainer break-glass against a specific
 #     PR number. Also the sweep job's fan-out target — see the
 #     `push:main` trigger above.
+#   - issue_comment: created — comment-driven dispatch surface for
+#     `@agent-auth-merge-bot <verb>` mentions on PRs (issue #504).
+#     Today's only verb is `update` (call `update-branch` without a
+#     merge attempt). The cheap pre-filter on the new `command` job
+#     rejects non-PR comments, comments without the `@-mention`
+#     prefix, and Bot-authored comments before any runner starts.
+#     The `command` job is otherwise self-contained: it does not
+#     interact with the `merge` / `label-needs-fix` / `sweep` jobs
+#     above. Verb dispatch is a small `case` table so follow-up
+#     verbs (`merge`, `cancel`, `rebase`, …) can be added without
+#     revisiting the trigger plumbing.
 #
 # The bot authors no commits — it only calls `PUT /pulls/{n}/merge`.
 # The squash commit's `commit_title` is `<PR title> (#<n>)` and the
@@ -148,6 +159,16 @@ on:
         description: PR number to merge (break-glass)
         required: true
         type: number
+  # Comment-command dispatch surface (issue #504). The `command` job
+  # below scopes itself to PR comments via
+  # `event.issue.pull_request != null`, to the `@agent-auth-merge-bot `
+  # prefix, and to non-Bot authors — so a `created` event on an
+  # ordinary issue comment, or a PR comment without the prefix, is
+  # rejected by the `if:` predicate before any runner starts. Only
+  # `created` is wired (not `edited`) so a contributor cannot smuggle
+  # a command into an old comment by editing it after-the-fact.
+  issue_comment:
+    types: [created]
 
 # `pull-requests: write` is needed by the `label-needs-fix` job
 # to apply / remove the `needs fix` label, and (via the App token)
@@ -1343,3 +1364,438 @@ jobs:
               --ref main \
               -f pr_number="${pr}"
           done
+
+  # `@-mention` comment-command dispatch (issue #504). A contributor
+  # (or any user with `write` permission on the repo) posts
+  # `@agent-auth-merge-bot <verb>` on a PR comment; this job
+  # acknowledges with a 👀 reaction, runs the verb, and reacts 👍 on
+  # success or 👎 on rejection. A follow-up `Claude: Cannot ...` PR
+  # comment is posted only on structured failures (unknown verb,
+  # `update-branch` API error other than `expected_head_sha`); the
+  # bare reaction lifecycle covers the success / wrong-permission
+  # paths.
+  #
+  # Today's only verb is `update`: poll `mergeStateStatus` to confirm
+  # the PR is BEHIND, then call `PUT /pulls/{n}/update-branch` with
+  # `expected_head_sha` pinned. Same shape as the `merge` job's
+  # `Detect BEHIND and auto-update branch` step, but in isolation —
+  # no merge attempt follows. The verb-dispatch table is a `case`
+  # statement so follow-up verbs (`merge`, `cancel`, `rebase`, …)
+  # can be added by appending a new arm without revisiting the
+  # trigger plumbing or the authorization gate.
+  #
+  # Authorization: `GET /repos/.../collaborators/{user}/permission`
+  # must return `admin / maintain / write`; anything below reacts 👎
+  # only and exits with a `::notice::` log line. The collaborator-
+  # permission endpoint on a user-owned repo is covered by the App's
+  # existing `Metadata: Read-only` grant; no new App permission
+  # needed (see docs/release/merge-bot-setup.md Step 1).
+  #
+  # Self-mention guard: two layers, defence-in-depth. The job-level
+  # `if:` rejects `event.comment.user.type == 'Bot'` so any future
+  # command-output comment that mentions the bot cannot loop, and an
+  # explicit login check inside the job rejects the bot's own login
+  # (`agent-auth-merge-bot[bot]`) for the unlikely case that GitHub
+  # changes the `user.type` value for App-authored comments.
+  #
+  # Future port to the hosted webhook handler (#428): the verb-
+  # dispatch shape, authorization model, and reaction protocol all
+  # port unchanged — only the trigger plumbing
+  # (`on: issue_comment` → HTTP webhook) is replaced.
+  command:
+    runs-on: ubuntu-latest
+    # Cheap pre-filter so we don't burn a runner on every issue-
+    # comment event. `event.issue.pull_request != null` rejects
+    # comments on non-PR issues; `startsWith` rejects unrelated PR
+    # comments without an API call; `user.type != 'Bot'` is the
+    # self-mention guard at the trigger level. The trailing space in
+    # the prefix string is intentional — it forces the verb to be a
+    # separate token (`@agent-auth-merge-bot update` matches;
+    # `@agent-auth-merge-bot-extension update` does not).
+    if: |
+      github.event_name == 'issue_comment'
+      && github.event.action == 'created'
+      && github.event.issue.pull_request != null
+      && startsWith(github.event.comment.body, '@agent-auth-merge-bot ')
+      && github.event.comment.user.type != 'Bot'
+    # Per-comment concurrency so two near-simultaneous comments on
+    # different PRs run in parallel. `cancel-in-progress: false`
+    # because cancelling a mid-`update-branch` call would leave the
+    # user without a 👍 / 👎 reaction (and the `expected_head_sha`
+    # pin on the API call already protects against the only race
+    # that matters — a new push during the update).
+    concurrency:
+      group: merge-bot-command-${{ github.event.comment.id }}
+      cancel-in-progress: false
+    steps:
+      # Same secrets-check shape as the `merge` and `label-needs-fix`
+      # jobs above — first-time setup / partial-config detection.
+      # The full rationale lives in the `merge` job's comment block;
+      # not duplicated here. Three call-sites of this pair now live
+      # in this file; a future cleanup PR can factor them into a
+      # `mint-merge-bot-app-token` composite action once the third
+      # call-site has merged on `main` (deferring the factor-out
+      # avoids the self-modifying-merge-bot-PR risk on this PR).
+      - name: Check secrets are configured
+        id: secrets-check
+        env:
+          APP_ID: ${{ secrets.MERGE_BOT_APP_ID }}
+          PRIVATE_KEY: ${{ secrets.MERGE_BOT_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APP_ID:-}" && -z "${PRIVATE_KEY:-}" ]]; then
+            echo "::notice::MERGE_BOT_APP_ID / MERGE_BOT_PRIVATE_KEY secrets are not set; skipping merge-bot command run."
+            echo "::notice::See docs/release/merge-bot-setup.md for setup instructions."
+            echo "configured=false" >> "${GITHUB_OUTPUT}"
+          elif [[ -n "${APP_ID:-}" && -n "${PRIVATE_KEY:-}" ]]; then
+            echo "configured=true" >> "${GITHUB_OUTPUT}"
+          else
+            if [[ -z "${APP_ID:-}" ]]; then
+              missing="MERGE_BOT_APP_ID"
+            else
+              missing="MERGE_BOT_PRIVATE_KEY"
+            fi
+            echo "::error::${missing} secret is not set but the other merge-bot secret is; this is a partial / broken configuration."
+            echo "::error::See docs/release/merge-bot-setup.md for setup instructions."
+            echo "configured=false" >> "${GITHUB_OUTPUT}"
+            exit 1
+          fi
+
+      - name: Mint merge-bot App token
+        id: app-token
+        if: steps.secrets-check.outputs.configured == 'true'
+        # Pinned by SHA per .claude/instructions/tooling-and-ci.md —
+        # same pin policy as the `merge` and `label-needs-fix` jobs.
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ secrets.MERGE_BOT_APP_ID }}
+          private-key: ${{ secrets.MERGE_BOT_PRIVATE_KEY }}
+
+      # Defence-in-depth self-mention guard. The job-level `if:`
+      # rejects `user.type == 'Bot'` already, but we re-check the
+      # commenter's login against the App's bot login here so a
+      # future GitHub schema change that puts the App's comments on
+      # a different `user.type` value cannot trigger an output-loop.
+      # The `[bot]` suffix is appended automatically by GitHub for
+      # App-authored comments.
+      - name: Reject self-mention (defence in depth)
+        if: |
+          steps.secrets-check.outputs.configured == 'true'
+          && github.event.comment.user.login == 'agent-auth-merge-bot[bot]'
+        env:
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          echo "merge-bot command: ignoring comment by ${ACTOR} (App's own login); exiting cleanly."
+          exit 0
+
+      # Parse the verb (and any args) out of the comment body. The
+      # body is bound through `env:` rather than inlined via `${{ }}`
+      # so backticks / `$(...)` / shell metacharacters in the body
+      # cannot be evaluated — the same defensive shape every other
+      # `run:` block in this file uses for tainted inputs. This is
+      # critical here because the comment body is a fully-external
+      # input (any contributor can author one).
+      #
+      # The parser is simple by design: take the first line, strip
+      # the `@agent-auth-merge-bot ` prefix, and take the first
+      # whitespace-delimited token as the verb. Anything past the
+      # verb is captured into ARGS for future multi-arg verbs, but
+      # the only verb shipped today (`update`) ignores it.
+      - name: Parse comment for verb
+        id: parse
+        if: |
+          steps.secrets-check.outputs.configured == 'true'
+          && github.event.comment.user.login != 'agent-auth-merge-bot[bot]'
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          # First line only — multi-line bodies are accepted but the
+          # command itself must sit on the first line so a follow-on
+          # paragraph (e.g. context for human readers) cannot
+          # accidentally introduce a second verb.
+          first_line="$(printf '%s' "${COMMENT_BODY}" | head -n 1)"
+          # Strip the `@agent-auth-merge-bot ` prefix the `if:`
+          # already verified is present. Use parameter expansion
+          # rather than `sed` — no regex, no shell-meta surface.
+          rest="${first_line#@agent-auth-merge-bot }"
+          # Verb = first whitespace-delimited token. `awk '{print $1}'`
+          # handles both space and tab separators uniformly. Lower-
+          # cased so `Update` / `UPDATE` map to `update` (humans
+          # capitalise inconsistently; the dispatch table is the
+          # source of truth for the canonical form).
+          verb="$(printf '%s\n' "${rest}" | awk '{print tolower($1)}')"
+          # Args = everything past the verb, preserved as-is for
+          # future multi-arg verbs. Today's `update` ignores it.
+          args="$(printf '%s\n' "${rest}" | awk '{$1=""; sub(/^ +/, ""); print}')"
+          echo "verb=${verb}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "args<<MERGE_BOT_COMMAND_EOF"
+            echo "${args}"
+            echo "MERGE_BOT_COMMAND_EOF"
+          } >> "${GITHUB_OUTPUT}"
+          echo "merge-bot command: parsed verb=${verb} args=${args}"
+
+      # Authorization gate. `GET /repos/.../collaborators/{user}/permission`
+      # returns one of `admin / maintain / write / triage / read /
+      # none`; we accept the top three (the same gating GitHub's own
+      # UI uses for write-tier actions). Anything below reacts 👎 and
+      # exits with a `::notice::` line — no follow-up PR comment
+      # (would invite drive-by command spam, since unauthorized
+      # users by definition aren't trusted to make signal-from-noise
+      # judgements about their own attempts).
+      #
+      # The collaborator-permission endpoint on a user-owned repo
+      # is covered by the App's existing `Metadata: Read-only` grant
+      # — no new permission needed.
+      - name: Authorize commenter
+        id: authz
+        if: |
+          steps.secrets-check.outputs.configured == 'true'
+          && github.event.comment.user.login != 'agent-auth-merge-bot[bot]'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          permission="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/collaborators/${ACTOR}/permission" \
+            --jq '.permission' \
+            2>/dev/null || echo "")"
+          case "${permission}" in
+            admin|maintain|write)
+              echo "merge-bot command: ${ACTOR} has '${permission}' permission; authorized."
+              echo "authorized=true" >> "${GITHUB_OUTPUT}"
+              ;;
+            *)
+              echo "::notice::merge-bot command: ${ACTOR} has permission='${permission:-<none>}'; rejecting."
+              echo "authorized=false" >> "${GITHUB_OUTPUT}"
+              ;;
+          esac
+
+      # Authorization-failed path: 👎 reaction only, no PR comment.
+      # Best-effort — a failed reaction post emits a `::warning::`
+      # and the workflow exits 0 anyway (the rejection has already
+      # been recorded in the `::notice::` line above).
+      - name: React 👎 (unauthorized)
+        if: |
+          steps.secrets-check.outputs.configured == 'true'
+          && github.event.comment.user.login != 'agent-auth-merge-bot[bot]'
+          && steps.authz.outputs.authorized == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          set -euo pipefail
+          if ! gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content="-1" \
+            > /dev/null 2> "${RUNNER_TEMP}/react.err"; then
+            err="$(cat "${RUNNER_TEMP}/react.err")"
+            echo "::warning::Failed to post 👎 reaction on comment ${COMMENT_ID}: ${err}"
+          fi
+
+      # Stop here on unauthorized — don't run the verb. Exits 0 so
+      # the workflow run is green (rejection is a normal outcome,
+      # not a failure of the bot).
+      - name: Exit on unauthorized
+        if: |
+          steps.secrets-check.outputs.configured == 'true'
+          && github.event.comment.user.login != 'agent-auth-merge-bot[bot]'
+          && steps.authz.outputs.authorized == 'false'
+        run: exit 0
+
+      # 👀 reaction — acknowledges the request before the API work
+      # starts. Only fires after the authorization gate passes so
+      # the timeline distinguishes "rejected because you can't run
+      # it" (👎 only) from "attempted-and-failed" (👀 then 👎).
+      # Best-effort like the other reaction calls.
+      - name: React 👀 (acknowledged)
+        if: |
+          steps.secrets-check.outputs.configured == 'true'
+          && github.event.comment.user.login != 'agent-auth-merge-bot[bot]'
+          && steps.authz.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          set -euo pipefail
+          if ! gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content="eyes" \
+            > /dev/null 2> "${RUNNER_TEMP}/react.err"; then
+            err="$(cat "${RUNNER_TEMP}/react.err")"
+            echo "::warning::Failed to post 👀 reaction on comment ${COMMENT_ID}: ${err}"
+          fi
+
+      # Verb dispatch. Today's only verb is `update`. The `case`
+      # table is the dispatch surface — adding a new verb is a new
+      # arm here plus its own helper step(s) above; the trigger,
+      # authorization, and reaction lifecycle don't need revisiting.
+      #
+      # Each arm sets two outputs:
+      #   - `outcome` = success | failure (drives the final 👍 / 👎)
+      #   - `message` = optional follow-up `Claude: ...` PR comment
+      #     body. Empty string means "no follow-up comment".
+      - name: Dispatch verb
+        id: dispatch
+        if: |
+          steps.secrets-check.outputs.configured == 'true'
+          && github.event.comment.user.login != 'agent-auth-merge-bot[bot]'
+          && steps.authz.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          VERB: ${{ steps.parse.outputs.verb }}
+        run: |
+          set -euo pipefail
+          outcome="failure"
+          message=""
+          case "${VERB}" in
+            update)
+              # Re-fetch mergeStateStatus + headRefOid so the BEHIND
+              # decision is based on current state, not on whatever
+              # the issue_comment payload would have carried.
+              # mergeStateStatus may come back UNKNOWN while GitHub
+              # is still computing it; poll for ~30s before giving
+              # up. Same shape as the `merge` job's
+              # `Detect BEHIND and auto-update branch` step.
+              merge_state=""
+              head_sha=""
+              for attempt in 1 2 3 4 5 6 7 8 9 10; do
+                state_payload="$(gh pr view "${PR_NUMBER}" \
+                  --repo "${GITHUB_REPOSITORY}" \
+                  --json mergeStateStatus,headRefOid)"
+                merge_state="$(jq -r '.mergeStateStatus' <<<"${state_payload}")"
+                head_sha="$(jq -r '.headRefOid' <<<"${state_payload}")"
+                if [[ "${merge_state}" != "UNKNOWN" ]]; then
+                  break
+                fi
+                echo "merge-bot command: mergeStateStatus=UNKNOWN on attempt ${attempt}; sleeping 3s before retry."
+                sleep 3
+              done
+              if [[ "${merge_state}" == "UNKNOWN" ]]; then
+                # State never resolved — surface as a structured
+                # failure so the user knows to retry. Distinct from
+                # the merge-job behaviour (which exits cleanly and
+                # waits for `workflow_run.completed` to retrigger);
+                # there is no equivalent retrigger for an
+                # `issue_comment`-driven run, so the user has to
+                # ask again.
+                message="Claude: Cannot update — \`mergeStateStatus\` stayed UNKNOWN after polling. Re-post \`@agent-auth-merge-bot update\` to retry."
+                outcome="failure"
+              elif [[ "${merge_state}" != "BEHIND" ]]; then
+                # Idempotent no-op per the issue-acceptance contract:
+                # "if the PR is already up to date with main, no-op
+                # cleanly". 👍 with no follow-up comment.
+                echo "merge-bot command: PR #${PR_NUMBER} mergeStateStatus=${merge_state}; not BEHIND, nothing to do."
+                outcome="success"
+              else
+                # Pin `expected_head_sha` so a contributor push that
+                # races us produces a documented 422 rather than us
+                # silently fast-forwarding past their commit. Treat
+                # 422 as a 👍 success — the contributor's push is the
+                # new head and the user gets the same end state
+                # (update happened, just not by our hand).
+                if gh api --method PUT \
+                  "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/update-branch" \
+                  -f expected_head_sha="${head_sha}" \
+                  > "${RUNNER_TEMP}/update.out" 2> "${RUNNER_TEMP}/update.err"; then
+                  echo "merge-bot command: branch updated for PR #${PR_NUMBER}."
+                  outcome="success"
+                else
+                  err="$(cat "${RUNNER_TEMP}/update.err")"
+                  if grep -qi "expected_head_sha" <<<"${err}"; then
+                    echo "::notice::merge-bot command: PR #${PR_NUMBER} head SHA advanced under us (contributor push); treating as success."
+                    outcome="success"
+                  else
+                    echo "::error::PR #${PR_NUMBER}: update-branch API call failed: ${err}"
+                    # Quote the API error inside backticks so the
+                    # rendered comment treats it as code, not Markdown.
+                    message="Claude: Cannot update — \`update-branch\` API call failed: \`${err}\`"
+                    outcome="failure"
+                  fi
+                fi
+              fi
+              ;;
+            *)
+              # Unknown verb. The known-verbs list here must be kept
+              # in sync with the `case` arms above; today there is
+              # only one.
+              echo "::notice::merge-bot command: PR #${PR_NUMBER} unknown verb '${VERB}'."
+              message="Claude: Unknown verb \`${VERB}\`. Known verbs: \`update\`."
+              outcome="failure"
+              ;;
+          esac
+          echo "outcome=${outcome}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "message<<MERGE_BOT_COMMAND_EOF"
+            echo "${message}"
+            echo "MERGE_BOT_COMMAND_EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      # Final 👍 / 👎 reaction. Best-effort like the other reaction
+      # calls — a failed reaction post emits a `::warning::` and the
+      # workflow continues to the structured-failure-comment step.
+      - name: React with outcome
+        if: |
+          steps.secrets-check.outputs.configured == 'true'
+          && github.event.comment.user.login != 'agent-auth-merge-bot[bot]'
+          && steps.authz.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          OUTCOME: ${{ steps.dispatch.outputs.outcome }}
+        run: |
+          set -euo pipefail
+          if [[ "${OUTCOME}" == "success" ]]; then
+            content="+1"
+          else
+            content="-1"
+          fi
+          if ! gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content="${content}" \
+            > /dev/null 2> "${RUNNER_TEMP}/react.err"; then
+            err="$(cat "${RUNNER_TEMP}/react.err")"
+            echo "::warning::Failed to post ${content} reaction on comment ${COMMENT_ID}: ${err}"
+          fi
+
+      # Structured-failure follow-up comment. Posted only when the
+      # dispatch step set a non-empty `message` — i.e. unknown verb
+      # or `update-branch` API error. Authorization rejections do
+      # NOT pass through here (`outcome` is never reached on the
+      # unauthorized branch); that is intentional, see the
+      # "React 👎 (unauthorized)" step's comment.
+      - name: Post structured-failure comment
+        if: |
+          steps.secrets-check.outputs.configured == 'true'
+          && github.event.comment.user.login != 'agent-auth-merge-bot[bot]'
+          && steps.authz.outputs.authorized == 'true'
+          && steps.dispatch.outputs.message != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          MESSAGE: ${{ steps.dispatch.outputs.message }}
+        run: |
+          set -euo pipefail
+          if ! gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            -f body="${MESSAGE}" \
+            > /dev/null 2> "${RUNNER_TEMP}/comment.err"; then
+            err="$(cat "${RUNNER_TEMP}/comment.err")"
+            echo "::warning::Failed to post structured-failure comment on PR #${PR_NUMBER}: ${err}"
+          fi
+
+      # Mirror the dispatch outcome into the workflow run's exit
+      # status so a failed verb produces a red Actions run for
+      # operator visibility (the reaction surface is for the
+      # commenter; this is for the maintainer scanning Actions).
+      # Authorization-rejected runs already exited 0 above.
+      - name: Mirror dispatch outcome
+        if: |
+          steps.secrets-check.outputs.configured == 'true'
+          && github.event.comment.user.login != 'agent-auth-merge-bot[bot]'
+          && steps.authz.outputs.authorized == 'true'
+          && steps.dispatch.outputs.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -1436,6 +1436,7 @@ jobs:
       # `mint-merge-bot-app-token` composite action once the third
       # call-site has merged on `main` (deferring the factor-out
       # avoids the self-modifying-merge-bot-PR risk on this PR).
+      # See #584.
       - name: Check secrets are configured
         id: secrets-check
         env:

--- a/changelog/@unreleased/pr-583-bot-c50cedb6.yml
+++ b/changelog/@unreleased/pr-583-bot-c50cedb6.yml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+type: feature
+feature:
+  description: |
+    `merge-bot` now responds to `@agent-auth-merge-bot <verb>` PR
+    comments. Today's only verb is `update`, which calls
+    `PUT /pulls/{n}/update-branch` (no merge attempt) so a contributor
+    can refresh a stuck `BEHIND` branch without applying `automerge`
+    or waiting for the sweep cron. Authorization gates the verb to
+    `admin / maintain / write` collaborators; the bot acknowledges
+    with reactions (eyes -> thumbs-up / thumbs-down) and only
+    posts a follow-up `Claude: Cannot ...` comment on structured
+    failures.
+  links:
+    - https://github.com/aidanns/agent-auth/pull/583

--- a/changelog/@unreleased/pr-583-bot-c50cedb6.yml
+++ b/changelog/@unreleased/pr-583-bot-c50cedb6.yml
@@ -5,14 +5,8 @@
 type: feature
 feature:
   description: |
-    `merge-bot` now responds to `@agent-auth-merge-bot <verb>` PR
-    comments. Today's only verb is `update`, which calls
-    `PUT /pulls/{n}/update-branch` (no merge attempt) so a contributor
-    can refresh a stuck `BEHIND` branch without applying `automerge`
-    or waiting for the sweep cron. Authorization gates the verb to
-    `admin / maintain / write` collaborators; the bot acknowledges
-    with reactions (eyes -> thumbs-up / thumbs-down) and only
-    posts a follow-up `Claude: Cannot ...` comment on structured
-    failures.
+    `merge-bot` now responds to `@agent-auth-merge-bot update` PR
+    comments by calling `update-branch` on the PR, with no merge
+    attempt.
   links:
     - https://github.com/aidanns/agent-auth/pull/583

--- a/plans/merge-bot-mention-commands.md
+++ b/plans/merge-bot-mention-commands.md
@@ -199,7 +199,7 @@ self-modifying-merge-bot-PR risk (per the auto-memory note,
 needs to be exact for the merge-bot run that lands this PR not to
 crater on a missing composite action). A future cleanup PR can
 factor the three call-sites once the third one has merged on `main`
-and the duplication is observable.
+and the duplication is observable; tracked as #584.
 
 The new `command` job DOES need its own `actions/checkout@... with: ref: main` before any `uses: ./.github/actions/...` call —
 unlikely to hit one in this PR (the `update` verb is pure

--- a/plans/merge-bot-mention-commands.md
+++ b/plans/merge-bot-mention-commands.md
@@ -1,0 +1,333 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# merge-bot — respond to `@-mention` comment commands
+
+Closes #504. Adds a comment-driven trigger surface to
+`.github/workflows/merge-bot.yml` so a contributor (or any user with
+`write` permission on the repo) can ask the bot to perform a discrete
+operation on a PR by posting `@agent-auth-merge-bot <verb>` in a PR
+comment. First verb shipped: `update` — calls the same
+`PUT /pulls/{n}/update-branch` path the BEHIND auto-update step uses
+inside the `merge` job, but in isolation, without a merge attempt.
+
+## Context
+
+Today the only way to nudge `agent-auth-merge-bot` is to apply or
+remove the `automerge` label. There is no way to ask it to perform a
+discrete operation on a PR — most concretely, to update a PR's branch
+against `main` *without* also asking it to merge.
+
+The bot already knows how to do an `update-branch`: the
+`Detect BEHIND and auto-update branch` step inside the `merge` job
+calls `PUT /pulls/{n}/update-branch` with `expected_head_sha` pinned
+when a labeled PR is `BEHIND`. But that path only runs as part of a
+merge attempt. A contributor who wants to verify CI on top of the
+latest `main` *before* committing to a merge has no way to trigger it.
+
+Comment-command dispatch is also a stepping-stone toward #428 (move
+the bot off Actions to a hosted webhook service): the verb-dispatch
+shape, authorization model, and reaction protocol designed here all
+port to the hosted handler unchanged. Only the trigger plumbing
+(`on: issue_comment` → HTTP webhook) changes.
+
+## Proposal
+
+A new top-level `command` job in `merge-bot.yml`, sibling to the
+existing `merge`, `label-needs-fix`, and `sweep` jobs. Triggered by
+`on: issue_comment: types: [created]`. The job filters non-PR
+comments and non-prefixed bodies cheaply in the `if:` predicate,
+authorizes the commenter via `GET /repos/.../collaborators/{user}/permission`,
+posts a 👀 reaction to acknowledge, dispatches on the verb via a
+small `case`-statement table (today: `update` only), and posts a 👍
+or 👎 reaction depending on the outcome. A follow-up PR comment is
+posted *only* on structured failures (e.g. `update-branch` API
+errors) — mirroring the `Claude: Cannot ...` style the legacy bot
+used before #503 stripped its merge-time PR-comment surface.
+
+### Trigger and `if:` predicate
+
+Add to `on:`:
+
+```yaml
+issue_comment:
+  types: [created]
+```
+
+Cheap pre-filter on the new `command` job's `if:` so we don't burn a
+runner on every issue or PR comment:
+
+```yaml
+if: |
+  github.event_name == 'issue_comment'
+  && github.event.action == 'created'
+  && github.event.issue.pull_request != null
+  && startsWith(github.event.comment.body, '@agent-auth-merge-bot ')
+  && github.event.comment.user.type != 'Bot'
+```
+
+- `event.issue.pull_request != null` rejects issue (non-PR) comments.
+- `startsWith(...)` rejects unrelated PR comments without an API call.
+- `event.comment.user.type != 'Bot'` is the self-mention guard. The
+  App posts as `Bot`-type users, so a future command-output comment
+  that happens to mention the bot cannot loop. Independent of name
+  comparison so a rename of the App slug doesn't break it. (Belt-and-
+  braces: the verb dispatch step also checks the actor login is not
+  the bot's own login.)
+
+### Verb dispatch table
+
+A single `case` on the parsed verb:
+
+```bash
+case "${VERB}" in
+  update)
+    # call PUT /pulls/{n}/update-branch — see "update verb" below
+    ;;
+  *)
+    # unknown verb — react 👎, optional comment
+    ;;
+esac
+```
+
+Today the only known verb is `update`. The table shape is
+deliberate: follow-up commands (`merge`, `cancel`, `rebase`, …) get a
+new `case` arm without revisiting trigger / authorization / reaction
+plumbing. Each open-issue follow-up will gate verbs separately
+(`merge` requires PR-author approval; `cancel` requires the original
+labeller; etc.).
+
+Verb-arg parsing today is just `awk '{print $2}'` on the body's
+first line — `@agent-auth-merge-bot update` produces `update`. When
+multi-arg verbs land we replace this with a small parser; until
+then, anything past the verb is ignored (and noted in the eventual
+unknown-verb response).
+
+### `update` verb
+
+Reuses the existing `Detect BEHIND and auto-update branch` step's
+shape:
+
+1. `gh pr view <n> --json mergeStateStatus,headRefOid` — re-read
+   state right before the API call. Same UNKNOWN polling loop the
+   merge job uses (10 × 3s) so we don't fall through with a stale
+   state.
+2. If `mergeStateStatus != BEHIND` after polling → react 👍 and exit
+   ("already up to date with main; no-op"). Idempotent per the
+   acceptance criterion. UNKNOWN-after-polling reacts 👎 (state
+   never resolved — surface as a structured failure).
+3. If BEHIND → call `gh api --method PUT "repos/.../pulls/{n}/update-branch" -f expected_head_sha=<sha>`.
+4. Treat `expected_head_sha` 422 as 👍 with a `::notice::` line
+   ("contributor pushed during update; their commit is the new
+   head"). Same as the merge-job behaviour: the contributor's push
+   is a benign race we don't need to retry.
+5. Treat any other `update-branch` API error as 👎 + a follow-up
+   `Claude: Cannot update — <api error>` PR comment. The merge job
+   only logs `::error::` because the failing required check / red
+   PR badge already surfaces the problem; the comment-command path
+   doesn't have an equivalent surface for "API call failed", so a
+   structured failure comment is required for the user to know
+   their request was rejected and why.
+6. Success → react 👍. No follow-up comment — the new head SHA on
+   the PR (and the resulting CI cycle) is the visible signal that
+   the update happened.
+
+### Authorization
+
+`GET /repos/{owner}/{repo}/collaborators/{user}/permission` returns a
+permission level (`admin` / `maintain` / `write` / `triage` / `read`
+/ `none`). Authorize iff the level is one of `admin / maintain / write` — same gating GitHub's own UI uses for write-tier actions.
+Anything below reacts 👎 and exits with a `::notice::` line; no
+follow-up PR comment (would invite drive-by command spam, since
+unauthorized users by definition aren't trusted to make signal-from-
+noise judgements about their own attempts).
+
+The lookup uses the App token (already minted by the existing
+`secrets-check` + `Mint merge-bot App token` steps the `merge` job
+uses; we factor those steps out per "Code organisation" below). The
+App's existing `Metadata: Read-only` grant covers the
+collaborator-permission endpoint on user-owned repos. No new App
+permission needed.
+
+### Reaction lifecycle
+
+GitHub reactions on `issue_comment` use
+`POST /repos/.../issues/comments/{id}/reactions` with a `content`
+field of `eyes` / `+1` / `-1`. Three calls per command:
+
+1. `eyes` immediately after the authorization check passes (so the
+   user sees the bot has accepted the request before the API work
+   starts).
+2. `+1` (success) OR `-1` (rejection) at the end of the dispatch
+   table.
+
+If authorization fails we post 👎 only — no 👀 first. (Distinguishes
+"command rejected because you can't run it" from "command attempted
+and failed" to anyone reading the timeline.)
+
+The reaction calls themselves are best-effort: a failed reaction
+post emits a `::warning::` and the workflow continues. Losing a
+reaction is observable noise but doesn't change the underlying
+outcome (the `update-branch` either ran or didn't).
+
+### Self-mention guard
+
+Two layers, defence-in-depth:
+
+1. `if:` filter on `event.comment.user.type != 'Bot'` — rejects all
+   App-authored comments at the trigger level so no runner starts.
+   Catches the most likely loop source.
+2. Inside the job, an explicit name guard reads
+   `github.event.comment.user.login` and bails if it matches the
+   App's bot login (`agent-auth-merge-bot[bot]` — the `[bot]` suffix
+   is appended automatically by GitHub for App-authored comments).
+   Catches the unlikely case where a future GitHub change makes
+   `user.type` carry a different value for our App.
+
+### Code organisation
+
+The existing `merge` and `label-needs-fix` jobs both inline the
+`secrets-check` + `Mint merge-bot App token` step pair. The new
+`command` job will inline a third copy of the same pair rather than
+factoring all three into a composite action — keeping this PR scoped
+to the issue-acceptance surface and minimising the
+self-modifying-merge-bot-PR risk (per the auto-memory note,
+`actions/checkout` ordering in both `merge` AND `label-needs-fix`
+needs to be exact for the merge-bot run that lands this PR not to
+crater on a missing composite action). A future cleanup PR can
+factor the three call-sites once the third one has merged on `main`
+and the duplication is observable.
+
+The new `command` job DOES need its own `actions/checkout@... with: ref: main` before any `uses: ./.github/actions/...` call —
+unlikely to hit one in this PR (the `update` verb is pure
+`gh api`-on-shell, no composite action dependency), but adding the
+checkout up front leaves the door open for future verbs that wrap
+the existing `read-required-contexts` action (e.g. a `recheck` verb
+that re-evaluates required-check status).
+
+### Permissions
+
+Workflow-level `permissions:` already grants
+`pull-requests: write` (covers reacting on issue-comments — the
+endpoint accepts the App-installation `Issues: Read & write` /
+`Pull requests: Read & write` grants the App already carries) and
+`contents: write` (covers `update-branch`). No change needed.
+
+### Failure surfaces
+
+- Unauthorized commenter → 👎 only, no PR comment.
+- Unknown verb → 👎 + PR comment
+  `Claude: Unknown verb '<verb>'. Known verbs: update.`
+- `update-branch` API error (other than `expected_head_sha`) → 👎
+  - PR comment `Claude: Cannot update — <api error>`.
+- Reaction post itself failed → `::warning::` only, no PR comment.
+
+### Concurrency
+
+```yaml
+concurrency:
+  group: merge-bot-command-${{ github.event.comment.id }}
+  cancel-in-progress: false
+```
+
+Per-comment key so two near-simultaneous comments on different PRs
+run in parallel. `cancel-in-progress: false` because cancelling a
+mid-`update-branch` call would leave the user without a 👍/👎 — and
+the `expected_head_sha` pin on the API call already protects against
+the only race that matters (a new push during the update).
+
+## Acceptance
+
+Per the issue:
+
+- Posting `@agent-auth-merge-bot update` on a behind-main PR makes
+  the bot react 👀, run `update-branch`, and react 👍 — with no
+  merge attempt.
+- Posting it from an unauthorized account reacts 👎 and does
+  nothing.
+
+Verification path: this is a workflow change, so end-to-end
+acceptance can only be tested *after* the workflow lands on `main`.
+The new `command` job will not exist on `main` until the squash-
+merge lands; the merge-bot run that processes this PR consumes the
+on-`main` definition (the `Detect BEHIND and auto-update branch`
+step is unchanged), so the PR landing itself doesn't depend on the
+new code path being callable.
+
+Post-merge verification (matches the issue's acceptance criterion):
+
+1. **Authorized happy path** — on a behind-main test PR, post
+   `@agent-auth-merge-bot update` from an account with `write+`
+   permission. Expect:
+   - 👀 reaction appears within seconds of posting.
+   - Bot calls `update-branch`; the PR head advances to a merge
+     commit by `agent-auth-merge-bot[bot]`.
+   - 👍 reaction follows.
+   - No merge attempt (the PR remains open; no `Merged` activity).
+2. **Authorized no-op path** — on an up-to-date PR, post the same
+   command. Expect:
+   - 👀 → 👍 (idempotent no-op).
+   - No new commits on the PR.
+3. **Unauthorized path** — from an account with `read` / `none`
+   permission (or no account; comment-as-non-collaborator), post
+   the same command. Expect:
+   - 👎 reaction only (no 👀).
+   - No PR comment, no `update-branch` call.
+
+The orchestrator should run probes 1 and 3 once the PR merges; the
+result lands on the issue as the "Acceptance verified" comment.
+
+## Plan-template checklist
+
+- **Verify implementation against design doc** — N/A; no design doc
+  changes (this is an additive surface on an existing workflow). The
+  ADR 0038 update path covers any future move to the hosted
+  webhook handler under #428; no new ADR required for this
+  command surface (the dispatch table is small, internal, and
+  superseded by the #428 design).
+- **Threat model** — security-relevant change (new external trigger
+  - authorization gate). Threat shape: drive-by spam, privilege
+    escalation via crafted comment body, self-loop via App-authored
+    comment. All three are addressed by the `if:` filter +
+    collaborator-permission gate + self-mention guard documented
+    above; no `SECURITY.md` edit required because the merge bot's
+    trust boundary doesn't change (App token still mints with the same
+    permission set; no new attack surface against `main`).
+- **Post-incident review** — N/A; not remediating a vulnerability.
+- **ADRs** — N/A per "Verify against design doc" above.
+- **Cybersecurity standard compliance** — verb dispatch +
+  authorization gate is OWASP ASVS L1 V4.1 (general access control)
+  and L1 V13.1 (generic web service security). Both satisfied by the
+  permission-level gate (write+).
+- **Verify QM / SIL compliance** — N/A; merge-bot is QM (per ADR 0019
+  / 0038, automation-only path with a manual rollback via direct
+  `gh api` call).
+- **Coding standards** — bash steps follow the existing
+  `set -euo pipefail` + `env:`-tunneled-input pattern in
+  `merge-bot.yml`. No new Python / Rust code.
+- **Service design standards** — N/A; workflow change, no service
+  surface affected.
+- **Release and hygiene standards** — `feature(ci):` PR; hand-author
+  changelog entry under `changelog/@unreleased/` per the project
+  policy (changelog-bot does not auto-author).
+- **Testing standards** — workflow test coverage is via
+  `actionlint` + post-merge live-fire on a real PR (see
+  Verification path above). No new unit test surface (the
+  merge-bot itself has no unit-test harness — every prior change to
+  this workflow has been verified the same way).
+- **Tooling and CI standards** — workflow filename / `name:` /
+  composite-action naming all follow ADR 0046 conventions. New
+  composite action sits at `.github/actions/mint-merge-bot-app-token/action.yml`,
+  `name: mint-merge-bot-app-token`.
+
+## Out of scope
+
+- Any verb other than `update` — open separate issues per command
+  before adding more `case` arms.
+- Changing the existing label-driven merge trigger.
+- Migration to the hosted webhook handler (#428) — this PR's verb-
+  dispatch shape, authorization model, and reaction protocol are
+  designed to port over unchanged.


### PR DESCRIPTION
==COMMIT_MSG==
- comment-driven dispatch: `@agent-auth-merge-bot update` on a PR
  calls `PUT /pulls/{n}/update-branch` (no merge attempt) so a
  contributor can refresh a stuck `BEHIND` branch without applying
  `automerge` or waiting for the sweep cron.
- defence-in-depth self-mention guard (job-level
  `user.type != 'Bot'` plus an explicit bot-login check inside the
  job), collaborator-permission gate (`admin / maintain / write`
  via the App's existing `Metadata: Read-only` grant), and a
  reaction protocol (eyes -> thumbs-up / thumbs-down) that keeps
  the failure surface to structured cases only.
- new `command` job is self-contained from `merge` /
  `label-needs-fix` / `sweep`; verb dispatch is a `case` table so
  follow-up verbs port without revisiting the trigger plumbing.

Closes: #504
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==CHANGELOG_MSG==
`merge-bot` now responds to `@agent-auth-merge-bot update` PR
comments by calling `update-branch` on the PR, with no merge
attempt.
==CHANGELOG_MSG==

## Review notes

Approved diff per https://github.com/aidanns/agent-auth/issues/504#issuecomment-4365820038. Implementation plan committed to `plans/merge-bot-mention-commands.md`.

Composite-action factor-out for the secrets-check + token-mint pair (now duplicated across three call-sites in `merge-bot.yml`) is deferred to #584.

### Test plan

- [ ] CI green on this PR (`pr-lint`, `dco`, `changelog-lint`, `treefmt`, etc.).
- [ ] After merge: post `@agent-auth-merge-bot update` on a deliberately-`BEHIND` PR; expect eyes reaction, then thumbs-up after `update-branch` completes.
- [ ] After merge: post `@agent-auth-merge-bot update` on an up-to-date PR; expect eyes reaction, then thumbs-up + `::notice::` log line ("already up to date with main; no-op").
- [ ] After merge: post `@agent-auth-merge-bot bogus` on a PR; expect eyes reaction, then thumbs-down + a `Claude: Unknown verb 'bogus'. Known verbs: update.` PR comment.
- [ ] After merge: have a non-collaborator (or a `read`-tier collaborator) post `@agent-auth-merge-bot update`; expect eyes reaction, then thumbs-down only (no follow-up PR comment) and a `::notice::` log line.
- [ ] After merge: confirm the bot's own command-output PR comments (e.g. `Claude: Unknown verb ...`) do NOT trigger a re-dispatch (self-mention guard).