### PR TITLE
chore(ci): self-test pr-lint workflow yaml on PRs

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -4,15 +4,22 @@
 
 name: pr-lint
 
-# Residual top-level workflow for two meta self-tests that don't belong
-# under `ci.yml` (they're checks on workflow YAML / lint constants, not
-# per-PR validators):
+# Residual top-level workflow for three meta self-tests that don't
+# belong under `ci.yml` (they're checks on workflow YAML / lint
+# constants, not per-PR validators):
 #
 # - `pr-title-types-self-test` — asserts the `types: |` allowlist in
 #   `check-pull-request.yml`'s `title-prefix` job stays in lockstep
 #   with `scripts/lint/commit_taxonomy.py::ALLOWED_TYPES`.
 # - `predict-release-impact-self-test` — exercises the predict
 #   script's bump matrix on every run.
+# - `pr-lint-yaml-loadable-self-test` — parses pr-lint.yml + the
+#   `install-pr-lint-validator` composite against the **head ref**
+#   so a load-time syntax error in either fails CI on the same PR
+#   that introduces it (issue #511; reproduces the PR #506 escape
+#   path where a `${{ github.token }}` expression in a composite
+#   `description:` field went unnoticed because the workflow ran on
+#   `pull_request_target` and exercised the BASE-ref copy).
 
 on:
   pull_request:
@@ -83,3 +90,49 @@ jobs:
           # `pytest-cov`; the job exercises one script in isolation,
           # not the workspace's full coverage matrix.
           python3 -m pytest -o addopts= scripts/changelog/tests/test_predict_release_impact.py -v
+
+  pr-lint-yaml-loadable-self-test:
+    runs-on: ubuntu-latest
+    # Head-ref guard for the pr-lint surface (issue #511). PR #506 cut
+    # the pr-lint jobs over to a new `install-pr-lint-validator`
+    # composite that contained a load-time syntax error
+    # (`${{ github.token }}` in a `description:` field — invalid
+    # because action.yml metadata only has the `inputs` context in
+    # scope at parse time). The bug escaped #506's CI because pr-lint
+    # was triggered on `pull_request_target` and checked out the BASE
+    # ref's copy of the workflow + composite — so the new (broken)
+    # version was never exercised on its own PR. The bug fired on
+    # every PR opened against main thereafter.
+    #
+    # Unlike the two sibling self-tests above (which check out the
+    # base ref to compare against frozen invariants), this job MUST
+    # check out the **head** ref so a load-time syntax error in the
+    # PR-under-test's copy of pr-lint.yml or the composite fails CI
+    # on the same PR. Default checkout (no `ref:`) on a `pull_request`
+    # event resolves to the synthetic merge commit, which carries the
+    # head ref's copy of every changed file — sufficient for this
+    # static guard.
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Install runtime deps (PyYAML, pytest)
+        run: pip install --no-cache-dir 'pyyaml>=6' 'pytest>=8'
+
+      - name: Run pr-lint YAML-loadable self-test
+        run: |
+          set -euo pipefail
+          # `-o addopts=` overrides the workspace `pyproject.toml`'s
+          # `[tool.pytest.ini_options].addopts` (which injects
+          # `--cov=packages` plus the integration-fixture plugin) so
+          # this isolated job runs without `pytest-cov` or the
+          # integration plugin installed — same rationale as the
+          # `predict-release-impact-self-test` job above. The test
+          # file lives under `ci/test-repo/` (whole-repo invariants
+          # that don't belong to any single workspace package's
+          # `tests/` tree); see `ci/test-repo/README.md`.
+          python3 -m pytest -o addopts= ci/test-repo/test_pr_lint_action_yml_loadable.py -v

--- a/ci/test-repo/README.md
+++ b/ci/test-repo/README.md
@@ -1,0 +1,61 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# `ci/test-repo/`
+
+Whole-repo (cross-package) tests that don't belong to any single
+workspace member's `packages/<svc>/tests/` tree.
+
+## Scope
+
+Tests here assert invariants over the **entire repository** — the
+shape of `.github/` workflows + composite actions, project-wide
+configuration files, repo-level conventions. They are not unit tests
+of a service's source, and they have no `packages/<svc>/`
+counterpart that could meaningfully own them.
+
+The original root-level `tests/` tree is reserved for cross-service
+checks that still depend on the workspace install surface
+(release-semver, OpenAPI spec, scan-failure formatting). Tests that
+are pure static checks over repo-shaped artefacts (workflow YAML,
+composite action metadata, branch-protection contracts derived from
+files in `.github/`) live here instead so the cross-package nature
+is obvious from the path.
+
+Each file in this directory is invoked from a dedicated CI job —
+no umbrella runner walks the directory. The job that owns the test
+lives next to the surface it guards (e.g. the
+`pr-lint-yaml-loadable-self-test` job in
+`.github/workflows/pr-lint.yml` runs
+`test_pr_lint_action_yml_loadable.py`). This keeps the trigger
+surface (which event fires which test) explicit per-test instead of
+deferring to a global pytest collector.
+
+## Adding a test
+
+1. Drop a `test_<descriptive_name>.py` file in this directory.
+2. Wire a CI job (typically a self-test job alongside the workflow
+   under test) that installs `pyyaml` + `pytest` and invokes the
+   file with `python3 -m pytest -o addopts= ci/test-repo/<file> -v`.
+   Use `-o addopts=` to override the workspace `pyproject.toml`'s
+   `[tool.pytest.ini_options].addopts` (which injects `--cov` and
+   the integration-fixture plugin) — these tests run in isolated
+   jobs without the workspace virtualenv.
+3. Document the file's purpose in its top-level docstring; readers
+   landing here from a CI failure should be able to understand the
+   bug class without grepping issue history.
+
+## Why a separate top-level location
+
+`packages/<svc>/tests/` is for service unit tests. The root
+`tests/` tree is for cross-service tests that depend on the
+workspace install surface. Repo-shape invariants (workflow YAML,
+composite-action metadata, branch-protection contracts) are a third
+category — they have no service owner and don't need the workspace
+venv to run. Putting them in `ci/test-repo/` makes that category
+visible at the directory level and prevents drift back into either
+of the other two homes when a future contributor adds a similar
+test.

--- a/ci/test-repo/test_pr_lint_action_yml_loadable.py
+++ b/ci/test-repo/test_pr_lint_action_yml_loadable.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+"""Static parse-time guard for the pr-lint surface (issue #511).
+
+PR #506 cut the pr-lint jobs over to a new
+``.github/actions/install-pr-lint-validator/action.yml`` composite.
+The new action.yml carried a load-time syntax error: a literal
+``${{ github.token }}`` expression inside an input ``description:``
+field. GitHub rejects that with ``Unrecognized named-value: 'github'``
+because composite-action metadata only has the ``inputs`` context in
+scope at parse time.
+
+The bug escaped #506's CI because pr-lint.yml ran on
+``pull_request_target`` at the time, which checks out the BASE ref's
+copy of the workflow + composite — so the new (broken) version was
+never exercised on its own PR. The bug only manifested on the next
+PR opened against main.
+
+This test is the minimal head-ref guard. It does NOT depend on the
+workflow's trigger surface: as long as it executes on every PR, a
+load-time bug in either of the two scoped files fails CI on the same
+PR that introduces it. The companion ``pr-lint-yaml-loadable-self-test``
+job in ``.github/workflows/pr-lint.yml`` is the runner — it checks
+out the head ref and invokes pytest on this file in isolation.
+
+Scope is intentionally narrow (the two files called out in the issue):
+expanding to every workflow / composite action is one line away if the
+need arises but would gold-plate a precise per-issue fix.
+
+Lives under ``ci/test-repo/`` per the directory's README — this test
+is a whole-repo invariant (it asserts a property of two specific
+files in ``.github/``) and does not belong to any single workspace
+package's ``tests/`` tree.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+# This file lives at ``ci/test-repo/<file>``, so the repo root is two
+# parents up (``parents[0]`` = ``test-repo``, ``parents[1]`` = ``ci``,
+# ``parents[2]`` = repo root).
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "pr-lint.yml"
+COMPOSITE_ACTION_PATH = (
+    REPO_ROOT / ".github" / "actions" / "install-pr-lint-validator" / "action.yml"
+)
+
+# Composite-action metadata only has the ``inputs`` context in scope at
+# parse time. Any ``${{ <other-context>.* }}`` expression in these
+# fields is rejected by GitHub at workflow-load time with
+# ``Unrecognized named-value: '<context>'``. The simplest accurate
+# guard is to forbid the literal ``${{`` substring in these fields
+# entirely — no production composite action in this repo legitimately
+# needs an ``${{ inputs.* }}`` expression in a ``description:`` /
+# ``default:`` / ``value:`` slot today, and a future need can be
+# carved out when it arises.
+_PARSE_TIME_FORBIDDEN_SUBSTRING = "${{"
+
+# Per the action.yml spec: ``inputs.<name>`` accepts ``description``
+# and ``default``; ``outputs.<name>`` accepts ``description`` and
+# (for composite actions) ``value``. Each of those values is
+# evaluated at workflow-load time, before any step has run.
+_FIELDS_PARSED_AT_LOAD_TIME: dict[str, tuple[str, ...]] = {
+    "inputs": ("description", "default"),
+    "outputs": ("description", "value"),
+}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param(WORKFLOW_PATH, id="workflow"),
+        pytest.param(COMPOSITE_ACTION_PATH, id="composite-action"),
+    ],
+)
+def test_yaml_parses(path: Path) -> None:
+    """The file must parse with ``yaml.safe_load`` without raising.
+
+    A YAML-level syntax error (mis-indentation, unbalanced quotes,
+    duplicate keys flagged by the safe loader) would prevent GitHub
+    from loading the workflow / composite at all and silently break
+    every PR opened after the bad version lands on ``main``. Catch
+    that on the same PR.
+    """
+    text = path.read_text(encoding="utf-8")
+    parsed = yaml.safe_load(text)
+    assert parsed is not None, f"{path} parsed to None — empty document?"
+    assert isinstance(
+        parsed, dict
+    ), f"{path} top-level must be a mapping, got {type(parsed).__name__}"
+
+
+def test_composite_action_metadata_has_no_load_time_expressions() -> None:
+    """No ``${{`` expressions in composite-action input/output metadata.
+
+    Reproduces the precise failure mode from PR #506: the
+    ``github-token`` input's ``description:`` field carried a literal
+    ``${{ github.token }}`` expression, which GitHub rejected with
+    ``Unrecognized named-value: 'github'`` because only the ``inputs``
+    context is in scope at parse time. The composite refused to load
+    on every subsequent PR, breaking the entire pr-lint surface.
+
+    Forbid the ``${{`` substring outright in the load-time-evaluated
+    fields. If a future legitimate use of ``${{ inputs.* }}`` arises
+    in those fields, carve it out with a deliberate exception here
+    rather than weaken the guard wholesale.
+    """
+    parsed = yaml.safe_load(COMPOSITE_ACTION_PATH.read_text(encoding="utf-8"))
+    assert isinstance(parsed, dict)
+
+    offences: list[str] = []
+    for section, fields in _FIELDS_PARSED_AT_LOAD_TIME.items():
+        section_block: Any = parsed.get(section) or {}
+        if not isinstance(section_block, dict):
+            continue
+        for entry_name, entry_spec in section_block.items():
+            if not isinstance(entry_spec, dict):
+                continue
+            for field in fields:
+                value = entry_spec.get(field)
+                if isinstance(value, str) and _PARSE_TIME_FORBIDDEN_SUBSTRING in value:
+                    offences.append(
+                        f"{section}.{entry_name}.{field} contains "
+                        f"{_PARSE_TIME_FORBIDDEN_SUBSTRING!r}: {value!r}"
+                    )
+
+    assert not offences, (
+        "Composite action metadata may not contain `${{` expressions "
+        "in input/output description/default/value fields — only the "
+        "`inputs` context is in scope at workflow-load time and a "
+        "`${{ github.* }}` reference fails parsing with "
+        "'Unrecognized named-value' (issue #511).\n\nOffences:\n  - " + "\n  - ".join(offences)
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,7 @@ exclude_lines = [
 [tool.ruff]
 src = [
     # keep-sorted start
+    "ci/test-repo",
     "packages/agent-auth-common/src",
     "packages/agent-auth/src",
     "packages/gpg-bridge/src",
@@ -231,6 +232,7 @@ strict = true
 # them here means ``mypy`` picks up the full matrix.
 files = [
     # keep-sorted start
+    "ci/test-repo",
     "packages/agent-auth-common/src",
     "packages/agent-auth-common/tests",
     "packages/agent-auth/benchmarks",


### PR DESCRIPTION
==COMMIT_MSG==
PR #506 cut the pr-lint jobs over to a new
`install-pr-lint-validator` composite that contained a load-time
syntax error (`${{ github.token }}` in a `description:` field —
invalid because action.yml metadata only has the `inputs` context
in scope at parse time). The bug escaped #506's own CI because
pr-lint.yml ran on `pull_request_target` and exercised the BASE
ref's copy of the workflow + composite, so the new (broken)
version was never tested on its own PR. The bug then fired on
every PR opened against main thereafter.

Add a self-test that runs on the head ref so a load-time syntax
error in either `pr-lint.yml` or `install-pr-lint-validator/action.yml`
fails CI on the same PR that introduces it:

- `ci/test-repo/test_pr_lint_action_yml_loadable.py` — three
  pytest cases. Two `yaml.safe_load` parse-checks (one per file)
  catch indentation / quoting / duplicate-key bugs; the third
  scans the composite's `inputs.<*>.{description,default}` and
  `outputs.<*>.{description,value}` slots for any `${{`
  substring, reproducing the precise PR #506 failure mode.
- `pr-lint-yaml-loadable-self-test` job in `pr-lint.yml` invokes
  the test via `python3 -m pytest -o addopts=` in an isolated
  job. Default `actions/checkout` resolves to the synthetic merge
  commit (head-ref copy of every changed file), unlike the two
  sibling self-tests that pin to the base ref.
- New `ci/test-repo/` top-level directory with a README that
  scopes it to whole-repo (cross-package) tests — invariants over
  `.github/` shape and project-wide config that don't belong to
  any single workspace package's `tests/` tree. `pyproject.toml`
  adds the directory to the ruff `src` and mypy `files` lists so
  the existing toolchain covers it.

Verified locally: re-injected the exact PR #506 bug into the
composite and confirmed the new test fails with a clear offence
message before restoring.

Closes: #511
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

Approach picked: Option 2 from the issue body (Python YAML check), discussed in the prior [blocker comment](https://github.com/aidanns/agent-auth/issues/511#issuecomment-4365818372). User-redirected the test location to a new top-level `ci/test-repo/` directory rather than `tests/`; the README in that directory scopes it as the canonical home for whole-repo (cross-package) tests so future contributors have a precedent.

Why `chore(ci):` rather than `improvement(ci):`: the change is pure CI scaffolding with no end-user behavioural impact, matching the precedent set by #517 (the previous CI-plumbing PR on this same surface, which used `chore(ci):` + `no changelog`). PR #512 (the one-line fix that cleared the original bug) used the same shape.

### Test plan

- [ ] Local: `task test -- --fast` passes (sanity).
- [ ] Local: `python3 -m pytest -o addopts= ci/test-repo/test_pr_lint_action_yml_loadable.py -v` returns 3 passed.
- [ ] Local bug-injection sanity: temporarily inject `description: ${{ github.token }}` into `install-pr-lint-validator/action.yml`, re-run the test, observe the third case fail with a clear `inputs.github-token.description contains '${{'` offence message, restore the file.
- [ ] Local: `task lint`, `task format -- --check`, `task typecheck`, `task verify-standards` all green.
- [ ] CI: the new `pr-lint-yaml-loadable-self-test` job appears alongside the existing two self-test jobs and exits green on this PR.
- [ ] CI: `Required checks passed` aggregator on `ci.yml` is green (no regression in the wider test matrix).
