### PR TITLE
fix(ci): run workspace tests + per-package coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,11 @@ jobs:
     if: needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'
     uses: ./.github/workflows/test-unit.yml
 
+  test-workspace:
+    needs: [plan]
+    if: needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'
+    uses: ./.github/workflows/test-workspace.yml
+
   test-integration:
     needs: [plan]
     if: needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'
@@ -346,7 +351,7 @@ jobs:
     # Repo-wide aggregator. Branch protection on `main` requires only
     # `ci / required-checks-passed`; adding a new child workflow is a
     # one-line edit to `needs:` here.
-    needs: [plan, check-docs, check-changelog, check-publish, check-pull-request, check-lint, check-standards, build, check-release, check-security, check-fmt, test-unit, test-integration, test-smoke, test-system]
+    needs: [plan, check-docs, check-changelog, check-publish, check-pull-request, check-lint, check-standards, build, check-release, check-security, check-fmt, test-unit, test-workspace, test-integration, test-smoke, test-system]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -378,6 +383,7 @@ jobs:
             check-standards
             build
             test-unit
+            test-workspace
             test-integration
             test-smoke
             test-system

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -8,8 +8,12 @@ name: test-unit
 # `unit-tests (<package>)` check per workspace member. Scoped to
 # per-package `tests/` trees and runs without coverage so the
 # per-shard runtime stays bounded; workspace-wide coverage and the
-# root `tests/` tree (release-semver, openapi-spec, pip-audit-to-
-# sarif, scan-failure) live elsewhere in this orchestrator.
+# root `tests/` tree (release-semver, scan-failure, openapi-spec,
+# devcontainer-signing, workspace-deps, merge-bot-rollup-dedupe, ...)
+# are gated by the sibling `test-workspace.yml` child, which runs the
+# canonical `task test -- --unit` invocation against a single pytest
+# session and chains `scripts/check-package-coverage.sh` against the
+# unified `.coverage` DB it produces (issues #581, #273).
 on:
   workflow_call:
 

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+name: test-workspace
+
+# Workspace-wide unit-test child of `ci.yml`. Runs the workspace
+# pytest invocation (`task test -- --unit`) which exercises both the
+# root `tests/` tree (release-semver, scan-failure, devcontainer-
+# signing, workspace-deps, merge-bot-rollup-dedupe, openapi-spec, ...)
+# AND every per-package `tests/` tree in a single session, producing a
+# unified `.coverage` database. `scripts/check-package-coverage.sh`
+# then enforces each package's `--cov-fail-under` floor against the
+# unified DB (per #273).
+#
+# Complements `test-unit.yml` (per-package matrix, no coverage, fast
+# per-package signal): the matrix gives PRs fast localisation on
+# regression, this workflow gives them workspace-wide root-tree
+# coverage and floor enforcement. The matrix's wall-clock is
+# unaffected.
+#
+# Restores both gates that the Phase 5 CI cutover (#516, commit
+# c9bb1f6) stranded — see issue #581.
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  test-workspace:
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth: 0 makes the workspace's git tags reachable so
+      # setuptools-scm can derive a real PEP 440 version when the
+      # release-wheel-version regression test
+      # (tests/test_release_wheel_version.py) builds a wheel. The
+      # default shallow clone (fetch-depth: 1, no tags) makes
+      # setuptools-scm fall back to a "0.0.1.dev1+unknown.gsha"
+      # placeholder that the test correctly rejects.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # `task test -- --unit` runs `scripts/test.sh --unit`, which:
+      #   1. Bootstraps the project virtualenv via _bootstrap_venv.sh
+      #      (so the workspace pytest invocation runs against the same
+      #      env as a local `task test` — including the `--cov=packages`
+      #      addopt from the root `pyproject.toml` that produces the
+      #      unified `.coverage` DB).
+      #   2. Invokes pytest against UNIT_TEST_PATHS (every package's
+      #      `tests/` tree plus the root `tests/` tree, with each
+      #      package's `tests/integration/` slice ignored — those run
+      #      under `test-integration.yml`).
+      #   3. Chains `scripts/check-package-coverage.sh` on success,
+      #      which queries the unified `.coverage` DB and asserts each
+      #      package's `--cov-fail-under` floor.
+      #
+      # Going through `task test -- --unit` rather than re-implementing
+      # the chain inline keeps the local and CI invocations identical;
+      # a future change to UNIT_TEST_PATHS or the floor-check protocol
+      # auto-flows here without a workflow edit.
+      - name: Run workspace tests + per-package coverage gate
+        run: task test -- --unit

--- a/plans/ci-workspace-tests-coverage.md
+++ b/plans/ci-workspace-tests-coverage.md
@@ -1,0 +1,145 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+
+SPDX-License-Identifier: MIT
+-->
+
+# Run workspace tests + per-package coverage gate in CI (#581)
+
+Closes the gap left by the Phase 5 CI cutover (#516, commit `c9bb1f6`):
+the workspace-wide root `tests/` tree (release-semver, scan-failure,
+devcontainer-signing, workspace-deps, merge-bot-rollup-dedupe, etc.)
+and the per-package coverage floors (#273) are configured but no CI
+workflow enforces them. Both gates only run on developer machines via
+`task test -- --unit`.
+
+## Chosen shape — Hybrid (per Agent Brief)
+
+Add a single `test-workspace` `workflow_call` child to `ci.yml`. The
+job runs `task test -- --unit` (which `scripts/test.sh` already wires
+to the canonical workspace-wide pytest invocation that produces a
+unified `.coverage`, then chains `scripts/check-package-coverage.sh`
+to enforce per-package floors). Add it to the `required-checks-passed`
+aggregator's `needs:`. Treat it as diff-dependent (skipped on
+verified-prior-success label re-runs, per #527).
+
+Keep the per-package matrix in `test-unit.yml` as-is — it provides
+fast per-package signal whose wall-clock would regress if the workspace
+gate were folded in. The two checks are complementary:
+
+- `test-unit.yml` (matrix): per-package shards, no coverage, fast
+  per-package signal on regression localisation.
+- `test-workspace.yml` (single job, new): one workspace-wide pytest
+  run that emits a unified `.coverage`; floor check chained on success.
+
+Rejected alternatives:
+
+- **Single workspace-coverage job replacing the matrix** — loses fast
+  per-package signal; out-of-scope per Agent Brief AC ("per-package
+  matrix continues to provide fast per-package signal — its
+  wall-clock is not regressed").
+- **Add a "root" entry to `test-unit.yml`'s matrix** — doesn't combine
+  `.coverage` files across shards, so the floor check can't run
+  against a unified DB (the floor-check script's contract is
+  per-package coverage queried from a single `.coverage` produced by
+  one workspace pytest invocation).
+
+## File changes
+
+1. **`.github/workflows/test-workspace.yml`** (new) — `workflow_call`
+   child mirroring `test-unit.yml`'s shape:
+
+   - `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6)
+     with `fetch-depth: 0` (setuptools-scm needs tags for
+     `tests/test_release_wheel_version.py`).
+   - `./.github/actions/setup-toolchain` with `github-token`.
+   - `uv sync --extra dev`.
+   - `task test -- --unit` (this runs the workspace pytest
+     invocation against `UNIT_TEST_PATHS` — including root `tests/`
+     — and chains `scripts/check-package-coverage.sh` on success).
+   - Single ubuntu-latest runner; no matrix.
+
+2. **`.github/workflows/ci.yml`** — wire the new child:
+
+   - Add `test-workspace` job slot after `test-unit`, gated by
+     `needs.plan.outputs.diff_dependent_jobs_already_passed != 'true'`
+     (mirrors siblings).
+   - Add `test-workspace` to `required-checks-passed.needs:`.
+   - Add `test-workspace` to the `DIFF_DEPENDENT_JOB_IDS` env block
+     in the aggregator step.
+
+3. **`.github/workflows/test-unit.yml`** — update the stale header
+   comment that references "elsewhere in this orchestrator" so it
+   points at `test-workspace.yml`.
+
+4. **`tests/test_ci_diff_dependent_probe.py`** — extend the pinned
+   `DIFF_DEPENDENT_JOB_IDS` constant and `expected_leaves` set to
+   include `test-workspace / test-workspace`. Without this the
+   regression-pin test fails immediately on the new diff-dependent
+   child (which is the exact drift this test exists to catch).
+
+## `needs:` graph
+
+The new `test-workspace` job runs in parallel with `test-unit`,
+`test-integration`, `test-smoke`, `test-system` — all consume the same
+`needs: [plan]` and the verified-prior-success `if:` gate. No
+inter-test ordering needed.
+
+## Observable user-facing changes
+
+- `ci / required-checks-passed` rollup grows by one diff-dependent
+  child (`test-workspace`). The aggregator gate is unchanged in shape
+  — branch protection still requires only the single `required-checks- passed` rollup, which now becomes stricter.
+- A PR that regresses any test under root `tests/` will now fail
+  `test-workspace` instead of passing CI silently.
+- A PR that drops any package's `--cov-fail-under` floor will now
+  fail `test-workspace` instead of passing CI silently.
+- Wall-clock for the rollup grows by ~3 minutes (the local run
+  measured 181s for the workspace pytest). Per-package matrix keeps
+  its existing wall-clock for fast feedback.
+
+## Out of scope
+
+Per the issue's Agent Brief:
+
+- Ratcheting per-package floors upward (current actuals: agent-auth
+  81%/78%, agent-auth-common 73%/49%, gpg-bridge 75%/62%, gpg-cli
+  76%/53%, pr-lint-validator 89%/88%, things-bridge 87%/83%,
+  things-cli 66%/65%, things-client-cli-applescript 84%/73%).
+- Adding new tests to the root `tests/` tree.
+- Modifying `scripts/check-package-coverage.sh`'s contract.
+- Branch-protection ruleset changes (the rollup gate name is
+  unchanged; the new child is invisible to branch protection).
+
+## Verification
+
+Local pre-push:
+
+- `task test -- --unit` exits 0 (already verified — 885 passed, all
+  package floors green).
+- `scripts/ci/diff-dependent-jobs.sh` enumerates `test-workspace / test-workspace` (verifies the helper auto-extends from `ci.yml`).
+- `pytest tests/test_ci_diff_dependent_probe.py -v` passes
+  (verifies the constant + expected-leaves drift detector still
+  matches after the constant update).
+
+CI:
+
+- The new `test-workspace` check appears on the PR.
+- The rollup `required-checks-passed` waits on it.
+- The diff-dependent gate skips it on `labeled` re-runs whose head
+  SHA already passed once.
+
+## Standards review (post-implementation)
+
+- `.claude/instructions/coding-standards.md` — N/A (workflow YAML, no
+  new Python code).
+- `.claude/instructions/service-design.md` — N/A (CI infra).
+- `.claude/instructions/release-and-hygiene.md` — `no changelog`
+  label applied at PR creation (CI-only change, no user-visible
+  behaviour beyond the rollup expanding).
+- `.claude/instructions/testing-standards.md` — the new gate restores
+  enforcement of existing tests; no new tests added (out of scope per
+  Agent Brief).
+- `.claude/instructions/tooling-and-ci.md` — the new workflow follows
+  the existing per-child workflow shape (single `workflow_call`,
+  `permissions: contents: read`, SHA-pinned `actions/checkout`).

--- a/tests/test_ci_diff_dependent_probe.py
+++ b/tests/test_ci_diff_dependent_probe.py
@@ -75,6 +75,7 @@ DIFF_DEPENDENT_JOB_IDS: frozenset[str] = frozenset(
         "test-smoke",
         "test-system",
         "test-unit",
+        "test-workspace",
     }
 )
 
@@ -354,6 +355,8 @@ def test_helper_script_outputs_all_expected_check_run_names() -> None:
         "test-unit / unit-tests (things-bridge)",
         "test-unit / unit-tests (things-cli)",
         "test-unit / unit-tests (things-client-cli-applescript)",
+        # test-workspace single-job child publishes one check-run.
+        "test-workspace / test-workspace",
         # test-integration matrix.
         "test-integration / integration-tests (agent-auth)",
         "test-integration / integration-tests (gpg-bridge)",


### PR DESCRIPTION
==COMMIT_MSG==
Phase 5 CI cutover (#516, c9bb1f6) deleted the workflow that exercised
the workspace-wide root `tests/` tree (release-semver, scan-failure,
devcontainer-signing, workspace-deps, merge-bot-rollup-dedupe, ...) and
the per-package `--cov-fail-under` floors (#273) without re-homing
either gate. Both ran only on developer machines via `task test --
--unit`; #580 surfaced the gap when a regression in
tests/test_merge_bot_rollup_dedupe.py landed undetected.

Add `test-workspace` as a single-job `workflow_call` child of `ci.yml`,
running the canonical `task test -- --unit` path so the workspace
pytest invocation produces the unified `.coverage` DB and chains
`scripts/check-package-coverage.sh` against it. Wire it into
`required-checks-passed.needs:` and the verified-prior-success
`DIFF_DEPENDENT_JOB_IDS` carve-out (#527). Keep the per-package
matrix in `test-unit.yml` as-is — its fast per-package signal is
out-of-scope per the AC.

The pinned `tests/test_ci_diff_dependent_probe.py` constants extend
to include the new diff-dependent child; the
`scripts/ci/diff-dependent-jobs.sh` helper auto-derives the leaf set
from `ci.yml` so no change is needed there.

Closes: #581
Closes: #579
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

==NO_CHANGELOG==

## Review notes

### Test plan

- [ ] `task test -- --unit` exits 0 locally (verified — 885 passed, all package floors green).
- [ ] `scripts/ci/diff-dependent-jobs.sh` includes `test-workspace / test-workspace`.
- [ ] `pytest tests/test_ci_diff_dependent_probe.py -v --no-cov` passes (11/11).
- [ ] `task lint` passes.
- [ ] CI: new `test-workspace` check appears on the PR and gates merge via `required-checks-passed`.