### PR TITLE
fix: repair merge-bot rollup-dedupe regression guard

### DIFF
--- a/tests/test_merge_bot_rollup_dedupe.py
+++ b/tests/test_merge_bot_rollup_dedupe.py
@@ -5,34 +5,39 @@
 """Unit tests for the rollup dedupe predicate in merge-bot.yml.
 
 The merge bot (`.github/workflows/merge-bot.yml`) classifies required
-checks into `failed` / `pending` / `success` by piping the GraphQL
-`statusCheckRollup` payload through a jq filter. `statusCheckRollup`
-returns one entry per check *run*, not per check *name* — a retried
-check (workflow rerun, fix-then-push, close+reopen retrigger) appears
-multiple times, and the historical FAILURE entry never disappears
-from the rollup for the lifetime of the head SHA.
+checks into `failed` / `pending` / `success` by iterating the
+required-contexts list and, per context, piping the GraphQL
+`statusCheckRollup` payload through a jq filter that takes the latest
+run by `startedAt`. `statusCheckRollup` returns one entry per check
+*run*, not per check *name* — a retried check (workflow rerun,
+fix-then-push, close+reopen retrigger) appears multiple times, and the
+historical FAILURE entry never disappears from the rollup for the
+lifetime of the head SHA.
 
-The dedupe step (group by name+context, keep latest by startedAt)
+The dedupe step (sort by startedAt, take latest per context name)
 collapses each check name down to its most recent run before the
-failure / pending predicates evaluate the rollup. Without it, a
-fail-then-pass on the same SHA wedges merge-bot indefinitely — the
-bug surfaced on PR #346 / issue #347, where `changelog-lint` failed
-on the original `opened` event, was retriggered green via close+reopen,
-and the merge call was refused with `FAILED_CHECKS: changelog-lint`
-until the stale failed run was manually deleted via `gh run delete`.
+bash `case` classifier buckets it into success / pending / fail.
+Without it, a fail-then-pass on the same SHA wedges merge-bot
+indefinitely — the bug surfaced on PR #346 / issue #347, where
+`changelog-lint` failed on the original `opened` event, was
+retriggered green via close+reopen, and the merge call was refused
+with `FAILED_CHECKS: changelog-lint` until the stale failed run was
+manually deleted via `gh run delete`.
 
-The tests pin both selectors (failed *and* pending) by extracting the
-jq blocks straight out of the workflow YAML and feeding them
-hand-rolled rollup payloads. Pinning the predicates against the
-workflow file (rather than copy-pasting them into the test) means a
-future edit to the dedupe-or-predicate logic that drifts from this
-test will fail at the assert site, not at "the workflow keeps running
-green but the bug is back".
+The tests pin the dedupe by extracting the per-context bash loop
+straight out of the workflow YAML (the inner jq selector + the `case`
+classifier) and running it under bash against hand-rolled rollup
+payloads. Pinning the loop body against the workflow file (rather
+than copy-pasting it into the test) means a future edit to the
+dedupe-or-classifier logic that drifts from this test will fail at
+the assert site, not at "the workflow keeps running green but the
+bug is back".
 """
 
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -60,40 +65,91 @@ def _load_inspect_required_checks_step() -> str:
 _STEP_BODY = _load_inspect_required_checks_step()
 
 
-def _extract_jq_filter(variable: str) -> str:
-    """Pull a `<variable>="$(jq -r '...' <<<"${rollup}")"` filter body.
+def _extract_classifier_loop(step_body: str) -> str:
+    """Pull the per-context classifier loop body out of the step.
 
-    The bot writes both selectors as multi-line jq programs assigned
-    to `failed=` and `pending=`. Pulling them out via a regex keeps the
-    test honest — the test exercises the *actual* filter the bot runs,
-    not a hand-typed copy that can silently drift.
+    The merge bot's `Inspect required checks` step iterates
+    `REQUIRED_CONTEXTS` and, per context, runs a `jq` selector that
+    sorts by `startedAt` and takes the latest matching entry, then a
+    `case` classifier that buckets it into success / pending / fail.
+    Extracting the loop verbatim — rather than copying the jq selector
+    or the `case` arms into the test source — keeps the test honest:
+    a future edit that weakens the dedupe (drops `sort_by`, flips
+    `(.[-1])` to `(.[0])`, removes the `select((.workflowName // "")
+    != "Merge Bot")` self-filter, etc.) will surface here at an assert
+    site, not as a silently-passing test against a dead copy.
     """
     pattern = (
-        rf"{re.escape(variable)}=\"\$\(jq -r '\n"
-        r"(?P<filter>.*?)\n"
-        r"\s*' <<<\"\$\{rollup\}\"\)\""
+        r'^(?P<loop>( *)fail=""\n'
+        r'\2pending=""\n'
+        r"\2while IFS= read -r ctx; do\n"
+        r".*?\n"
+        r'\2done <<<"\$\{REQUIRED_CONTEXTS\}")'
     )
-    match = re.search(pattern, _STEP_BODY, flags=re.DOTALL)
-    assert match is not None, f"could not find jq filter for `{variable}=` in workflow"
-    return match.group("filter")
+    match = re.search(pattern, step_body, flags=re.DOTALL | re.MULTILINE)
+    assert match is not None, (
+        "could not locate the per-context classifier loop in the "
+        "`Inspect required checks` step. The harness pin against "
+        "merge-bot.yml has drifted; update the extractor."
+    )
+    return match.group("loop")
 
 
-_FAILED_FILTER = _extract_jq_filter("failed")
-_PENDING_FILTER = _extract_jq_filter("pending")
+_CLASSIFIER_LOOP = _extract_classifier_loop(_STEP_BODY)
 
 
-def _run_jq(filter_body: str, rollup: list[dict[str, Any]]) -> list[str]:
-    """Run jq -r over `rollup` with the workflow's filter; return name lines."""
+def _classify(
+    rollup: list[dict[str, Any]],
+    contexts: list[str],
+) -> tuple[list[str], list[str]]:
+    """Run the extracted classifier loop against `rollup` for `contexts`.
+
+    Returns `(failed, pending)` — the names that the merge bot would
+    bucket as failing or pending, respectively, for the given fixture
+    rollup and required-context list. `success` is the implicit third
+    bucket: any context not in either returned list.
+
+    The extracted loop reads `${rollup}` and `${REQUIRED_CONTEXTS}`
+    from the environment of the bash invocation; the wrapper here
+    sets both, runs the loop, then prints the post-`awk 'NF'` `fail`
+    and `pending` strings on disjoint stdout lines so we can split
+    them back into Python lists.
+    """
+    script = (
+        "set -euo pipefail\n"
+        'rollup="${ROLLUP}"\n' + _CLASSIFIER_LOOP + "\n"
+        # Same post-loop tidy-up the workflow performs before writing
+        # to GITHUB_OUTPUT; included so the test exercises the same
+        # final shape the downstream `Refuse to merge` / `Wait for
+        # pending checks` steps see.
+        "fail=\"$(printf '%s' \"${fail}\" | awk 'NF')\"\n"
+        "pending=\"$(printf '%s' \"${pending}\" | awk 'NF')\"\n"
+        "printf 'FAIL_BEGIN\\n%s\\nFAIL_END\\nPENDING_BEGIN\\n%s\\nPENDING_END\\n' "
+        '"${fail}" "${pending}"\n'
+    )
     proc = subprocess.run(
-        ["jq", "-r", filter_body],
-        input=json.dumps(rollup),
+        ["bash", "-c", script],
+        env={
+            "ROLLUP": json.dumps(rollup),
+            "REQUIRED_CONTEXTS": "\n".join(contexts),
+            "PATH": os.environ.get("PATH", ""),
+        },
         capture_output=True,
         text=True,
         check=True,
     )
-    # The filter emits one name per line via `... | .[]`. An empty stdout
-    # means no entries matched (e.g. nothing failed, nothing pending).
-    return [line for line in proc.stdout.splitlines() if line]
+    return _parse_buckets(proc.stdout)
+
+
+def _parse_buckets(stdout: str) -> tuple[list[str], list[str]]:
+    """Split the bash wrapper's stdout into `(failed, pending)` lists."""
+    fail_match = re.search(r"FAIL_BEGIN\n(.*?)\nFAIL_END", stdout, re.DOTALL)
+    pending_match = re.search(r"PENDING_BEGIN\n(.*?)\nPENDING_END", stdout, re.DOTALL)
+    assert fail_match is not None, f"no FAIL_BEGIN block in stdout: {stdout!r}"
+    assert pending_match is not None, f"no PENDING_BEGIN block in stdout: {stdout!r}"
+    failed = [line for line in fail_match.group(1).splitlines() if line]
+    pending = [line for line in pending_match.group(1).splitlines() if line]
+    return failed, pending
 
 
 # Reference rollup entries used across the table-driven cases. Mirroring
@@ -101,7 +157,7 @@ def _run_jq(filter_body: str, rollup: list[dict[str, Any]]) -> list[str]:
 # `conclusion`, `status`, `startedAt` for Actions check-runs;
 # `context`, `state` for legacy commit statuses.
 
-# --- failure selector --------------------------------------------------
+# --- failure bucket ----------------------------------------------------
 
 
 def test_failed_empty_when_latest_run_per_name_succeeded() -> None:
@@ -131,7 +187,9 @@ def test_failed_empty_when_latest_run_per_name_succeeded() -> None:
             "startedAt": "2026-04-26T04:00:00Z",
         },
     ]
-    assert _run_jq(_FAILED_FILTER, rollup) == []
+    failed, pending = _classify(rollup, ["changelog-lint", "pr-lint"])
+    assert failed == []
+    assert pending == []
 
 
 def test_failed_reports_name_when_latest_run_is_failure() -> None:
@@ -155,7 +213,9 @@ def test_failed_reports_name_when_latest_run_is_failure() -> None:
             "startedAt": "2026-04-26T04:30:00Z",
         },
     ]
-    assert _run_jq(_FAILED_FILTER, rollup) == ["pytest"]
+    failed, pending = _classify(rollup, ["pytest"])
+    assert failed == ["pytest"]
+    assert pending == []
 
 
 def test_failed_handles_mixed_names_with_multiple_history_each() -> None:
@@ -174,7 +234,9 @@ def test_failed_handles_mixed_names_with_multiple_history_each() -> None:
         {"name": "gamma", "conclusion": "FAILURE", "startedAt": "2026-04-26T04:00:00Z"},
         {"name": "gamma", "conclusion": "FAILURE", "startedAt": "2026-04-26T04:10:00Z"},
     ]
-    assert sorted(_run_jq(_FAILED_FILTER, rollup)) == ["beta", "gamma"]
+    failed, pending = _classify(rollup, ["alpha", "beta", "gamma"])
+    assert sorted(failed) == ["beta", "gamma"]
+    assert pending == []
 
 
 def test_failed_excludes_merge_bot_own_runs() -> None:
@@ -200,30 +262,44 @@ def test_failed_excludes_merge_bot_own_runs() -> None:
             "startedAt": "2026-04-26T04:00:00Z",
         },
     ]
-    assert _run_jq(_FAILED_FILTER, rollup) == []
+    # `Merge ==COMMIT_MSG== block as squash body` is intentionally
+    # listed in the required contexts to prove the self-filter
+    # short-circuits before the classifier sees the entry: with the
+    # filter active the context falls through to "missing" and lands
+    # in `pending`; without it, the entry's FAILURE conclusion would
+    # surface in `failed`.
+    failed, pending = _classify(
+        rollup,
+        ["pr-lint", "Merge ==COMMIT_MSG== block as squash body"],
+    )
+    assert failed == []
+    assert pending == ["Merge ==COMMIT_MSG== block as squash body"]
 
 
-def test_failed_includes_legacy_commit_status_via_context() -> None:
+def test_failed_classifies_legacy_commit_status_via_context() -> None:
     """Legacy commit statuses use `context` + `state`, not `name` + `conclusion`.
 
-    The dedupe falls back to `.context` for the group key so legacy
-    statuses get the same fail-then-pass treatment as Actions check-runs.
+    The classifier falls back to `.context` for the match key and
+    `.state` for the conclusion so legacy statuses get the same
+    fail-then-pass treatment as Actions check-runs.
     """
     rollup = [
         {"context": "ci/jenkins", "state": "FAILURE", "startedAt": "2026-04-26T04:00:00Z"},
         {"context": "ci/jenkins", "state": "SUCCESS", "startedAt": "2026-04-26T04:10:00Z"},
     ]
-    assert _run_jq(_FAILED_FILTER, rollup) == []
+    failed, pending = _classify(rollup, ["ci/jenkins"])
+    assert failed == []
+    assert pending == []
 
 
-# --- pending selector --------------------------------------------------
+# --- pending bucket ----------------------------------------------------
 
 
 def test_pending_empty_when_stale_in_progress_was_superseded_by_success() -> None:
     """Stale IN_PROGRESS from a cancelled run must not pin the wait path.
 
     The bot exits cleanly (and waits for `check_suite.completed`) when
-    `pending` is non-empty. Without dedupe on the pending selector, an
+    `pending` is non-empty. Without the latest-run dedupe, an
     abandoned IN_PROGRESS entry — common after a cancelled rerun —
     keeps the bot in the wait-clean-exit branch even though every
     check has since completed. With dedupe, the latest SUCCESS entry
@@ -243,11 +319,21 @@ def test_pending_empty_when_stale_in_progress_was_superseded_by_success() -> Non
             "startedAt": "2026-04-26T04:00:00Z",
         },
     ]
-    assert _run_jq(_PENDING_FILTER, rollup) == []
+    failed, pending = _classify(rollup, ["pytest"])
+    assert failed == []
+    assert pending == []
 
 
 def test_pending_reports_name_when_latest_run_is_in_progress() -> None:
-    """A genuinely-running rerun after an old completion is still pending."""
+    """A genuinely-running rerun after an old completion is still pending.
+
+    The classifier reads `.conclusion` first; an IN_PROGRESS entry
+    has an empty / missing conclusion, which under `ascii_downcase`
+    becomes the empty string and falls through the empty/null/missing
+    `case` arm into the `pending` bucket. (The `status` field isn't
+    consulted; the empty-conclusion path is the workflow's signal for
+    "still running".)
+    """
     rollup = [
         {
             "name": "pytest",
@@ -262,28 +348,59 @@ def test_pending_reports_name_when_latest_run_is_in_progress() -> None:
             "startedAt": "2026-04-26T04:30:00Z",
         },
     ]
-    assert _run_jq(_PENDING_FILTER, rollup) == ["pytest"]
+    failed, pending = _classify(rollup, ["pytest"])
+    assert failed == []
+    assert pending == ["pytest"]
 
 
-# --- regression-pin: filters extracted, not invented -------------------
+# --- regression-pin: classifier extracted, not invented ----------------
 
 
-def test_dedupe_step_present_in_both_selectors() -> None:
-    """Defence-in-depth: the test relies on the dedupe being in *both* filters.
+def test_classifier_pins_dedupe_against_workflow_yaml() -> None:
+    """Defence-in-depth: the loop body must keep the dedupe primitives.
 
-    A future edit that removes the dedupe from one selector (say,
-    pending) but leaves the other intact would pass the
-    fail-then-pass case but reintroduce the stale-IN_PROGRESS bug.
-    Pin the structural shape so the only way to silence this test is
-    to keep the dedupe in both filters — exactly the invariant issue
-    #347 calls out.
+    `_classify` relies on the extracted loop containing both the
+    `sort_by(.startedAt)` clause and the `(.[-1])` "take latest"
+    selection. A future edit that drops either — say, by replacing
+    `sort_by` with a no-op `select(true)` or flipping `(.[-1])` to
+    `(.[0])` — would silently wedge the bot on the issue #347
+    fail-then-pass case. Pin the structural shape so the only way to
+    silence this test is to keep the dedupe primitives intact, which
+    is exactly the invariant issue #347 calls out.
     """
-    for name, filter_body in [("failed", _FAILED_FILTER), ("pending", _PENDING_FILTER)]:
-        assert "group_by" in filter_body, f"{name} filter is missing group_by"
-        assert "max_by" in filter_body, f"{name} filter is missing max_by"
+    assert (
+        "sort_by(.startedAt" in _CLASSIFIER_LOOP
+    ), "extracted loop is missing the `sort_by(.startedAt)` dedupe primitive"
+    assert (
+        "(.[-1]" in _CLASSIFIER_LOOP
+    ), "extracted loop is missing the `(.[-1])` 'take latest' selector"
+    assert (
+        'workflowName // ""' in _CLASSIFIER_LOOP and "Merge Bot" in _CLASSIFIER_LOOP
+    ), "extracted loop is missing the merge-bot self-filter"
 
 
-@pytest.mark.parametrize("filter_body", [_FAILED_FILTER, _PENDING_FILTER])
-def test_filters_handle_empty_rollup(filter_body: str) -> None:
-    """Empty rollup is valid input; both selectors must return zero names."""
-    assert _run_jq(filter_body, []) == []
+def test_classifier_handles_empty_rollup() -> None:
+    """Empty rollup with required contexts: every context buckets as pending.
+
+    `missing` is the workflow's sentinel for "context exists in
+    branch protection but no run reported yet" — bucketed as pending
+    so the bot waits rather than refusing.
+    """
+    failed, pending = _classify([], ["alpha", "beta"])
+    assert failed == []
+    assert sorted(pending) == ["alpha", "beta"]
+
+
+@pytest.mark.parametrize("contexts", [[], [""]])
+def test_classifier_handles_empty_required_contexts(contexts: list[str]) -> None:
+    """No required contexts (or only blank lines) yields empty buckets.
+
+    The fail-closed branch upstream of this step refuses the merge
+    when `REQUIRED_SOURCE == "empty"`, so the loop never runs against
+    a truly-empty contexts list in production. Pin the shape anyway
+    so a future refactor that lets this code path execute won't
+    silently bypass classification.
+    """
+    failed, pending = _classify([{"name": "ignored"}], contexts)
+    assert failed == []
+    assert pending == []


### PR DESCRIPTION
==COMMIT_MSG==
PR #540 / #542 refactored merge-bot.yml's `Inspect required checks`
step from a pair of single jq pipelines (one for `failed`, one for
`pending`) to a per-context bash loop that calls jq once per
required check and buckets the result via a `case` statement. The
test's regex extractor was anchored on the old `failed="$(jq -r
'...' <<<"${rollup}")"` shape, so it returned no match against the
post-refactor workflow and the assert at module-load time aborted
pytest collection — tanking the entire `task test` run for anyone
exercising the workspace suite locally.

Rework the harness to extract the new shape:

- `_extract_classifier_loop` pulls the per-context loop body
  (initializers + `while ... done`) verbatim out of the
  `Inspect required checks` step. Anchored on the literal shape
  `fail=""\npending=""\nwhile IFS= read -r ctx; do ... done
  <<<"${REQUIRED_CONTEXTS}"` so a future refactor that moves the
  loop will surface here, not silently bypass the pin.
- `_classify(rollup, contexts)` runs the extracted loop under
  `bash -c` against a fixture rollup and a Python-supplied
  contexts list, then parses the `fail` / `pending` outputs back
  into Python lists. The extracted loop is the actual workflow
  bytes — not a hand-typed copy — so the test continues to fail
  at the assert site if the dedupe (`sort_by(.startedAt)` plus
  `(.[-1])`) is weakened or the merge-bot self-filter is
  removed.
- All seven existing scenarios (fail-then-pass, pass-then-fail,
  mixed history, merge-bot self-filter, legacy commit-status
  context, stale-IN_PROGRESS dedupe, genuinely-pending rerun)
  port over to the new harness with assertions on the
  `(failed, pending)` tuple. Two extra cases pin the empty-rollup
  and empty-contexts edge cases.
- `test_classifier_pins_dedupe_against_workflow_yaml` upgrades
  the structural pin: a future edit that drops `sort_by`, flips
  `(.[-1])` to `(.[0])`, or removes the `select((.workflowName
  // "") != "Merge Bot")` self-filter still surfaces here even
  if the data-driven scenarios happen to mask the regression
  (verified by mutation-injecting each of the three primitives
  against the workflow before committing).

Closes: #580
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

Approach picked: option 2 from the issue body (`subprocess.run(["bash", "-c", <step-body>], env=...)`) over option 1 (replicate the loop in Python). Rationale: extracting the loop verbatim keeps the test pinned to the actual workflow bytes — including the `case` arm bucketing — without rebuilding the bash semantics in Python. The extra fixture overhead is one bash invocation per test (~50ms), which is well within the unit-test budget.

Mutation-test confirmation that the new harness catches the dedupe property: temporarily applied each of the three mutations below to `merge-bot.yml`, re-ran the test, observed the listed failures, then restored.

| Mutation | Tests that fail |
|---|---|
| `(.[-1] // {})` → `(.[0] // {})` | 7 of 11 (4 data-driven + structural pin + 2 collateral) |
| Drop `\| sort_by(.startedAt // "")` | 1 (structural pin) |
| `select((.workflowName // "") != "Merge Bot")` → `select(true)` | 2 (`test_failed_excludes_merge_bot_own_runs` + structural pin) |

The structural pin (`test_classifier_pins_dedupe_against_workflow_yaml`) is the catch-all: any single-line edit that removes `sort_by(.startedAt`, `(.[-1]`, or the `Merge Bot` self-filter substring trips it. Data-driven scenarios catch the semantic regressions on top.

### Test plan

- [ ] Local: `task test -- --fast` passes (sanity).
- [ ] Local: `uv run pytest tests/test_merge_bot_rollup_dedupe.py -v` returns 11 passed (was: 0 collected / 1 error before this PR).
- [ ] Local mutation sanity: temporarily apply each of the three mutations in the table above to `.github/workflows/merge-bot.yml`, re-run the test file, confirm the listed scenarios fail, restore the file.
- [ ] Local: `task lint`, `task format -- --check`, `task typecheck`, `task check` all green.
- [ ] CI: `Required checks passed` aggregator on `ci.yml` is green.