### PR TITLE
fix(ci): bump tart VM SSH-ready deadline 180s -> 600s

### DIFF
--- a/.github/workflows/test-system-macos-tart.yml
+++ b/.github/workflows/test-system-macos-tart.yml
@@ -201,12 +201,17 @@ jobs:
         # Run Tart in the background so the workflow can keep
         # going. Loop on `tart ip` (which returns the guest's
         # DHCP-assigned IP once the boot reaches the network stack)
-        # plus an SSH probe. Cap at 180s to keep failures quick.
+        # plus an SSH probe. Cap at 600s — first cold boot of the
+        # `cirruslabs/macos-sequoia-base` image on a hosted macos-15
+        # runner reliably takes 2–5 min (DHCP-lease + launchd warmup),
+        # and the previous 180s ceiling timed out before the guest
+        # ever advertised an IP (verified against workflow_dispatch
+        # run 25375494433 on `main`).
         run: |
           set -euo pipefail
           tart run --no-graphics "${VM}" >"${ARTEFACT_DIR}/tart-run.log" 2>&1 &
           echo "$!" >tart.pid
-          deadline=$((SECONDS + 180))
+          deadline=$((SECONDS + 600))
           ip=""
           while (( SECONDS < deadline )); do
             ip=$(tart ip "${VM}" 2>/dev/null || true)

--- a/changelog/@unreleased/pr-602-tart-ssh-deadline-bump.yml
+++ b/changelog/@unreleased/pr-602-tart-ssh-deadline-bump.yml
@@ -8,4 +8,4 @@ fix:
     Bump macOS Tart SSH-ready deadline 180s → 600s; cold first boot
     on hosted macos-15 reliably takes 2–5 min.
   links:
-    - https://github.com/aidanns/agent-auth/pull/PRNUM
+    - https://github.com/aidanns/agent-auth/pull/602

--- a/changelog/@unreleased/pr-tart-ssh-deadline-bump.yml
+++ b/changelog/@unreleased/pr-tart-ssh-deadline-bump.yml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2026 Aidan Nagorcka-Smith
+#
+# SPDX-License-Identifier: MIT
+
+type: fix
+fix:
+  description: |
+    Bump macOS Tart SSH-ready deadline 180s → 600s; cold first boot
+    on hosted macos-15 reliably takes 2–5 min.
+  links:
+    - https://github.com/aidanns/agent-auth/pull/PRNUM

--- a/docs/operations/macos-tart-ci.md
+++ b/docs/operations/macos-tart-ci.md
@@ -129,7 +129,7 @@ issue against the package.
 ### VM never reaches SSH-ready
 
 **Signature**: workflow step "Boot VM Headless and Wait for SSH"
-fails with `VM <name> did not reach SSH-ready within 180s`.
+fails with `VM <name> did not reach SSH-ready within 600s`.
 `tart-run.log` may contain Tart's own diagnosis.
 
 **Fix**: usually the base image got rotated upstream and the


### PR DESCRIPTION
==COMMIT_MSG==
Manual workflow_dispatch run on \`main\` after PR #597 landed
(run id 25375494433) showed the \`Boot VM Headless and Wait
for SSH\` step time out with no IP advertised. Tart CLI install,
sha256 verification, and GHCR pull of the pinned
\`cirruslabs/macos-sequoia-base\` digest all succeeded — only the
SSH-ready loop hit its 180s ceiling.

Cold first boot of the cirruslabs base image on a hosted
\`macos-15\` runner reliably takes 2–5 min (DHCP-lease +
launchd warmup); 180s was too aggressive. Bumping to 600s
matches the upstream blacksmith-tart-runner examples.

Failure-mode doc (\`docs/operations/macos-tart-ci.md\`) updated
in lockstep so the troubleshooting "Signature" line matches the
new deadline.

Closes: #485
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Signed-off-by: Aidan Nagorcka-Smith <aidanns@gmail.com>
==COMMIT_MSG==

## Review notes

Tiny follow-up to #597 — single-line ceiling bump in
`.github/workflows/test-system-macos-tart.yml` plus a
docs-string update for the matching error message.

### Test plan

- [ ] CI green on this PR (no new logic, just a numeric bound).
- [ ] After merge, re-run `gh workflow run test-system-macos-tart.yml`
      against `main` and confirm the smoke job completes the
      `Boot VM Headless and Wait for SSH` step within the new 600s
      window.